### PR TITLE
Fix sharingLink log

### DIFF
--- a/embedding/sigma_embed_link_sharing/index.html
+++ b/embedding/sigma_embed_link_sharing/index.html
@@ -103,7 +103,7 @@
           : null;
 
         console.log("Sending sharing links to Sigma:");
-        console.log("Sharing Link:", baseUrl);
+        console.log("Sharing Link:", sharingLink);
         console.log("Sharing Exploration Link:", sharingExplorationLink);
 
         iframe.contentWindow.postMessage(


### PR DESCRIPTION
I accidentally printed the `baseUrl` rather than the `sharingLink`. 