### PR TITLE
Add env var description and fix URL

### DIFF
--- a/embedding/sigma_embed_link_sharing/.env
+++ b/embedding/sigma_embed_link_sharing/.env
@@ -6,7 +6,7 @@ EMBED_SECRET={your embed secret}
 # Required Parameters
 EMAIL={your embed test user email address}
 EXTERNAL_USER_ID=123
-EXTERNAL_USER_TEAM=Sales_People
+EXTERNAL_USER_TEAM={your team that has access to the workbook you embedded}
 ACCOUNT_TYPE=Pro
 MODE=userbacked
 SESSION_LENGTH=600

--- a/embedding/sigma_embed_link_sharing/index.html
+++ b/embedding/sigma_embed_link_sharing/index.html
@@ -82,21 +82,19 @@
         if (exploreKey) params.append("exploreKey", exploreKey);
         if (bookmarkId) params.append("bookmarkId", bookmarkId);
 
-        const newUrl = `${window.location.origin}${
-          window.location.pathname
-        }?${params.toString()}`;
+        const paramsToString = params.toString();
+        const newUrl = paramsToString
+          ? `${window.location.origin}${window.location.pathname}?${paramsToString}`
+          : `${window.location.origin}${window.location.pathname}`;
         window.history.pushState({}, "", newUrl);
       }
 
       // Function to send sharing links back to Sigma
       function sendSharingLinks() {
         const baseUrl = window.location.origin + window.location.pathname;
-        const finalSharingLink =
-          currentExploreKey || currentBookmarkId
-            ? `${baseUrl}?${
-                currentExploreKey ? `exploreKey=${currentExploreKey}` : ""
-              }${currentBookmarkId ? `&bookmarkId=${currentBookmarkId}` : ""}`
-            : baseUrl;
+        const sharingLink = currentBookmarkId
+          ? `${baseUrl}?&bookmarkId=${currentBookmarkId}`
+          : baseUrl;
 
         const sharingExplorationLink = currentExploreKey
           ? currentBookmarkId
@@ -105,13 +103,13 @@
           : null;
 
         console.log("Sending sharing links to Sigma:");
-        console.log("Final Sharing Link:", finalSharingLink);
+        console.log("Sharing Link:", baseUrl);
         console.log("Sharing Exploration Link:", sharingExplorationLink);
 
         iframe.contentWindow.postMessage(
           {
             type: "workbook:sharinglink:update",
-            sharingLink: finalSharingLink,
+            sharingLink: sharingLink,
             sharingExplorationLink: sharingExplorationLink,
           },
           "https://app.sigmacomputing.com"


### PR DESCRIPTION
This PR is making the following changes:
- EXTERNAL_USER_TEAM in env variables will be unpopulated and will have a description placeholder instead
- The URL has a trailing '?' when all of the URL params become undefined. We'll only add the '?' if there are URL params
- The `sharingLink` passed to the iframe event shouldn't have any `exploreId`. We save links with `exploreIds` for the variable `sharingExplorationLink`
- Variable 'Final Sharing Link' is confusing since there is no Initial Sharing Link. In my opinion 'Sharing Link' is sufficient.