### PR TITLE
Vendor microstrategy-migration-skills from twells89 upstream

### DIFF
--- a/microstrategy-migration-skills/microstrategy-assessment/PRIVACY.md
+++ b/microstrategy-migration-skills/microstrategy-assessment/PRIVACY.md
@@ -1,0 +1,45 @@
+# MicroStrategy Assessment — privacy disclosure
+
+Share this with the customer's privacy / security reviewer before running the
+skill against a live MicroStrategy environment.
+
+## What this skill does
+
+It logs in (`POST /api/auth/login` — the only POST, it creates a session) and
+then issues **read-only `GET` requests** to the MicroStrategy REST API to
+count reports/documents, fetch dossier definitions, and list datasources. It
+then scores everything locally and renders a markdown readout. It **never**
+modifies, executes, or deletes anything in MicroStrategy, **never runs a
+report or warehouse query**, and never touches Sigma.
+
+## What crosses the LLM (Anthropic) API
+
+Like every Claude Code skill, the content it reads is sent through the
+Anthropic API to Claude so the assessment can be produced:
+
+| Crosses the API | Stays in MicroStrategy / local only |
+|---|---|
+| Aggregate counts (report / document / dossier / datasource counts) | Warehouse rows — never queried |
+| Object names and ids (projects, reports, dossiers, datasources) | Database credentials (the endpoints used never return them) |
+| Dossier definitions: chapter/page names, visualization types, panel-stack structure, dataset attribute/metric names | Report *results* / metric values (no report is executed) |
+| Datasource database types (e.g. `snow_flake`) | Connection strings / logins |
+
+## Where outputs go
+
+A local directory (`/tmp/mstr-assessment-<env>/` by default):
+`inventory.json` + `readout.md`. Nothing is uploaded anywhere; sharing the
+readout is a deliberate user action.
+
+## Auth handling
+
+`MSTR_USERNAME` / `MSTR_PASSWORD` are read from environment variables (or
+`~/.sigma-migration/env`) and used only for the login call. The session token
+lives in process memory; credentials are not stored and not written to any
+output file.
+
+## How to run it more privately
+
+- Use a **low-privilege account** — MicroStrategy's own object security bounds
+  what the walk can see.
+- Cap the per-dossier fetches with `--max-dossiers`.
+- Scope to one project with `--project`.

--- a/microstrategy-migration-skills/microstrategy-assessment/SKILL.md
+++ b/microstrategy-migration-skills/microstrategy-assessment/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: microstrategy-assessment
+description: >-
+  Take inventory of a MicroStrategy (Strategy One) environment and produce a
+  migration-readiness readout — project/report/dossier counts, a
+  visualization-type histogram (walking panel stacks recursively), datasource
+  types, per-dossier complexity flags, and migrate-first / moderate /
+  needs-review tags scored against the microstrategy-to-sigma converter's
+  actual coverage. Use when a user wants to scope a MicroStrategy→Sigma
+  migration, audit dossier sprawl, or pick which dossiers to convert first.
+  Read-only, all-free pre-scoping.
+user-invocable: true
+---
+
+# MicroStrategy Assessment
+
+Surveys a MicroStrategy (Strategy One) environment via its REST API and
+produces a JSON inventory + markdown readout. The differentiator versus a
+generic BI audit is **converter-coverage classification**: every dossier's
+visualizations are scored against the *same* viz-type lookup the
+`microstrategy-to-sigma` converter actually applies
+(`../microstrategy-to-sigma/refs/viz-type-mapping.md`), so the readout
+reflects what the tool will really do.
+
+> **Read-only.** Only `GET`s against the MicroStrategy API (login `POST` aside,
+> which creates a session, nothing else). It never modifies, executes, or
+> deletes anything in MicroStrategy, never runs a warehouse query, and never
+> touches Sigma. See `PRIVACY.md` for the full disclosure — surface it to the
+> customer before running.
+
+> **All free.** Inventory, scoring, readout — all part of the open migration
+> tooling; no paid tier. For a deeper engagement (security-filter audit, live
+> parity testing), point the customer at a Sigma SE.
+
+---
+
+## Phase 0 — Connect
+
+```bash
+export MSTR_BASE_URL="https://<host>/MicroStrategyLibrary"   # Library root
+export MSTR_USERNAME="..." MSTR_PASSWORD="..."
+# optional: export MSTR_PROJECT_ID="..."   (default: first project)
+python3 ../microstrategy-to-sigma/scripts/mstr.py            # login probe
+```
+
+Credentials can also live in `~/.sigma-migration/env` (agent-neutral pattern).
+Auth is session-based — no API key exists. REST gotchas (TLS strictness on
+trial certs, headers) are documented in
+`../microstrategy-to-sigma/refs/mstr-rest-api.md`; `mstr.py` handles them.
+
+## Phase 1 — Inventory + readout
+
+```bash
+python3 scripts/assess.py --out /tmp/mstr-assessment-<env> [--project <id>] [--max-dossiers 100]
+```
+
+What it does:
+
+- **Counts** reports (quick-search type 3) and documents (type 55) in the
+  project; lists instance datasources with database types.
+- **Classifies documents vs dossiers** by probing
+  `GET /api/v2/dossiers/{id}/definition` (non-dossier documents error — that
+  *is* the probe).
+- **Walks every dossier correctly**: each page's `visualizations` AND
+  `panelStacks[].panels[]` **recursively** (panels nest further panel stacks)
+  plus free-form `fields` (images/text) and `selectors` — the places naive
+  walks silently miss content.
+- **Histograms `visualizationType`** and classifies each against the
+  converter's `VIZ_MAPPED` lookup (mapped vs flagged-table fallback).
+- **Tags each dossier**: `needs-review` (panel stacks or unmapped viz types),
+  `moderate` (selectors / free-form fields / chart mix), `migrate-first`
+  (grid/kpi-only, no panel stacks).
+
+Outputs `<out>/inventory.json` (machine-readable, feeds the converter's
+Phase 0) and `<out>/readout.md` (counts, viz histogram with converter status,
+per-dossier table with flags + tags).
+
+## Phase 2 — Hand off (optional)
+
+Hand the migrate-first shortlist to the **`microstrategy-to-sigma`** converter
+skill — `inventory.json`'s dossier ids go straight into
+`extract.py <dossierId>`. Do not auto-convert; surface the shortlist and let
+the user choose.
+
+## Limitations (honest)
+
+- **Usage telemetry**: not collected — Strategy One exposes usage through
+  Platform Analytics (a separate warehouse-backed project), not the plain
+  REST surface this skill uses. Value ranking therefore isn't usage-weighted;
+  ask the admin for Platform Analytics access if usage matters.
+- **Security filters**: the classic REST extract doesn't surface them;
+  ask the customer explicitly (see the converter SKILL's security note).
+- Documents that aren't dossiers are counted but not analyzed (their format is
+  the legacy Report Services document, out of converter scope).

--- a/microstrategy-migration-skills/microstrategy-assessment/scripts/assess.py
+++ b/microstrategy-migration-skills/microstrategy-assessment/scripts/assess.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""
+assess.py — read-only MicroStrategy (Strategy One) estate inventory.
+
+GET-only against the MicroStrategy REST API. Produces:
+  <out>/inventory.json   — machine-readable estate inventory
+  <out>/readout.md       — human-readable migration-readiness readout
+
+Surveyed per project:
+  - report + document/dossier counts (quick-search API)
+  - per-dossier structure: chapters / pages / visualizations, walking
+    panelStacks[].panels[] RECURSIVELY (panels nest further panelStacks)
+    and counting free-form `fields` (images / text boxes)
+  - visualization-type histogram, classified against the converter's
+    viz-type lookup (see ../microstrategy-to-sigma/refs/viz-type-mapping.md)
+  - instance datasource inventory (database types)
+  - per-dossier complexity flags + migrate-first / moderate / needs-review tag
+
+Usage:
+  python3 assess.py [--project <id>] [--out /tmp/mstr-assessment] [--max-dossiers 100]
+
+Credentials: MSTR_BASE_URL / MSTR_USERNAME / MSTR_PASSWORD env vars (or
+~/.sigma-migration/env) — see ../../microstrategy-to-sigma/scripts/mstr.py.
+"""
+import argparse
+import collections
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                '..', '..', 'microstrategy-to-sigma', 'scripts'))
+import mstr  # noqa: E402
+
+# Sigma-analog lookup, mirroring the converter (flagged-table fallback).
+# Keep in sync with refs/viz-type-mapping.md in the converter skill.
+# Types with a real Sigma mapping (see ../microstrategy-to-sigma/refs/
+# viz-type-mapping.md, demo-sweep-validated). Others = flagged-table fallback;
+# custom/marketplace vizzes (HC*/D3*/Vitara*/EChart*/Arria*…) are never mapped.
+VIZ_MAPPED = {
+    'grid', 'compound_grid', 'kpi', 'multi_metric_kpi', 'comparison_kpi',
+    'bar_chart', 'line_chart', 'combo_chart', 'area_chart',
+    'pie_chart', 'ring_chart', 'bubble_chart',
+    'geospatial_service', 'google_map', 'esri_map',
+}
+# MicroStrategy object types (quick-search `type` param)
+TYPE_REPORT = 3
+TYPE_DOCUMENT = 55  # documents AND dossiers
+
+
+def search(s, obj_type, limit=500):
+    """Quick-search for objects of a type in the session's project."""
+    out, offset = [], 0
+    while True:
+        r = s.get(f'/searches/results?type={obj_type}'
+                  f'&offset={offset}&limit={limit}')
+        items = r.get('result', [])
+        out.extend(items)
+        offset += len(items)
+        if offset >= r.get('totalItems', 0) or not items:
+            return out
+
+
+def walk_container(node, hist, flags):
+    """Recursively walk a page/panel: visualizations + panelStacks[].panels[]
+    (+ free-form `fields` — images / text boxes)."""
+    for v in node.get('visualizations') or []:
+        hist[v.get('visualizationType', 'unknown')] += 1
+    for _f in node.get('fields') or []:
+        flags['free_form_fields'] += 1
+    if node.get('selectors'):
+        flags['selectors'] += len(node['selectors'])
+    for ps in node.get('panelStacks') or []:
+        flags['panel_stacks'] += 1
+        for p in ps.get('panels') or []:
+            walk_container(p, hist, flags)
+
+
+def assess_dossier(s, doc):
+    """Fetch /v2/dossiers/{id}/definition; None if not a dossier."""
+    try:
+        d = s.get(f"/v2/dossiers/{doc['id']}/definition")
+    except RuntimeError:
+        return None
+    hist = collections.Counter()
+    flags = collections.Counter()
+    n_pages = 0
+    for ch in d.get('chapters') or []:
+        for pg in ch.get('pages') or []:
+            n_pages += 1
+            walk_container(pg, hist, flags)
+    unmapped = sorted(t for t in hist if t not in VIZ_MAPPED)
+    if flags['panel_stacks'] or unmapped:
+        tag = 'needs-review'
+    elif flags['free_form_fields'] or flags['selectors'] or len(hist) > 2:
+        tag = 'moderate'
+    else:
+        tag = 'migrate-first'
+    # dataset names (the dossier's source cubes/reports) — used as the
+    # duplicate-detector `sources` signal; fall back to id when unnamed.
+    dataset_names = [ds.get('name') or ds.get('id')
+                     for ds in d.get('datasets') or [] if ds.get('name') or ds.get('id')]
+    return {
+        'id': doc['id'],
+        'name': d.get('name', doc.get('name')),
+        'chapters': len(d.get('chapters') or []),
+        'pages': n_pages,
+        'datasets': len(d.get('datasets') or []),
+        'dataset_names': dataset_names,
+        'visualizations': sum(hist.values()),
+        'viz_types': dict(hist),
+        'unmapped_viz_types': unmapped,
+        'flags': dict(flags),
+        'tag': tag,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--project', default=None,
+                    help='project id (default: MSTR_PROJECT_ID, else first project)')
+    ap.add_argument('--out', default='/tmp/mstr-assessment')
+    ap.add_argument('--max-dossiers', type=int, default=100,
+                    help='cap on per-dossier definition fetches')
+    args = ap.parse_args()
+
+    s = mstr.Session(project_id=args.project)
+    projects = s.get('/projects')
+    if not s.project_id:
+        s.project_id = projects[0]['id']
+    project = next((p for p in projects if p['id'] == s.project_id), None)
+
+    # instance-level datasources (db types)
+    try:
+        ds = s.get('/datasources').get('datasources', [])
+    except RuntimeError:
+        ds = []
+    ds_types = collections.Counter(
+        (d.get('database') or {}).get('type', 'unknown') for d in ds)
+
+    reports = search(s, TYPE_REPORT)
+    documents = search(s, TYPE_DOCUMENT)
+
+    dossiers, plain_documents = [], []
+    viz_hist = collections.Counter()
+    for doc in documents[: args.max_dossiers]:
+        a = assess_dossier(s, doc)
+        if a is None:
+            plain_documents.append({'id': doc['id'], 'name': doc.get('name')})
+        else:
+            dossiers.append(a)
+            viz_hist.update(a['viz_types'])
+
+    # Duplicate / consolidation candidates — flag dossiers that are the same
+    # report rebuilt (shared dataset + overlapping viz set + near-identical
+    # name) so the estate migrates ONCE instead of N times. Shared, tool-neutral
+    # detector; hyphenated filename → load via importlib. Only present signals
+    # are passed (sources = dataset names, viz = per-dossier viz-type keys);
+    # MicroStrategy's quick-search exposes no per-dossier field list or hit
+    # count, so `fields`/`usage` are intentionally omitted (flag-not-fake).
+    import importlib.util
+    _dd_path = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            'dup-dashboards.py')
+    _spec = importlib.util.spec_from_file_location('dup_dashboards', _dd_path)
+    _dd = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_dd)
+    duplicate_dashboards = _dd.detect([
+        {'id': d['id'], 'name': d['name'],
+         'sources': d.get('dataset_names') or [],
+         'viz': list((d.get('viz_types') or {}).keys())}
+        for d in dossiers])
+
+    inventory = {
+        'project': {'id': s.project_id,
+                    'name': project['name'] if project else None},
+        'projects_available': [{'id': p['id'], 'name': p['name']}
+                               for p in projects],
+        'counts': {
+            'reports': len(reports),
+            'documents': len(documents),
+            'dossiers': len(dossiers),
+            'plain_documents': len(plain_documents),
+            'datasources': len(ds),
+        },
+        'datasource_types': dict(ds_types),
+        'viz_type_histogram': dict(viz_hist),
+        'unmapped_viz_types': sorted(t for t in viz_hist if t not in VIZ_MAPPED),
+        'dossiers': dossiers,
+        'plain_documents': plain_documents,
+        'reports': [{'id': r['id'], 'name': r.get('name')} for r in reports],
+        'duplicate_dashboards': duplicate_dashboards,
+    }
+
+    os.makedirs(args.out, exist_ok=True)
+    inv_path = os.path.join(args.out, 'inventory.json')
+    json.dump(inventory, open(inv_path, 'w'), indent=1)
+
+    # ---- readout
+    L = ['# MicroStrategy estate — migration readout', '',
+         f"Project: **{inventory['project']['name']}** (`{s.project_id}`)", '',
+         '## Counts', '',
+         f"- Reports: {len(reports)}",
+         f"- Documents: {len(documents)} ({len(dossiers)} dossiers, "
+         f"{len(plain_documents)} non-dossier documents)",
+         f"- Datasources: {len(ds)} "
+         f"({', '.join(f'{k}: {v}' for k, v in ds_types.items()) or 'n/a'})",
+         '', '## Visualization types (all dossiers, incl. panel stacks)', '',
+         '| Type | Count | Converter |', '|---|---|---|']
+    for t, n in viz_hist.most_common():
+        L.append(f"| {t} | {n} | "
+                 f"{'mapped' if t in VIZ_MAPPED else 'FLAGGED (table fallback)'} |")
+    L += ['', '## Dossiers', '',
+          '| Dossier | Chapters | Pages | Vizzes | Flags | Tag |', '|---|---|---|---|---|---|']
+    for d in sorted(dossiers, key=lambda x: x['tag']):
+        fl = ', '.join(f'{k}={v}' for k, v in d['flags'].items()) or '—'
+        if d['unmapped_viz_types']:
+            fl += f"; unmapped: {', '.join(d['unmapped_viz_types'])}"
+        L.append(f"| {d['name']} | {d['chapters']} | {d['pages']} | "
+                 f"{d['visualizations']} | {fl} | **{d['tag']}** |")
+    L += ['', '_Tags: migrate-first = grid/kpi-only, no panel stacks; '
+          'moderate = selectors / free-form fields / chart mix; '
+          'needs-review = panel stacks or unmapped viz types._', '']
+    # Consolidation section (shared duplicate-dashboard detector).
+    L += ['', _dd.render_md(duplicate_dashboards).rstrip(), '']
+    md_path = os.path.join(args.out, 'readout.md')
+    open(md_path, 'w').write('\n'.join(L))
+
+    print(f"project: {inventory['project']['name']}")
+    print(f"reports={len(reports)} documents={len(documents)} "
+          f"dossiers={len(dossiers)} datasources={len(ds)}")
+    print(f"viz histogram: {dict(viz_hist)}")
+    _ds = duplicate_dashboards['summary']
+    if _ds['duplicate_groups']:
+        print(f"duplicate/consolidation: {_ds['duplicate_groups']} group(s) across "
+              f"{_ds['dashboards_in_groups']} dossiers — avoids "
+              f"{_ds['conversions_avoided']} redundant migration(s)")
+    print(f"wrote {inv_path} and {md_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/microstrategy-migration-skills/microstrategy-assessment/scripts/dup-dashboards.py
+++ b/microstrategy-migration-skills/microstrategy-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/microstrategy-migration-skills/microstrategy-to-sigma/QUICKSTART.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/QUICKSTART.md
@@ -1,0 +1,112 @@
+author: Sigma Computing
+summary: Migrating from MicroStrategy made easy — convert Strategy One semantic models and dossiers to Sigma with Claude Code
+id: developers_migrating_from_microstrategy_made_easy
+categories: Developers, Migration, AI
+environments: Web
+status: Draft
+feedback link: https://github.com/twells89/microstrategy-to-sigma/issues
+
+# Migrating from MicroStrategy to Sigma made easy
+
+## Introduction & why it matters
+Duration: 2
+
+Rebuilding MicroStrategy content by hand means re-deriving every attribute's
+key mapping, re-typing every metric formula, and hoping the numbers still tie
+out — across a semantic layer (attributes, facts, metrics), reports, and
+dossiers.
+
+This quickstart automates the path with **your coding agent** (Claude Code,
+Cursor, Cortex Code, …) + the MicroStrategy→Sigma skills: discover content
+over the MicroStrategy REST API, extract the dossier *and* the semantic model
+behind it, build a Sigma data model and matching workbook, and **verify data
+parity** against the same warehouse.
+
+positive
+: **Validation status:** live-validated end-to-end on a Strategy One cloud
+trial against Snowflake — exact parity on every row of every report in the
+fixture (money/counts exact, ratios 1e-6), for both the classic project
+schema **and** the newer Mosaic "Data Model" objects.
+
+negative
+: Dossier **visualization authoring** has no public REST surface, so the
+parity-proven build path is grids; chart viz types are extracted and mapped
+by lookup, and anything unmapped is **flagged as a table, never faked**.
+
+## Who this is for
+Duration: 1
+
+- Sigma SEs and technical CSMs
+- Migration partners
+- MicroStrategy admins evaluating a move to Sigma
+
+## Prerequisites
+Duration: 2
+
+- **A coding agent that runs skills** — Claude Code (CLI or desktop), Cursor, etc.
+- **MicroStrategy REST access** — any Library deployment exposes it at
+  `…/MicroStrategyLibrary/api` (cloud trials included; no API key concept —
+  standard login works): `MSTR_BASE_URL`, `MSTR_USERNAME`, `MSTR_PASSWORD`.
+- **Sigma API credentials** (`SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`,
+  or `~/.sigma-migration/env`).
+- **The same warehouse on both sides** — Sigma's connection must reach the
+  database MicroStrategy queries. In-memory cubes migrate as their
+  *underlying* warehouse tables.
+
+## Assess the estate (optional, ~minutes)
+Duration: 5
+
+```bash
+export MSTR_BASE_URL="https://<env>/MicroStrategyLibrary" \
+       MSTR_USERNAME="…" MSTR_PASSWORD="…"
+python3 skills/microstrategy-assessment/scripts/assess.py --out /tmp/mstr-assessment
+open /tmp/mstr-assessment/readout.md
+```
+
+The readout inventories projects, reports, documents, and dossiers, walks
+panel stacks for a visualization-type histogram, and tags each dossier
+migrate-first / moderate / needs-review against the converter's actual
+coverage.
+
+## Migrate a dossier
+Duration: 15
+
+Ask your agent:
+
+> Migrate my MicroStrategy dossier "Orders Performance Overview" to Sigma.
+
+The `microstrategy-to-sigma` skill walks the phases: discover → `extract.py`
+(dossier + every attribute/fact/metric/table it touches → `bundle.json`;
+join keys are recovered from attributes whose ID form maps to both the fact
+and a lookup table) → `convert.py` (→ Sigma data model + workbook specs,
+metrics translated incl. `Count<Distinct=True>` and compound ratios) →
+POST + readback gate (hard-fails on any error-typed column) →
+`verify_parity.py` (hard gate: every row compared to numbers re-executed
+from MicroStrategy itself — expected values are never invented).
+
+negative
+: If a report groups by an attribute with a **non-unique key**, MicroStrategy's
+Analytical Engine silently collapses groups to arbitrary representative rows.
+The skill detects this and reproduces it deterministically
+(`resolve_ae_winners.py`) instead of shipping a near-miss.
+
+## Strategy One Data Models (Mosaic)
+Duration: 3
+
+If the customer models in the newer **Data Model** objects instead of the
+classic schema, the same flow applies: `extract_datamodel.py` pulls tables,
+attributes, factMetrics, metrics, and relationships (`refs/datamodels.md`
+documents the dataServer-pipeline binding and the
+`POST /v2/cubes/{id}/instances` parity-query path).
+
+## Verify & wrap up
+Duration: 3
+
+- Parity gate: `verify_parity.py` green — all rows, exact (ratios 1e-6).
+- Readback gate: no `type: "error"` columns in the DM or workbook spec.
+- Finalize gate: `assert-phase6-ran.rb` — seven shared gates including the
+  layout lint and the control-wiring lint (dossier selectors/chapter filters
+  convert to Sigma controls wired to their declared viz targets).
+- Anything flagged (unmapped viz types, prompts, panel selectors) is listed
+  in the conversion notes and `control-scope.json` for human follow-up —
+  loud and explicit, never silent.

--- a/microstrategy-migration-skills/microstrategy-to-sigma/SKILL.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/SKILL.md
@@ -1,0 +1,315 @@
+---
+name: microstrategy-to-sigma
+description: >-
+  Migrate MicroStrategy (Strategy One) content to Sigma. Use when the user has
+  MicroStrategy dossiers, reports, or a classic schema (attributes / facts /
+  metrics) and wants to recreate them in Sigma. Extracts the dossier + full
+  semantic model over the MSTR REST API into a bundle, converts it to a Sigma
+  data model + workbook, reproduces Analytical-Engine row-collapse quirks
+  deterministically, and verifies row-level parity. Live-validated with exact
+  parity on the classic-schema grid path.
+user-invocable: true
+---
+
+# MicroStrategy → Sigma migration
+
+## Preflight the workbook spec before POST (mandatory)
+
+Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.
+
+## Phase 0 — Choose where to build (ask first; `--folder-id` is required downstream)
+
+Don't pick the destination folder for the user. `convert.py` requires `--folder-id`,
+so resolve it WITH the user before building:
+
+1. `python3 scripts/pick_destination.py list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root),
+   an existing **folder**, **My Documents** (when non-null — null for service tokens), or
+   **create a new folder**: `python3 scripts/pick_destination.py create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder-id <id>`. `folderId` accepts a workspace id or a folder id.
+
+If the user already named a destination, honor it silently — don't ask.
+
+Extract a MicroStrategy **dossier + its full semantic model** into one
+`bundle.json`, convert it to a Sigma **data model** (table sources + joins +
+metrics) and a matching **workbook**, then **verify row-level parity** against
+the numbers MicroStrategy itself reports. Translate what maps cleanly; **flag
+what doesn't** (unmapped viz types → flagged tables) instead of emitting wrong
+logic.
+
+> **Validated**: exact parity (19/19 + 30/30 + 3/3 rows) on a live Strategy One
+> trial against Snowflake — classic-schema path, grid reports, incl. a
+> `Count<Distinct=True>` metric, a compound margin metric, and an
+> Analytical-Engine row-collapse report. Chart-viz emission and the newer
+> "Data Model" object are roadmap (`refs/design-notes.md`).
+
+> Read `refs/` before relying on shapes: `mstr-rest-api.md` (every verified
+> REST gotcha — changesets, locks, lowercase response headers, session-bound
+> dossier flows), `ae-row-collapse.md` (the one MSTR behavior no clean SQL
+> reproduces, and the pinning workflow), `viz-type-mapping.md` (dossier viz →
+> Sigma element lookup), `design-notes.md` (architecture + modeling gotchas +
+> roadmap), `control-parity.md` (shared control-targeting contract: the
+> control lint, the control-scope.json sidecar, and the flip test). For
+> canonical Sigma spec shapes, defer to the companion `sigma-data-models` /
+> `sigma-workbooks` skills.
+
+---
+
+## Prerequisites
+
+- **MicroStrategy REST access** — `MSTR_BASE_URL` (the Library root, e.g.
+  `https://<host>/MicroStrategyLibrary`), `MSTR_USERNAME`, `MSTR_PASSWORD`
+  (+ optional `MSTR_PROJECT_ID`), exported or in `~/.sigma-migration/env`.
+  Auth is session-based (`POST /api/auth/login`, loginMode 1) — there is no
+  API-key concept; `scripts/mstr.py` handles it.
+- **Sigma API token** — `eval "$(scripts/get-token.sh)"` (uses
+  `SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`, same neutral-cred pattern as the
+  sibling skills).
+- **The same warehouse on both sides.** Sigma reads the warehouse live; parity
+  only means something when the Sigma connection reaches the database
+  MicroStrategy queries.
+- **Python 3** (stdlib only; `resolve_ae_winners.py` and parity readback also
+  want `PyYAML` for Sigma's YAML spec responses) and **Ruby** (the shared
+  gate stack: `put-layout.rb`, `assert-phase6-ran.rb`, `probe-controls.rb`,
+  `scripts/lib/*.rb` — vendored byte-identical across the sibling plugins).
+
+## Phase 0 — Discover
+
+Run the sibling **`microstrategy-assessment`** skill for an estate-wide
+inventory (reports/dossiers, viz histogram, complexity tags) — its
+`inventory.json` lists dossier ids. Or quick-check connectivity and pick a
+dossier by hand:
+
+```bash
+python3 scripts/mstr.py                          # login probe + project list
+# dossiers: see assessment, or GET /api/searches/results?type=55 via mstr.py
+```
+
+## Phase 1 — Extract the bundle
+
+```bash
+python3 scripts/extract.py <dossierId> bundle.json
+```
+
+Walks dossier definition → dataset reports (`showExpressionAs=tokens`) →
+referenced attributes / metrics (compound bases included via a second pass) /
+facts / logical tables / hierarchy relationships. The bundle is the converter
+contract — `fixtures/bundle.json` is a real, validated example.
+
+## Phase 2 — Convert → Sigma specs
+
+```bash
+python3 scripts/convert.py --bundle bundle.json \
+  --connection-id <SIGMA_CONNECTION_ID> --database <DB> --folder-id <FOLDER_ID> \
+  [--inode-map inodes.json]        # physical table name -> inode tail, optional
+```
+
+Emits `sigma_dm_spec.json` (one table element per logical table, derived
+left-outer joins, a consumable join element, token-parsed metrics with derived
+display formats) + `sigma_workbook_spec.json` (one page per dossier chapter,
+grouped tables mirroring each report template, **controls** from the dossier's
+filter signals, banded-layout container elements) + `parity_keys.json` +
+`layout.xml` + `control-scope.json`. The workbook spec carries
+`{{DATA_MODEL_ID}}` / element-id placeholders until Phase 4 re-runs with real
+ids.
+
+**Controls** (`refs/control-parity.md` is the contract): MSTR dossiers DECLARE
+selector targets (`selectors[].targets` = viz keys) — the strongest
+source-scope signal of any BI tool — so each selector becomes a Sigma control
+whose `filters` wire to exactly the table elements built from the declared
+vizzes; chapter filter panels cover every element on their chapter's page.
+Verified shapes baked in: filter targets only on TABLE elements; controls
+AFTER their targets in spec order; date attributes → `date-range` with flat
+`mode: between` (list-on-datetime targets are silently stripped); **numeric
+attributes bind through a hidden `Text()` cast column** (a list-control filter
+target on a NUMERIC column also posts 200 and reads back `filters: null` —
+live-verified 2026-06-12). Panel selectors are navigation, not filters —
+flagged MANUAL in the sidecar, never silently dropped. `control-scope.json`
+carries `sourceFilterSignals` + per-control declared scope/`mustReach` for
+gate 7.
+
+Conversion patterns to know (details in `refs/`): grids group by the
+attribute's KEY form and label with `Max([DESC])`; dim-keyed groupings get an
+`exclude [null]` filter to mirror MSTR's inner joins; metrics referencing
+metrics are inlined in workbook context, `[Name]`-referenced in DM context.
+
+## Phase 2.5 — AE row-collapse resolution (only when flagged)
+
+If any report has an attribute whose DESC form differs from its key (the
+converter's grouping output makes this visible — and `resolve_ae_winners.py`
+detects it itself), MicroStrategy's Analytical Engine collapses non-unique key
+groups to one representative row that **cannot be derived from the model**:
+
+```bash
+eval "$(scripts/get-token.sh)"
+python3 scripts/resolve_ae_winners.py --connection-id <id> --database <DB> \
+  --folder-id <folderId> --out ae_winners.json
+python3 scripts/convert.py ... --ae-winners ae_winners.json
+```
+
+It re-executes the affected reports in MSTR, computes the clean warehouse
+groups via a throwaway Sigma probe workbook, pins each winner empirically, and
+the converter emits a deterministic SQL element reproducing the grid. Read
+`refs/ae-row-collapse.md` — this is the single biggest parity trap.
+(Fixture path: `fixtures/ae_winners.json` carries the winners pinned during
+the live validation, so the bundled fixture runs end-to-end without a
+Strategy One instance.)
+
+## Phase 2.6 — Reuse an existing DM? (avoid sprawl — mirrors tableau Phase 1.5 / cognos Phase 1.5)
+
+Before POSTing a new data model, score the org's existing Sigma DMs against this
+dossier's tables/columns and reuse on a strong match — don't create a 4th
+near-identical model:
+
+```bash
+python3 scripts/mstr-dm-signature.py --dm-spec sigma_dm_spec.json --out dm-signature.json
+eval "$(scripts/get-token.sh)"
+ruby scripts/find-or-pick-dm.rb --workbook-signature dm-signature.json \
+  --out dm-match.json [--auto-pick]
+```
+
+`mstr-dm-signature.py` derives `{warehouse_tables, referenced_columns, measures}`
+from the Phase-2 `sigma_dm_spec.json`. `find-or-pick-dm.rb` scores each existing
+DM (0.7·column + 0.2·table + 0.1·metric overlap):
+
+- **Score ≥ 0.6** → **ASK the user** reuse-vs-new: surface the candidate name,
+  matched cols (N/M), and the inherited-extras warning from `dm-match.json`. On
+  reuse, **skip the Phase 3 POST** and point Phase 4's workbook at the reused
+  `dataModelId`.
+- **Below threshold** → build new (continue to Phase 3). Non-destructive; never
+  auto-reuses without confirmation unless `--auto-pick` (with tie-window safety).
+
+## Phase 3 — POST the data model + read back ids (hard gate)
+
+```bash
+eval "$(scripts/get-token.sh)"
+curl -s -X POST "$SIGMA_BASE_URL/v2/dataModels/spec" \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Content-Type: application/json" \
+  -d @sigma_dm_spec.json            # -> dataModelId
+curl -s "$SIGMA_BASE_URL/v2/dataModels/<dataModelId>/spec" \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" > dm_readback.yaml
+```
+
+The readback is **YAML**, with **reassigned element ids** — capture them as
+`dm_element_ids.json` (`{"<element name>": "<server id>"}`). **Gate:** scan the
+readback for any column with `type: error` (a spec can POST 200 yet carry
+formulas that don't resolve at query time). Do not proceed on errors —
+`mcp__sigma-data-model__diagnose_sigma_save_error` and the
+`sigma-data-models` skill are the debugging path.
+
+## Phase 4 — Re-emit the workbook with real ids, POST it
+
+```bash
+python3 scripts/convert.py ... --data-model-id <dataModelId> \
+  --dm-element-ids dm_element_ids.json [--ae-winners ae_winners.json]
+curl -s -X POST "$SIGMA_BASE_URL/v2/workbooks/spec" \
+  -H "Authorization: Bearer $SIGMA_API_TOKEN" -H "Content-Type: application/json" \
+  -d @sigma_workbook_spec.json      # -> workbookId
+# MANDATORY run-each-time gap-scout gate (bead beads-sigma-5l5e): the converter
+# passes metric function names through, so a function with no Sigma equivalent
+# surfaces HERE as a type=error column. This script STOPS (exit 11) on any
+# UNSCOUTED error column — spawn a gap-scout per the printed --gap-id (see
+# scripts/gap-scout.md), re-run the gate, and only proceed when it exits 0.
+python3 scripts/scout-gate-readback.py --workbook-id <workbookId> --workdir <out-dir>
+ruby scripts/put-layout.rb --workbook <workbookId> --layout layout.xml
+```
+
+The layout PUT applies the banded layout (header band titled from the
+chapter/dossier name, controls band, full-width tables) the converter emitted
+— without it the workbook renders as Sigma's single-column stack and gates
+4/6 fail. The `scout-gate-readback.py` step above is the **mechanical** version
+of the old "confirm no `type: error` columns" check — do NOT skip it; a broken
+metric must be scouted (translated or escalated) before the workbook ships, not
+waved through. (Workbook DELETE, if you need to retry, is
+`DELETE /v2/files/<id>` — not `/v2/workbooks/<id>`.)
+
+## Phase 5 — Verify parity (hard gate — the real proof)
+
+Expected values come **from MicroStrategy, never invented**: execute each
+report via `POST /api/v2/reports/{id}/instances?limit=N` and write
+`expected_parity.json` (`{"<report name>": [{"keys": [...], "values": {...}}]}`
+— `fixtures/expected_parity.json` is the shape). Then:
+
+```bash
+python3 scripts/verify_parity.py --workbook-id <workbookId> \
+  --expected expected_parity.json --report parity_report.md
+```
+
+Exports every workbook element to CSV via the Sigma export API and compares
+row-by-row (money/counts exact; ratio metrics rel 1e-6). **GREEN only when
+every report PASSes** — never on a 200 POST alone. Mind freshness: Sigma reads
+the live warehouse; if rows landed since the MSTR numbers were captured,
+re-capture before calling a delta a failure (reconcile the delta against the
+post-snapshot rows — the fixture's shared demo tables drift daily).
+
+It also writes the gate sentinels `parity-final.json` + `wb-ids.json` next to
+the report — the contract Phase 6 reads.
+
+## Visual QA (mandatory gate — never skip)
+A workbook that POSTs 200 and passes parity can still be visually broken — **overlapping tiles, clipped KPI titles, dead zones, filters over charts.** Sigma's grid has no z-order; the shared layout lib de-overlaps bands, but this visual gate is the safety net (without a top-level layout the workbook renders as a single-column stack — see the existing layout gate).
+
+1. Render every page to PNG (token first: `eval "$(scripts/get-token.sh)"`):
+   `python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/<page>.png --w 1600`
+2. **Read each PNG** and check it against `refs/layout-visual-qa.md` (no overlaps/stacking, no dead zones, controls in-band, no clipped titles, even heights, right chart kind/format).
+3. Fix any failure in the spec — for multi-page workbooks use `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit → push) — then **re-render and re-read**.
+4. Declare the migration done on a **clean render**, not on HTTP 200.
+
+## Phase 6 — Finalize (hard gate before declaring GREEN)
+
+```bash
+ruby scripts/assert-phase6-ran.rb --workdir <dir> --workbook-id <workbookId>
+```
+
+Seven independent gates (shared, vendored byte-identical): parity ran + PASS,
+no orphan workbooks, no live `type=error` columns, layout applied, tile
+census (skipped — this converter does not emit one), **layout lint** (gate 6:
+no raw-id titles, no orphan controls, no dead zones, no generic "Page N"
+header, no under-filled bands), and **control lint** (gate 7: no dead
+controls, no ghost targets, full declared reach, `control-scope.json`
+coverage — an interactive dossier converting to zero controls FAILS).
+Exit 0 = GREEN. Optional runtime proof after the lint passes:
+
+```bash
+ruby scripts/probe-controls.rb --workbook-id <workbookId> --check-out-of-closure
+# numeric selectors bind via a hidden "<Name> (Filter)" Text() column the
+# auto-picker can't see — pass --value, e.g. --value YearFilter=2024
+```
+
+---
+
+## What converts, what's flagged (never faked)
+
+**Converted (live-validated):** classic schema → DM (logical tables → table
+elements; attribute key forms on fact+lookup → left-outer joins; heterogeneous
+key columns; facts + token-parsed metrics incl. `Count<Distinct=True>` →
+`CountDistinct` and compound metrics; semantic display formats) · dossier
+chapters → workbook pages with grouped tables (KEY-form grouping + `Max(DESC)`
+labels + null-exclude filters) · AE row-collapse reports → deterministic
+pinned-winner SQL elements · **chapter filters + attribute selectors → Sigma
+controls** wired to the selectors' DECLARED viz targets (gate-7-verified +
+flip-tested) with banded layout.
+
+**Flagged / roadmap:** unmapped viz types → flagged table fallback
+(`refs/viz-type-mapping.md`); chart emission (kpi/bar/line/combo) extraction-
+validated but build roadmap; metric-condition selectors / page-by / prompts
+(metric qualification selectors land in `control-scope.json` `unbound` as
+MANUAL); panel selectors (navigation — flagged MANUAL); the newer
+REST-authorable "Data Model" object incl. `securityFilters` (the future RLS
+port surface — until then, **ask the customer about security filters
+explicitly**; never assume an estate has none just because the classic extract
+doesn't carry them).
+
+## Gotchas baked into the scripts (don't re-learn these)
+
+- Changeset lock dangling + `DELETE /api/model/schema/lock`; reports do NOT
+  use changesets; lowercase `x-mstr-ms-instance` response header; PUT
+  relationships REPLACES the parent list — `refs/mstr-rest-api.md`.
+- Attribute-count metrics (`Count(Customer)`) → cartesian governance aborts —
+  count a fact/key column instead; compound denominators need `ZeroToNull()`
+  or Snowflake kills the report — `refs/design-notes.md`.
+- A list-control filter target on a DATETIME **or NUMERIC** column posts 200
+  and is SILENTLY STRIPPED (`filters: null` on readback) — dates → date-range
+  controls, numbers → hidden `Text()` cast column (`convert.py` handles both;
+  gate 7 catches escapes).
+- Python 3.13+ rejects some MSTR cloud CA certs (`VERIFY_X509_STRICT`) —
+  `mstr.py` handles it.

--- a/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/BUILD_SPEC.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/BUILD_SPEC.md
@@ -1,0 +1,65 @@
+# "Orders Analytics Workbench" — dossier build spec (Library UI)
+
+Goal: one big dossier exercising every visualization type the Library gallery
+offers, all on live Snowflake data, as the migration-converter fixture.
+REST cannot author visualizations, so this is ~30 min of drag-and-drop.
+
+**Dataset:** every page uses the report **`Orders Wide Dataset`**
+(Public Objects → Reports). When creating the dossier: ⊕ New Dashboard →
+Add Data → Existing Dataset → Orders Wide Dataset.
+It has 15 attributes (Region, State, Store, Store Type, Category, Subcategory,
+Brand, Customer Segment, Loyalty Tier, Year, Month, Day, Order Channel,
+Ship Method, Order Status) and 12 metrics (Total Net Revenue, Total Gross
+Profit, Profit Margin Pct, Units Sold, Order Count, Avg Unit Price, Total
+Discount, Total Shipping, Units Returned, Customer Count, Avg Order Value,
+Return Rate).
+
+Name the dossier **Orders Analytics Workbench**, save into Public Objects → Reports.
+
+If a viz type below isn't in your gallery, skip it and note which.
+
+## Page 1 — Revenue Overview
+| # | Viz type | Slots |
+|---|----------|-------|
+| 1 | KPI | Metric: Total Net Revenue |
+| 2 | Multi-Metric KPI | Metrics: Total Net Revenue, Order Count, Units Sold, Avg Order Value |
+| 3 | Bar (vertical clustered) | Vertical: Total Net Revenue · Horizontal: Region · Color By: Category |
+| 4 | Bar (stacked) | Vertical: Total Net Revenue · Horizontal: Order Channel · Color By: Category (Stacked) |
+| 5 | Line | Vertical: Total Net Revenue · Horizontal: Month (sorted by ID) · Break By: Year |
+| 6 | Area | Vertical: Units Sold · Horizontal: Month |
+
+## Page 2 — Product & Mix
+| # | Viz type | Slots |
+|---|----------|-------|
+| 7 | Pie | Angle: Total Net Revenue · Slice: Category |
+| 8 | Ring/Donut | Angle: Order Count · Slice: Loyalty Tier |
+| 9 | Heat Map | Grouping: Category, Subcategory · Size By: Total Net Revenue · Color By: Profit Margin Pct |
+| 10 | Combo | Vertical L: Total Net Revenue (bar) · Vertical R: Profit Margin Pct (line) · Horizontal: Month |
+| 11 | Grid | Rows: Brand · Metrics: all 12 — then add a **threshold** (e.g. Profit Margin Pct < 0.5 red) |
+
+## Page 3 — Statistical
+| # | Viz type | Slots |
+|---|----------|-------|
+| 12 | Scatter | X: Avg Unit Price · Y: Units Sold · Group/point: Product? not in dataset — use Subcategory · Color: Category |
+| 13 | Bubble | X: Total Net Revenue · Y: Profit Margin Pct · Size: Units Sold · Group: Store · Color: Region |
+| 14 | Histogram | Metric: Avg Order Value · binning default (per Store) |
+| 15 | Box Plot | Y: Total Net Revenue · Group: Region · point = Store |
+| 16 | Waterfall | Vertical: Total Net Revenue · Horizontal: Category |
+
+## Page 4 — Geo, Flow & Text
+| # | Viz type | Slots |
+|---|----------|-------|
+| 17 | Map (Geospatial / ESRI) | Geo attribute: State (set Geo Role → State when prompted) · Color: Total Net Revenue |
+| 18 | Sankey (if present) | From: Region · To: Order Channel · Weight: Units Sold |
+| 19 | Network (if present) | From: Category · To: Brand · Weight: Order Count |
+| 20 | Funnel (if present) | Stage: Order Status · Metric: Order Count |
+| 21 | Word Cloud (if present) | Word: Brand · Size: Total Net Revenue |
+| 22 | Text box + Image | any title text + any image (free-form `fields` coverage) |
+
+## Dossier-level features (converter coverage beyond viz types)
+- **Chapter filter:** add Year as a filter (All / 2026).
+- **Selector/panel:** put vizzes 7–8 in a Panel Stack with a panel selector.
+- **Attribute selector** targeting viz 3 (e.g. element selector on Region).
+- Rename chapters: "Overview", "Product", "Statistical", "Geo & Flow".
+
+When done, tell Claude — extraction + Sigma migration take it from there.

--- a/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/ae_winners.json
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/ae_winners.json
@@ -1,0 +1,23 @@
+{
+ "Monthly Revenue Trend": {
+  "quirkKeyCol": "MONTH_NUMBER",
+  "quirkDescCol": "MONTH_NAME",
+  "parentKeyCols": [
+   "YEAR"
+  ],
+  "winners": [
+   {"Month Number": 1, "Year": 2024},
+   {"Month Number": 2, "Year": 2026},
+   {"Month Number": 3, "Year": 2025},
+   {"Month Number": 4, "Year": 2026},
+   {"Month Number": 5, "Year": 2026},
+   {"Month Number": 6, "Year": 2024},
+   {"Month Number": 7, "Year": 2025},
+   {"Month Number": 8, "Year": 2024},
+   {"Month Number": 9, "Year": 2025},
+   {"Month Number": 10, "Year": 2025},
+   {"Month Number": 11, "Year": 2025},
+   {"Month Number": 12, "Year": 2025}
+  ]
+ }
+}

--- a/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/build_schema.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/build_schema.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Build the orders-star fixture schema in a MicroStrategy project.
+
+This is the FIXTURE BUILDER (not part of a customer migration): it recreates
+the schema objects behind fixtures/bundle.json in a fresh Strategy One
+project so the converter's validated end-to-end loop can be rehearsed on a
+trial env. Logical tables must exist first (create via the modeling UI or
+POST /api/model/tables) and two small sidecar files describe them:
+
+  table_ids.json  — {"ORDER_FACT": "<logical table objectId>", ...}
+  folder_ids.json — {"attributes": "<folderId>", "facts": ..., "metrics": ...}
+
+Creates attributes, hierarchy relationships, facts, and metrics; reloads the
+schema at the end. Progress is checkpointed to object_ids.json. Idempotence
+beyond that checkpoint: not attempted — run against a clean project.
+"""
+import json
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                '..', 'scripts'))
+import mstr
+
+s = mstr.Session()
+T = json.load(open('table_ids.json'))
+F = json.load(open('folder_ids.json'))
+state_path = 'object_ids.json'
+try:
+    state = json.load(open(state_path))
+except FileNotFoundError:
+    state = {'attributes': {}, 'facts': {}, 'metrics': {}}
+
+
+def tbl(name):
+    return {'objectId': T[name], 'subType': 'logical_table', 'name': name}
+
+
+def save():
+    json.dump(state, open(state_path, 'w'), indent=1)
+
+
+def form(category, display, column, tables, name=None):
+    f = {'category': category, 'displayFormat': display,
+         'expressions': [{'expression': {'tokens': [{'value': column}]},
+                          'tables': [tbl(t) for t in tables]}]}
+    if name:
+        f['name'] = name
+    return f
+
+
+# (name, lookup table, forms, report/browse display form)
+ATTRIBUTES = [
+    ('Customer', 'CUSTOMER_DIM',
+     [form('ID', 'number', 'CUSTOMER_KEY', ['CUSTOMER_DIM', 'ORDER_FACT']),
+      form('DESC', 'text', 'CUSTOMER_ID', ['CUSTOMER_DIM'])], 'DESC'),
+    ('Customer Segment', 'CUSTOMER_DIM',
+     [form('ID', 'text', 'CUSTOMER_SEGMENT', ['CUSTOMER_DIM'])], 'ID'),
+    ('Region', 'STORE_DIM',
+     [form('ID', 'text', 'REGION', ['STORE_DIM'])], 'ID'),
+    ('Store', 'STORE_DIM',
+     [{'category': 'ID', 'displayFormat': 'number',
+       'expressions': [
+           {'expression': {'tokens': [{'value': 'STORE_KEY'}]},
+            'tables': [tbl('STORE_DIM')]},
+           {'expression': {'tokens': [{'value': 'ORDER_STORE_KEY'}]},
+            'tables': [tbl('ORDER_FACT')]},
+       ]},
+      form('DESC', 'text', 'STORE_NAME', ['STORE_DIM'])], 'DESC'),
+    ('Category', 'PRODUCT_DIM',
+     [form('ID', 'text', 'CATEGORY', ['PRODUCT_DIM'])], 'ID'),
+    ('Product', 'PRODUCT_DIM',
+     [form('ID', 'number', 'PRODUCT_KEY', ['PRODUCT_DIM', 'ORDER_FACT']),
+      form('DESC', 'text', 'PRODUCT_NAME', ['PRODUCT_DIM'])], 'DESC'),
+    ('Year', 'DATE_DIM',
+     [form('ID', 'number', 'YEAR', ['DATE_DIM'])], 'ID'),
+    ('Month', 'DATE_DIM',
+     [form('ID', 'number', 'MONTH_NUMBER', ['DATE_DIM']),
+      form('DESC', 'text', 'MONTH_NAME', ['DATE_DIM'])], 'DESC'),
+    ('Day', 'DATE_DIM',
+     [{'category': 'ID', 'displayFormat': 'number',
+       'expressions': [
+           {'expression': {'tokens': [{'value': 'DATE_KEY'}]},
+            'tables': [tbl('DATE_DIM')]},
+           {'expression': {'tokens': [{'value': 'ORDER_DATE_KEY'}]},
+            'tables': [tbl('ORDER_FACT')]},
+       ]},
+      form('DESC', 'date', 'FULL_DATE', ['DATE_DIM'])], 'DESC'),
+    ('Order Channel', 'ORDER_FACT',
+     [form('ID', 'text', 'ORDER_CHANNEL', ['ORDER_FACT'])], 'ID'),
+    ('Order Status', 'ORDER_FACT',
+     [form('ID', 'text', 'ORDER_STATUS', ['ORDER_FACT'])], 'ID'),
+]
+
+# child -> (parent, relationship table)
+RELATIONSHIPS = {
+    'Customer': ('Customer Segment', 'CUSTOMER_DIM'),
+    'Store': ('Region', 'STORE_DIM'),
+    'Product': ('Category', 'PRODUCT_DIM'),
+    'Month': ('Year', 'DATE_DIM'),
+    'Day': ('Month', 'DATE_DIM'),
+}
+
+FACTS = [
+    ('Net Revenue', 'NET_REVENUE'),
+    ('Gross Profit', 'GROSS_PROFIT'),
+    ('Quantity', 'QUANTITY_ORDERED'),
+    ('Discount', 'DISCOUNT_AMOUNT'),
+    ('Order Id Fact', 'ORDER_ID'),
+]
+
+METRICS = [
+    ('Total Net Revenue', 'Sum([Net Revenue]) {~}'),
+    ('Total Gross Profit', 'Sum([Gross Profit]) {~}'),
+    ('Units Sold', 'Sum([Quantity]) {~}'),
+    ('Order Count', 'Count<Distinct=True>([Order Id Fact]) {~}'),
+    ('Profit Margin Pct', '([Total Gross Profit] / [Total Net Revenue])'),
+]
+
+
+def create_attributes(cs):
+    for name, lookup, forms, disp in ATTRIBUTES:
+        if name in state['attributes']:
+            continue
+        body = {
+            'information': {'name': name, 'subType': 'attribute',
+                            'destinationFolderId': F['attributes']},
+            'forms': forms,
+            'attributeLookupTable': tbl(lookup),
+            'keyForm': {'name': 'ID'},
+            'displays': {'reportDisplays': [{'name': disp}],
+                         'browseDisplays': [{'name': disp}]},
+        }
+        r = s.cs_post('/model/attributes', body, cs)
+        state['attributes'][name] = r['information']['objectId']
+        print('attribute', name, '->', state['attributes'][name])
+        save()
+
+
+def create_relationships(cs):
+    for child, (parent, table) in RELATIONSHIPS.items():
+        child_id = state['attributes'][child]
+        body = {'relationships': [{
+            'parent': {'objectId': state['attributes'][parent],
+                       'subType': 'attribute', 'name': parent},
+            'child': {'objectId': child_id,
+                      'subType': 'attribute', 'name': child},
+            'relationshipTable': tbl(table),
+            'relationshipType': 'one_to_many',
+        }]}
+        s.put(f'/model/systemHierarchy/attributes/{child_id}/relationships',
+              body, headers={'X-MSTR-MS-Changeset': cs})
+        print('relationship', parent, '>', child)
+
+
+def create_facts(cs):
+    for name, column in FACTS:
+        if name in state['facts']:
+            continue
+        body = {
+            'information': {'name': name, 'subType': 'fact',
+                            'destinationFolderId': F['facts']},
+            'expressions': [{'expression': {'tokens': [{'value': column}]},
+                             'tables': [tbl('ORDER_FACT')]}],
+        }
+        r = s.cs_post('/model/facts', body, cs)
+        state['facts'][name] = r['information']['objectId']
+        print('fact', name, '->', state['facts'][name])
+        save()
+
+
+def create_metrics(cs):
+    for name, formula in METRICS:
+        if name in state['metrics']:
+            continue
+        body = {
+            'information': {'name': name, 'subType': 'metric',
+                            'destinationFolderId': F['metrics']},
+            'expression': {'tokens': [{'value': formula}]},
+        }
+        r = s.cs_post('/model/metrics', body, cs)
+        state['metrics'][name] = r['information']['objectId']
+        print('metric', name, '->', state['metrics'][name])
+        save()
+
+
+if __name__ == '__main__':
+    s.schema_edit(create_attributes)
+    s.schema_edit(create_relationships)
+    s.schema_edit(create_facts)
+    s.schema_edit(create_metrics)
+    s.post('/model/schema/reload')
+    print('schema reloaded')

--- a/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/bundle.json
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/bundle.json
@@ -1,0 +1,4374 @@
+{
+ "dossier": {
+  "id": "77EFB43F5B441BA7B6EEECAB4D92A7EF",
+  "name": "Orders Performance Overview",
+  "datasets": [
+   {
+    "name": "Revenue by Region and Category",
+    "id": "5C8ABD78BC4EA7F4AF876E97091E6BA5",
+    "availableObjects": [
+     {
+      "id": "6140BFA7309B406AA76A90454BC7BB53",
+      "name": "Region",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "13AF74581AA84A46B8FD2D1BBA073150",
+      "name": "Category",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "413D98E4993B4D6ABB2DC440F7B31971",
+      "name": "Total Net Revenue",
+      "type": "metric"
+     },
+     {
+      "id": "653830C2CB684809B7030FBBEA498C8C",
+      "name": "Total Gross Profit",
+      "type": "metric"
+     },
+     {
+      "id": "5393F49A94A443E79E38CB3855B0272F",
+      "name": "Profit Margin Pct",
+      "type": "metric"
+     }
+    ],
+    "rows": [
+     {
+      "id": "6140BFA7309B406AA76A90454BC7BB53",
+      "name": "Region",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "13AF74581AA84A46B8FD2D1BBA073150",
+      "name": "Category",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     }
+    ],
+    "columns": [
+     {
+      "id": "00000000000000000000000000000000",
+      "name": "Metrics",
+      "type": "templateMetrics",
+      "elements": [
+       {
+        "name": "Total Net Revenue",
+        "id": "413D98E4993B4D6ABB2DC440F7B31971",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Total Gross Profit",
+        "id": "653830C2CB684809B7030FBBEA498C8C",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Profit Margin Pct",
+        "id": "5393F49A94A443E79E38CB3855B0272F",
+        "type": "metric",
+        "dataType": "reserved"
+       }
+      ]
+     }
+    ],
+    "pageBy": []
+   },
+   {
+    "name": "Monthly Revenue Trend",
+    "id": "864205BFBA4B4E6E863C3FB42FB0A406",
+    "availableObjects": [
+     {
+      "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "name": "Year",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "decimal",
+        "baseFormCategory": "ID",
+        "baseFormType": "number"
+       }
+      ]
+     },
+     {
+      "id": "C3292DAD4FAF404F88590CB19C3930F9",
+      "name": "Month",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "name": "DESC",
+        "dataType": "varChar",
+        "baseFormCategory": "DESC",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "413D98E4993B4D6ABB2DC440F7B31971",
+      "name": "Total Net Revenue",
+      "type": "metric"
+     },
+     {
+      "id": "145746BAC65E4BF39E83149A843A3DF7",
+      "name": "Order Count",
+      "type": "metric"
+     }
+    ],
+    "rows": [
+     {
+      "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "name": "Year",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "decimal",
+        "baseFormCategory": "ID",
+        "baseFormType": "number"
+       }
+      ]
+     },
+     {
+      "id": "C3292DAD4FAF404F88590CB19C3930F9",
+      "name": "Month",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "name": "DESC",
+        "dataType": "varChar",
+        "baseFormCategory": "DESC",
+        "baseFormType": "text"
+       }
+      ]
+     }
+    ],
+    "columns": [
+     {
+      "id": "00000000000000000000000000000000",
+      "name": "Metrics",
+      "type": "templateMetrics",
+      "elements": [
+       {
+        "name": "Total Net Revenue",
+        "id": "413D98E4993B4D6ABB2DC440F7B31971",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Order Count",
+        "id": "145746BAC65E4BF39E83149A843A3DF7",
+        "type": "metric",
+        "dataType": "reserved"
+       }
+      ]
+     }
+    ],
+    "pageBy": []
+   },
+   {
+    "name": "Channel Performance",
+    "id": "69759BAD734F3EB9308219B61D916432",
+    "availableObjects": [
+     {
+      "id": "E951AA8437BF46BB860E98F0DB349617",
+      "name": "Order Channel",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     },
+     {
+      "id": "413D98E4993B4D6ABB2DC440F7B31971",
+      "name": "Total Net Revenue",
+      "type": "metric"
+     },
+     {
+      "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+      "name": "Units Sold",
+      "type": "metric"
+     },
+     {
+      "id": "145746BAC65E4BF39E83149A843A3DF7",
+      "name": "Order Count",
+      "type": "metric"
+     }
+    ],
+    "rows": [
+     {
+      "id": "E951AA8437BF46BB860E98F0DB349617",
+      "name": "Order Channel",
+      "type": "attribute",
+      "forms": [
+       {
+        "id": "45C11FA478E745FEA08D781CEA190FE5",
+        "name": "ID",
+        "dataType": "varChar",
+        "baseFormCategory": "ID",
+        "baseFormType": "text"
+       }
+      ]
+     }
+    ],
+    "columns": [
+     {
+      "id": "00000000000000000000000000000000",
+      "name": "Metrics",
+      "type": "templateMetrics",
+      "elements": [
+       {
+        "name": "Total Net Revenue",
+        "id": "413D98E4993B4D6ABB2DC440F7B31971",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Units Sold",
+        "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+        "type": "metric",
+        "dataType": "reserved"
+       },
+       {
+        "name": "Order Count",
+        "id": "145746BAC65E4BF39E83149A843A3DF7",
+        "type": "metric",
+        "dataType": "reserved"
+       }
+      ]
+     }
+    ],
+    "pageBy": []
+   }
+  ],
+  "currentChapter": "K123",
+  "chapters": [
+   {
+    "key": "K65",
+    "name": "Revenue by Region and Category",
+    "pages": [
+     {
+      "key": "K85",
+      "name": "Page 1",
+      "visualizations": [
+       {
+        "key": "K86",
+        "name": "Visualization 1",
+        "visualizationType": "grid"
+       }
+      ]
+     }
+    ],
+    "filters": [
+     {
+      "key": "K201",
+      "name": "Region",
+      "source": {
+       "id": "6140BFA7309B406AA76A90454BC7BB53",
+       "name": "Region"
+      }
+     }
+    ]
+   },
+   {
+    "key": "K69",
+    "name": "Monthly Revenue Trend",
+    "pages": [
+     {
+      "key": "K120",
+      "name": "Page 1",
+      "visualizations": [
+       {
+        "key": "K121",
+        "name": "Visualization 1",
+        "visualizationType": "grid"
+       }
+      ],
+      "selectors": [
+       {
+        "key": "K124",
+        "name": "Year",
+        "selectorType": "attribute_selector_lists",
+        "source": {
+         "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+         "name": "Year"
+        },
+        "multiSelectionAllowed": true,
+        "hasAll": true,
+        "targets": [
+         {
+          "key": "K121"
+         }
+        ]
+       }
+      ]
+     }
+    ],
+    "filters": []
+   },
+   {
+    "key": "K123",
+    "name": "Channel Performance",
+    "pages": [
+     {
+      "key": "K158",
+      "name": "Page 1",
+      "visualizations": [
+       {
+        "key": "K159",
+        "name": "Visualization 1",
+        "visualizationType": "grid"
+       }
+      ],
+      "selectors": [
+       {
+        "key": "K160",
+        "name": "Order Channel",
+        "selectorType": "attribute_selector_lists",
+        "source": {
+         "id": "E951AA8437BF46BB860E98F0DB349617",
+         "name": "Order Channel"
+        },
+        "multiSelectionAllowed": true,
+        "hasAll": true,
+        "targets": [
+         {
+          "key": "K159"
+         }
+        ]
+       },
+       {
+        "key": "K162",
+        "name": "Panel Selector 1",
+        "selectorType": "panel_selector_button_bar",
+        "targets": []
+       }
+      ]
+     }
+    ],
+    "filters": []
+   }
+  ]
+ },
+ "reports": {
+  "5C8ABD78BC4EA7F4AF876E97091E6BA5": {
+   "information": {
+    "dateCreated": "2026-06-11T01:51:17.284Z",
+    "dateModified": "2026-06-11T01:51:17.284Z",
+    "versionId": "A81A552B3B4FAB584A8293ABBBEE2798",
+    "acg": 255,
+    "objectId": "5C8ABD78BC4EA7F4AF876E97091E6BA5",
+    "subType": "report_grid",
+    "name": "Revenue by Region and Category"
+   },
+   "sourceType": "normal",
+   "dataSource": {
+    "dataTemplate": {
+     "units": [
+      {
+       "id": "6140BFA7309B406AA76A90454BC7BB53",
+       "name": "Region",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "id": "13AF74581AA84A46B8FD2D1BBA073150",
+       "name": "Category",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "type": "metrics",
+       "elements": [
+        {
+         "id": "413D98E4993B4D6ABB2DC440F7B31971",
+         "name": "Total Net Revenue",
+         "subType": "metric"
+        },
+        {
+         "id": "653830C2CB684809B7030FBBEA498C8C",
+         "name": "Total Gross Profit",
+         "subType": "metric"
+        },
+        {
+         "id": "5393F49A94A443E79E38CB3855B0272F",
+         "name": "Profit Margin Pct",
+         "subType": "metric"
+        }
+       ]
+      }
+     ]
+    },
+    "filter": {}
+   },
+   "grid": {
+    "viewTemplate": {
+     "rows": {
+      "units": [
+       {
+        "id": "6140BFA7309B406AA76A90454BC7BB53",
+        "name": "Region",
+        "type": "attribute"
+       },
+       {
+        "id": "13AF74581AA84A46B8FD2D1BBA073150",
+        "name": "Category",
+        "type": "attribute"
+       }
+      ],
+      "sorts": []
+     },
+     "columns": {
+      "units": [
+       {
+        "type": "metrics",
+        "elements": [
+         {
+          "id": "413D98E4993B4D6ABB2DC440F7B31971",
+          "name": "Total Net Revenue",
+          "subType": "metric"
+         },
+         {
+          "id": "653830C2CB684809B7030FBBEA498C8C",
+          "name": "Total Gross Profit",
+          "subType": "metric"
+         },
+         {
+          "id": "5393F49A94A443E79E38CB3855B0272F",
+          "name": "Profit Margin Pct",
+          "subType": "metric"
+         }
+        ]
+       }
+      ],
+      "sorts": []
+     },
+     "pageBy": {
+      "units": [],
+      "sorts": []
+     }
+    },
+    "viewFilter": {}
+   }
+  },
+  "864205BFBA4B4E6E863C3FB42FB0A406": {
+   "information": {
+    "dateCreated": "2026-06-11T01:51:17.779Z",
+    "dateModified": "2026-06-11T01:51:17.779Z",
+    "versionId": "43BB95B68A4CCA7DBDBC93B9B2F6DA34",
+    "acg": 255,
+    "objectId": "864205BFBA4B4E6E863C3FB42FB0A406",
+    "subType": "report_grid",
+    "name": "Monthly Revenue Trend"
+   },
+   "sourceType": "normal",
+   "dataSource": {
+    "dataTemplate": {
+     "units": [
+      {
+       "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+       "name": "Year",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "id": "C3292DAD4FAF404F88590CB19C3930F9",
+       "name": "Month",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "type": "metrics",
+       "elements": [
+        {
+         "id": "413D98E4993B4D6ABB2DC440F7B31971",
+         "name": "Total Net Revenue",
+         "subType": "metric"
+        },
+        {
+         "id": "145746BAC65E4BF39E83149A843A3DF7",
+         "name": "Order Count",
+         "subType": "metric"
+        }
+       ]
+      }
+     ]
+    },
+    "filter": {}
+   },
+   "grid": {
+    "viewTemplate": {
+     "rows": {
+      "units": [
+       {
+        "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+        "name": "Year",
+        "type": "attribute"
+       },
+       {
+        "id": "C3292DAD4FAF404F88590CB19C3930F9",
+        "name": "Month",
+        "type": "attribute"
+       }
+      ],
+      "sorts": []
+     },
+     "columns": {
+      "units": [
+       {
+        "type": "metrics",
+        "elements": [
+         {
+          "id": "413D98E4993B4D6ABB2DC440F7B31971",
+          "name": "Total Net Revenue",
+          "subType": "metric"
+         },
+         {
+          "id": "145746BAC65E4BF39E83149A843A3DF7",
+          "name": "Order Count",
+          "subType": "metric"
+         }
+        ]
+       }
+      ],
+      "sorts": []
+     },
+     "pageBy": {
+      "units": [],
+      "sorts": []
+     }
+    },
+    "viewFilter": {}
+   }
+  },
+  "69759BAD734F3EB9308219B61D916432": {
+   "information": {
+    "dateCreated": "2026-06-11T01:51:18.212Z",
+    "dateModified": "2026-06-11T01:51:18.212Z",
+    "versionId": "A44A49EA35425984036D79927BEFA145",
+    "acg": 255,
+    "objectId": "69759BAD734F3EB9308219B61D916432",
+    "subType": "report_grid",
+    "name": "Channel Performance"
+   },
+   "sourceType": "normal",
+   "dataSource": {
+    "dataTemplate": {
+     "units": [
+      {
+       "id": "E951AA8437BF46BB860E98F0DB349617",
+       "name": "Order Channel",
+       "type": "attribute",
+       "nonAggregatable": false
+      },
+      {
+       "type": "metrics",
+       "elements": [
+        {
+         "id": "413D98E4993B4D6ABB2DC440F7B31971",
+         "name": "Total Net Revenue",
+         "subType": "metric"
+        },
+        {
+         "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+         "name": "Units Sold",
+         "subType": "metric"
+        },
+        {
+         "id": "145746BAC65E4BF39E83149A843A3DF7",
+         "name": "Order Count",
+         "subType": "metric"
+        }
+       ]
+      }
+     ]
+    },
+    "filter": {}
+   },
+   "grid": {
+    "viewTemplate": {
+     "rows": {
+      "units": [
+       {
+        "id": "E951AA8437BF46BB860E98F0DB349617",
+        "name": "Order Channel",
+        "type": "attribute"
+       }
+      ],
+      "sorts": []
+     },
+     "columns": {
+      "units": [
+       {
+        "type": "metrics",
+        "elements": [
+         {
+          "id": "413D98E4993B4D6ABB2DC440F7B31971",
+          "name": "Total Net Revenue",
+          "subType": "metric"
+         },
+         {
+          "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+          "name": "Units Sold",
+          "subType": "metric"
+         },
+         {
+          "id": "145746BAC65E4BF39E83149A843A3DF7",
+          "name": "Order Count",
+          "subType": "metric"
+         }
+        ]
+       }
+      ],
+      "sorts": []
+     },
+     "pageBy": {
+      "units": [],
+      "sorts": []
+     }
+    },
+    "viewFilter": {}
+   }
+  }
+ },
+ "attributes": {
+  "13AF74581AA84A46B8FD2D1BBA073150": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:40:35.091Z",
+    "versionId": "2F7B0587EB4A72B49B0EAAAC1FC4B0C4",
+    "acg": 255,
+    "objectId": "13AF74581AA84A46B8FD2D1BBA073150",
+    "subType": "attribute",
+    "name": "Category"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "text",
+     "dataType": {
+      "type": "fixed_length_string",
+      "precision": 50,
+      "scale": -2147483648
+     },
+     "expressions": [
+      {
+       "expressionId": "B8BB213EB9B3474BA0A064C69F846AE9",
+       "expression": {
+        "text": "CATEGORY",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "CATEGORY",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "EE2E24FFDF58489193BB93F5FEB66D5B",
+           "subType": "column",
+           "name": "CATEGORY"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+         "subType": "logical_table",
+         "name": "PRODUCT_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "CATEGORY",
+     "lookupTable": {
+      "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+      "subType": "logical_table",
+      "name": "PRODUCT_DIM"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+    "subType": "logical_table",
+    "name": "PRODUCT_DIM"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "13AF74581AA84A46B8FD2D1BBA073150",
+      "subType": "attribute",
+      "name": "Category"
+     },
+     "child": {
+      "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "relationshipTable": {
+      "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+      "subType": "logical_table",
+      "name": "PRODUCT_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  },
+  "6140BFA7309B406AA76A90454BC7BB53": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:40:35.091Z",
+    "versionId": "2F7B0587EB4A72B49B0EAAAC1FC4B0C4",
+    "acg": 255,
+    "objectId": "6140BFA7309B406AA76A90454BC7BB53",
+    "subType": "attribute",
+    "name": "Region"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "text",
+     "dataType": {
+      "type": "fixed_length_string",
+      "precision": 20,
+      "scale": -2147483648
+     },
+     "expressions": [
+      {
+       "expressionId": "02676EBADA84448B9F8C161CA904811C",
+       "expression": {
+        "text": "REGION",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "REGION",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "31FC4505562A431BBBB15D0B79514023",
+           "subType": "column",
+           "name": "REGION"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+         "subType": "logical_table",
+         "name": "STORE_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "REGION",
+     "lookupTable": {
+      "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+      "subType": "logical_table",
+      "name": "STORE_DIM"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+    "subType": "logical_table",
+    "name": "STORE_DIM"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "6140BFA7309B406AA76A90454BC7BB53",
+      "subType": "attribute",
+      "name": "Region"
+     },
+     "child": {
+      "objectId": "9177026370BB44A3A0CD521FE5166500",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "relationshipTable": {
+      "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+      "subType": "logical_table",
+      "name": "STORE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  },
+  "C025482DAE4C4BFDA72E8297D981ABAC": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:40:35.091Z",
+    "versionId": "2F7B0587EB4A72B49B0EAAAC1FC4B0C4",
+    "acg": 255,
+    "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+    "subType": "attribute",
+    "name": "Year"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "number",
+     "dataType": {
+      "type": "decimal",
+      "precision": 4,
+      "scale": 0
+     },
+     "expressions": [
+      {
+       "expressionId": "D06E7BCA19D543F589D084E7C90B89E9",
+       "expression": {
+        "text": "YEAR",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "YEAR",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "A443425EB7684086B49B5182EDA0D825",
+           "subType": "column",
+           "name": "YEAR"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+         "subType": "logical_table",
+         "name": "DATE_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "YEAR",
+     "lookupTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+    "subType": "logical_table",
+    "name": "DATE_DIM"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "child": {
+      "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "relationshipTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  },
+  "C3292DAD4FAF404F88590CB19C3930F9": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:40:35.091Z",
+    "versionId": "2F7B0587EB4A72B49B0EAAAC1FC4B0C4",
+    "acg": 255,
+    "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+    "subType": "attribute",
+    "name": "Month"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "number",
+     "dataType": {
+      "type": "decimal",
+      "precision": 2,
+      "scale": 0
+     },
+     "expressions": [
+      {
+       "expressionId": "526242A750714963BE42EB4E80918214",
+       "expression": {
+        "text": "MONTH_NUMBER",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "MONTH_NUMBER",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "421F8160638F4F9AA7FC434C0EBF14EC",
+           "subType": "column",
+           "name": "MONTH_NUMBER"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+         "subType": "logical_table",
+         "name": "DATE_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "MONTH_NUMBER",
+     "lookupTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     }
+    },
+    {
+     "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+     "name": "",
+     "category": "DESC",
+     "type": "system",
+     "displayFormat": "text",
+     "dataType": {
+      "type": "fixed_length_string",
+      "precision": 10,
+      "scale": -2147483648
+     },
+     "expressions": [
+      {
+       "expressionId": "E56418E7E00A4115BB562695AE70921E",
+       "expression": {
+        "text": "MONTH_NAME",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "MONTH_NAME",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "4C6BF4B48BF94197B76731366E39ED7A",
+           "subType": "column",
+           "name": "MONTH_NAME"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+         "subType": "logical_table",
+         "name": "DATE_DIM"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "MONTH_NAME",
+     "lookupTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+    "subType": "logical_table",
+    "name": "DATE_DIM"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "child": {
+      "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "relationshipTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    },
+    {
+     "parent": {
+      "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "child": {
+      "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "relationshipTable": {
+      "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  },
+  "E951AA8437BF46BB860E98F0DB349617": {
+   "information": {
+    "dateCreated": "2026-06-11T01:39:45.089Z",
+    "dateModified": "2026-06-11T01:39:45.089Z",
+    "versionId": "B6C6654A01446E6F7D4C42BDD134E645",
+    "acg": 255,
+    "objectId": "E951AA8437BF46BB860E98F0DB349617",
+    "subType": "attribute",
+    "name": "Order Channel"
+   },
+   "forms": [
+    {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "",
+     "category": "ID",
+     "type": "system",
+     "displayFormat": "text",
+     "dataType": {
+      "type": "fixed_length_string",
+      "precision": 20,
+      "scale": -2147483648
+     },
+     "expressions": [
+      {
+       "expressionId": "30FCC73845F54BD0AAA4D55C723C8432",
+       "expression": {
+        "text": "ORDER_CHANNEL",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "ORDER_CHANNEL",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T01:34:19.851Z",
+           "dateModified": "2026-06-11T01:34:19.851Z",
+           "versionId": "D84CD810B84204E035ADD5BF872EC621",
+           "acg": 255,
+           "objectId": "6D2F6387F5624C3FA6D4F9CC5320D324",
+           "subType": "column",
+           "name": "ORDER_CHANNEL"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "D9FC61279B1B493896B8D146734F3706",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ],
+       "autoMapping": true
+      }
+     ],
+     "alias": "ORDER_CHANNEL",
+     "lookupTable": {
+      "objectId": "D9FC61279B1B493896B8D146734F3706",
+      "subType": "logical_table",
+      "name": "ORDER_FACT"
+     }
+    }
+   ],
+   "attributeLookupTable": {
+    "objectId": "D9FC61279B1B493896B8D146734F3706",
+    "subType": "logical_table",
+    "name": "ORDER_FACT"
+   },
+   "keyForm": {
+    "id": "45C11FA478E745FEA08D781CEA190FE5"
+   },
+   "displays": {
+    "reportDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ],
+    "browseDisplays": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5"
+     }
+    ]
+   },
+   "sorts": {},
+   "relationships": [],
+   "nonAggregatable": false,
+   "applySecurityFiltersToElementBrowsing": true,
+   "enableElementCaching": true,
+   "elementDisplayOption": "all_elements"
+  }
+ },
+ "metrics": {
+  "145746BAC65E4BF39E83149A843A3DF7": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:18.866Z",
+    "dateModified": "2026-06-11T01:41:18.866Z",
+    "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+    "acg": 255,
+    "objectId": "145746BAC65E4BF39E83149A843A3DF7",
+    "subType": "metric",
+    "name": "Order Count"
+   },
+   "expression": {
+    "text": "Count({Order Id Fact})",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Count",
+      "type": "function",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C31CDD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "Count",
+       "description": "Returns the number of values the ValueList. This is a group-value function."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "<",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Distinct",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "True",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ",",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "UseLookupForAttributes",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "False",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ">",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "(",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Order Id Fact]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:40:36.959Z",
+       "dateModified": "2026-06-11T01:40:36.959Z",
+       "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+       "acg": 255,
+       "objectId": "313BB989028B430A9E8734AEB7432BF3",
+       "subType": "fact",
+       "name": "Order Id Fact"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ")",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "{",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "~",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "}",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "dimty": {
+    "dimtyUnits": [
+     {
+      "dimtyUnitType": "report_base_level",
+      "aggregation": "normal",
+      "filtering": "none",
+      "groupBy": true
+     }
+    ],
+    "excludeAttribute": false,
+    "allowAddingUnit": true
+   },
+   "conditionality": {
+    "embedMethod": "report_into_metric_filter",
+    "removeElements": true
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  },
+  "3BF64C66D95D41888EE5EEDEFAFB7C69": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:18.866Z",
+    "dateModified": "2026-06-11T01:41:18.866Z",
+    "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+    "acg": 255,
+    "objectId": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+    "subType": "metric",
+    "name": "Units Sold"
+   },
+   "expression": {
+    "text": "Sum(Quantity)",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Sum",
+      "type": "function",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "Sum",
+       "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "<",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "UseLookupForAttributes",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "False",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ">",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "(",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Quantity",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:40:36.959Z",
+       "dateModified": "2026-06-11T01:40:36.959Z",
+       "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+       "acg": 255,
+       "objectId": "5BC47E4C35454EA5BD24C54AF3430577",
+       "subType": "fact",
+       "name": "Quantity"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ")",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "{",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "~",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "}",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "dimty": {
+    "dimtyUnits": [
+     {
+      "dimtyUnitType": "report_base_level",
+      "aggregation": "normal",
+      "filtering": "none",
+      "groupBy": true
+     }
+    ],
+    "excludeAttribute": false,
+    "allowAddingUnit": true
+   },
+   "conditionality": {
+    "embedMethod": "report_into_metric_filter",
+    "removeElements": true
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  },
+  "413D98E4993B4D6ABB2DC440F7B31971": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:18.866Z",
+    "dateModified": "2026-06-11T01:41:18.866Z",
+    "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+    "acg": 255,
+    "objectId": "413D98E4993B4D6ABB2DC440F7B31971",
+    "subType": "metric",
+    "name": "Total Net Revenue"
+   },
+   "expression": {
+    "text": "Sum({Net Revenue})",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Sum",
+      "type": "function",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "Sum",
+       "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "<",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "UseLookupForAttributes",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "False",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ">",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "(",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Net Revenue]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:40:36.959Z",
+       "dateModified": "2026-06-11T01:40:36.959Z",
+       "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+       "acg": 255,
+       "objectId": "DDBF580D0AD14785A742CCC40EE2EE5C",
+       "subType": "fact",
+       "name": "Net Revenue"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ")",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "{",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "~",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "}",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "dimty": {
+    "dimtyUnits": [
+     {
+      "dimtyUnitType": "report_base_level",
+      "aggregation": "normal",
+      "filtering": "none",
+      "groupBy": true
+     }
+    ],
+    "excludeAttribute": false,
+    "allowAddingUnit": true
+   },
+   "conditionality": {
+    "embedMethod": "report_into_metric_filter",
+    "removeElements": true
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  },
+  "5393F49A94A443E79E38CB3855B0272F": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:19.395Z",
+    "dateModified": "2026-06-11T01:41:19.395Z",
+    "versionId": "1CEBD6B78A4C252713DAA3ACB624BBB3",
+    "acg": 255,
+    "objectId": "5393F49A94A443E79E38CB3855B0272F",
+    "subType": "metric",
+    "name": "Profit Margin Pct"
+   },
+   "expression": {
+    "text": "{Total Gross Profit} / {Total Net Revenue}",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Total Gross Profit]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:41:18.866Z",
+       "dateModified": "2026-06-11T01:41:18.866Z",
+       "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+       "acg": 255,
+       "objectId": "653830C2CB684809B7030FBBEA498C8C",
+       "subType": "metric",
+       "name": "Total Gross Profit"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "/",
+      "type": "character",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C313DD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "/",
+       "description": "Returns the quotient when one value is divided by another."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Total Net Revenue]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:41:18.866Z",
+       "dateModified": "2026-06-11T01:41:18.866Z",
+       "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+       "acg": 255,
+       "objectId": "413D98E4993B4D6ABB2DC440F7B31971",
+       "subType": "metric",
+       "name": "Total Net Revenue"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  },
+  "653830C2CB684809B7030FBBEA498C8C": {
+   "information": {
+    "dateCreated": "2026-06-11T01:41:18.866Z",
+    "dateModified": "2026-06-11T01:41:18.866Z",
+    "versionId": "A2BC09E4554816CC81EE99B40B10F9E6",
+    "acg": 255,
+    "objectId": "653830C2CB684809B7030FBBEA498C8C",
+    "subType": "metric",
+    "name": "Total Gross Profit"
+   },
+   "expression": {
+    "text": "Sum({Gross Profit})",
+    "tokens": [
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "Sum",
+      "type": "function",
+      "target": {
+       "dateCreated": "2025-05-29T19:58:08.059Z",
+       "dateModified": "2025-05-29T19:58:08.059Z",
+       "versionId": "CD5315C011DF671600088AA0669A0C20",
+       "acg": 255,
+       "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+       "subType": "function",
+       "name": "Sum",
+       "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "<",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "UseLookupForAttributes",
+      "type": "identifier"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "=",
+      "type": "function"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "False",
+      "type": "boolean"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ">",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "(",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "[Gross Profit]",
+      "type": "object_reference",
+      "target": {
+       "dateCreated": "2026-06-11T01:40:36.959Z",
+       "dateModified": "2026-06-11T01:40:36.959Z",
+       "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+       "acg": 255,
+       "objectId": "AE6CEAC55D054ABDAA3526C8931BD21B",
+       "subType": "fact",
+       "name": "Gross Profit"
+      }
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": ")",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "{",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "~",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "}",
+      "type": "character"
+     },
+     {
+      "level": "resolved",
+      "state": "initial",
+      "value": "",
+      "type": "end_of_text"
+     }
+    ]
+   },
+   "dimty": {
+    "dimtyUnits": [
+     {
+      "dimtyUnitType": "report_base_level",
+      "aggregation": "normal",
+      "filtering": "none",
+      "groupBy": true
+     }
+    ],
+    "excludeAttribute": false,
+    "allowAddingUnit": true
+   },
+   "conditionality": {
+    "embedMethod": "report_into_metric_filter",
+    "removeElements": true
+   },
+   "metricSubtotals": [],
+   "aggregateFromBase": false,
+   "formulaJoinType": "default",
+   "smartTotal": "decomposable_false",
+   "dataType": {
+    "type": "reserved",
+    "precision": 0,
+    "scale": 0
+   },
+   "format": {
+    "header": [],
+    "values": []
+   },
+   "subtotalFromBase": false,
+   "metricFormatType": "reserved",
+   "thresholds": []
+  }
+ },
+ "facts": {
+  "313BB989028B430A9E8734AEB7432BF3": {
+   "information": {
+    "dateCreated": "2026-06-11T01:40:36.959Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "313BB989028B430A9E8734AEB7432BF3",
+    "subType": "fact",
+    "name": "Order Id Fact"
+   },
+   "dataType": {
+    "type": "fixed_length_string",
+    "precision": 20,
+    "scale": -2147483648
+   },
+   "expressions": [
+    {
+     "expressionId": "81AA6DD90EDC46B5BF314F1830DDA14E",
+     "expression": {
+      "text": "ORDER_ID",
+      "tokens": [
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "ORDER_ID",
+        "type": "column_reference",
+        "target": {
+         "dateCreated": "2026-06-11T01:34:19.851Z",
+         "dateModified": "2026-06-11T01:34:19.851Z",
+         "versionId": "D84CD810B84204E035ADD5BF872EC621",
+         "acg": 255,
+         "objectId": "B183B71282A94A5ABC04FEC48ABDE592",
+         "subType": "column",
+         "name": "ORDER_ID"
+        }
+       },
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "",
+        "type": "end_of_text"
+       }
+      ]
+     },
+     "tables": [
+      {
+       "objectId": "D9FC61279B1B493896B8D146734F3706",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     ],
+     "autoMapping": true
+    }
+   ],
+   "extensions": [],
+   "entryLevel": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "alias": "ORDER_ID"
+  },
+  "5BC47E4C35454EA5BD24C54AF3430577": {
+   "information": {
+    "dateCreated": "2026-06-11T01:40:36.959Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "5BC47E4C35454EA5BD24C54AF3430577",
+    "subType": "fact",
+    "name": "Quantity"
+   },
+   "dataType": {
+    "type": "decimal",
+    "precision": 6,
+    "scale": 0
+   },
+   "expressions": [
+    {
+     "expressionId": "2057D1110EA14C20822C052771D8D47B",
+     "expression": {
+      "text": "QUANTITY_ORDERED",
+      "tokens": [
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "QUANTITY_ORDERED",
+        "type": "column_reference",
+        "target": {
+         "dateCreated": "2026-06-11T01:34:19.851Z",
+         "dateModified": "2026-06-11T01:34:19.851Z",
+         "versionId": "D84CD810B84204E035ADD5BF872EC621",
+         "acg": 255,
+         "objectId": "3FBBDD38F0174D8096AF8840C4740821",
+         "subType": "column",
+         "name": "QUANTITY_ORDERED"
+        }
+       },
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "",
+        "type": "end_of_text"
+       }
+      ]
+     },
+     "tables": [
+      {
+       "objectId": "D9FC61279B1B493896B8D146734F3706",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     ],
+     "autoMapping": true
+    }
+   ],
+   "extensions": [],
+   "entryLevel": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "alias": "QUANTITY_ORDERED"
+  },
+  "AE6CEAC55D054ABDAA3526C8931BD21B": {
+   "information": {
+    "dateCreated": "2026-06-11T01:40:36.959Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "AE6CEAC55D054ABDAA3526C8931BD21B",
+    "subType": "fact",
+    "name": "Gross Profit"
+   },
+   "dataType": {
+    "type": "decimal",
+    "precision": 12,
+    "scale": 2
+   },
+   "expressions": [
+    {
+     "expressionId": "1C48419202864E2092EB33D7AB7C7184",
+     "expression": {
+      "text": "GROSS_PROFIT",
+      "tokens": [
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "GROSS_PROFIT",
+        "type": "column_reference",
+        "target": {
+         "dateCreated": "2026-06-11T01:34:19.851Z",
+         "dateModified": "2026-06-11T01:34:19.851Z",
+         "versionId": "D84CD810B84204E035ADD5BF872EC621",
+         "acg": 255,
+         "objectId": "962C692A0DC748F2802B6479DC93756A",
+         "subType": "column",
+         "name": "GROSS_PROFIT"
+        }
+       },
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "",
+        "type": "end_of_text"
+       }
+      ]
+     },
+     "tables": [
+      {
+       "objectId": "D9FC61279B1B493896B8D146734F3706",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     ],
+     "autoMapping": true
+    }
+   ],
+   "extensions": [],
+   "entryLevel": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "alias": "GROSS_PROFIT"
+  },
+  "DDBF580D0AD14785A742CCC40EE2EE5C": {
+   "information": {
+    "dateCreated": "2026-06-11T01:40:36.959Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "DDBF580D0AD14785A742CCC40EE2EE5C",
+    "subType": "fact",
+    "name": "Net Revenue"
+   },
+   "dataType": {
+    "type": "decimal",
+    "precision": 12,
+    "scale": 2
+   },
+   "expressions": [
+    {
+     "expressionId": "31463B9045A24EF0B627A186801BDB85",
+     "expression": {
+      "text": "NET_REVENUE",
+      "tokens": [
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "NET_REVENUE",
+        "type": "column_reference",
+        "target": {
+         "dateCreated": "2026-06-11T01:34:19.851Z",
+         "dateModified": "2026-06-11T01:34:19.851Z",
+         "versionId": "D84CD810B84204E035ADD5BF872EC621",
+         "acg": 255,
+         "objectId": "03E5DD935D8C4BB48FA2335D47921180",
+         "subType": "column",
+         "name": "NET_REVENUE"
+        }
+       },
+       {
+        "level": "resolved",
+        "state": "initial",
+        "value": "",
+        "type": "end_of_text"
+       }
+      ]
+     },
+     "tables": [
+      {
+       "objectId": "D9FC61279B1B493896B8D146734F3706",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     ],
+     "autoMapping": true
+    }
+   ],
+   "extensions": [],
+   "entryLevel": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "alias": "NET_REVENUE"
+  }
+ },
+ "tables": {
+  "47E46839DEBB4EEF9B10CCA524E0C794": {
+   "information": {
+    "dateCreated": "2026-06-11T01:34:19.851Z",
+    "dateModified": "2026-06-11T01:39:45.089Z",
+    "versionId": "B6C6654A01446E6F7D4C42BDD134E645",
+    "acg": 255,
+    "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+    "subType": "logical_table",
+    "name": "PRODUCT_DIM"
+   },
+   "physicalTable": {
+    "information": {
+     "dateCreated": "2026-06-11T01:34:19.851Z",
+     "dateModified": "2026-06-11T01:34:19.851Z",
+     "versionId": "D84CD810B84204E035ADD5BF872EC621",
+     "acg": 255,
+     "objectId": "D940EBAC1FB74D9689BED56A11642F05",
+     "subType": "physical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "tableName": "PRODUCT_DIM",
+    "columns": [
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "1BBA29679ABE48E7B554D8FD947DB2BE",
+       "subType": "column",
+       "name": "BRAND"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 50,
+       "scale": -2147483648
+      },
+      "columnName": "BRAND"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "EE2E24FFDF58489193BB93F5FEB66D5B",
+       "subType": "column",
+       "name": "CATEGORY"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 50,
+       "scale": -2147483648
+      },
+      "columnName": "CATEGORY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "E23718322CBE48F3980C90549F47691C",
+       "subType": "column",
+       "name": "DISCONTINUE_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "DISCONTINUE_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "9E4A20F1F6D84F259409F1A8617667EE",
+       "subType": "column",
+       "name": "IS_ACTIVE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_ACTIVE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "45C00E20CE4244F0A33DCDD0EE27FAE6",
+       "subType": "column",
+       "name": "IS_PRIVATE_LABEL"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_PRIVATE_LABEL"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "51038229B06B400F98B2470A75A0B4D8",
+       "subType": "column",
+       "name": "IS_SEASONAL"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_SEASONAL"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "F28C6CD1025E4B068CEC24D7C43F4B1D",
+       "subType": "column",
+       "name": "LAUNCH_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "LAUNCH_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "022FD6B1B053432E998F5BD387583EEF",
+       "subType": "column",
+       "name": "PRODUCT_ID"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "PRODUCT_ID"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "42FC35A6FBF248458F96D54C8404E071",
+       "subType": "column",
+       "name": "PRODUCT_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "PRODUCT_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "748EC2993D1D4C5D87CAD5421722B576",
+       "subType": "column",
+       "name": "PRODUCT_NAME"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 150,
+       "scale": -2147483648
+      },
+      "columnName": "PRODUCT_NAME"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "661455C3624F4CE3B614D1627D7D6E9F",
+       "subType": "column",
+       "name": "Product_Key/Name"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 16777216,
+       "scale": -2147483648
+      },
+      "columnName": "Product_Key/Name"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4F17FDCB18764647AFAFFD24D6217CAE",
+       "subType": "column",
+       "name": "SUBCATEGORY"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 50,
+       "scale": -2147483648
+      },
+      "columnName": "SUBCATEGORY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D30824A0D0D54A4DB3B5300BAFB2D859",
+       "subType": "column",
+       "name": "UNIT_COST"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "UNIT_COST"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4A933FCF738D45B89787EF4E8D70053B",
+       "subType": "column",
+       "name": "UNIT_PRICE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "UNIT_PRICE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "FC32EF80F2A04FE8B061D05F52F09630",
+       "subType": "column",
+       "name": "WEIGHT_LBS"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 2
+      },
+      "columnName": "WEIGHT_LBS"
+     }
+    ],
+    "namespace": "TJ",
+    "tablePrefix": "TJ.",
+    "type": "normal"
+   },
+   "logicalSize": 15,
+   "isLogicalSizeLocked": false,
+   "isTrueKey": true,
+   "isPartOfPartition": false,
+   "tableKey": [
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    }
+   ],
+   "attributes": [
+    {
+     "information": {
+      "objectId": "13AF74581AA84A46B8FD2D1BBA073150",
+      "subType": "attribute",
+      "name": "Category"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+        "subType": "logical_table",
+        "name": "PRODUCT_DIM"
+       },
+       "expression": {
+        "text": "CATEGORY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+        "subType": "logical_table",
+        "name": "PRODUCT_DIM"
+       },
+       "expression": {
+        "text": "PRODUCT_KEY"
+       }
+      },
+      {
+       "formCategory": {
+        "objectId": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "subType": "attribute_form_system",
+        "name": "DESC"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": false,
+       "lookupTable": {
+        "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+        "subType": "logical_table",
+        "name": "PRODUCT_DIM"
+       },
+       "expression": {
+        "text": "PRODUCT_NAME"
+       }
+      }
+     ]
+    }
+   ],
+   "primaryDataSource": {
+    "objectId": "B2ABAAB6EA4FE181C3BF43B09D0930FC",
+    "subType": "db_role",
+    "name": "Snowflake CSA"
+   },
+   "secondaryDataSources": []
+  },
+  "64D5C75E86F84FC78F39C8413018DF3D": {
+   "information": {
+    "dateCreated": "2026-06-11T01:34:19.851Z",
+    "dateModified": "2026-06-11T01:39:45.089Z",
+    "versionId": "B6C6654A01446E6F7D4C42BDD134E645",
+    "acg": 255,
+    "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+    "subType": "logical_table",
+    "name": "DATE_DIM"
+   },
+   "physicalTable": {
+    "information": {
+     "dateCreated": "2026-06-11T01:34:19.851Z",
+     "dateModified": "2026-06-11T01:34:19.851Z",
+     "versionId": "D84CD810B84204E035ADD5BF872EC621",
+     "acg": 255,
+     "objectId": "9609286525994536AE82F4CAD0BB05EC",
+     "subType": "physical_table",
+     "name": "DATE_DIM"
+    },
+    "tableName": "DATE_DIM",
+    "columns": [
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "CF20E78112994A5D96B2D39B628240E9",
+       "subType": "column",
+       "name": "DATE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "DATE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "C635418469C84543A173102128C48A02",
+       "subType": "column",
+       "name": "DAY_OF_MONTH"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 2,
+       "scale": 0
+      },
+      "columnName": "DAY_OF_MONTH"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "E314B08C2F51449081C21E13C044E490",
+       "subType": "column",
+       "name": "DAY_OF_WEEK"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 10,
+       "scale": -2147483648
+      },
+      "columnName": "DAY_OF_WEEK"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "2390FE17710B4F7EB162540D2AF60934",
+       "subType": "column",
+       "name": "FISCAL_PERIOD"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 10,
+       "scale": -2147483648
+      },
+      "columnName": "FISCAL_PERIOD"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "6C552A18D8114E0E89E934EDE6EE0534",
+       "subType": "column",
+       "name": "FULL_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "FULL_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "B4DBBBD4F03845E3843E121237CA1E22",
+       "subType": "column",
+       "name": "IS_HOLIDAY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_HOLIDAY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "04FBCA2E65074CF2855F2C636EF51055",
+       "subType": "column",
+       "name": "IS_WEEKEND"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_WEEKEND"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4C6BF4B48BF94197B76731366E39ED7A",
+       "subType": "column",
+       "name": "MONTH_NAME"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 10,
+       "scale": -2147483648
+      },
+      "columnName": "MONTH_NAME"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "421F8160638F4F9AA7FC434C0EBF14EC",
+       "subType": "column",
+       "name": "MONTH_NUMBER"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 2,
+       "scale": 0
+      },
+      "columnName": "MONTH_NUMBER"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "A48AC88A9B4C4D599059820954BE4043",
+       "subType": "column",
+       "name": "QUARTER"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "QUARTER"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "15842FC875714225ADD1D284FA31167B",
+       "subType": "column",
+       "name": "WEEK_OF_YEAR"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 2,
+       "scale": 0
+      },
+      "columnName": "WEEK_OF_YEAR"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "A443425EB7684086B49B5182EDA0D825",
+       "subType": "column",
+       "name": "YEAR"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 4,
+       "scale": 0
+      },
+      "columnName": "YEAR"
+     }
+    ],
+    "namespace": "TJ",
+    "tablePrefix": "TJ.",
+    "type": "normal"
+   },
+   "logicalSize": 20,
+   "isLogicalSizeLocked": false,
+   "isTrueKey": true,
+   "isPartOfPartition": false,
+   "tableKey": [
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    }
+   ],
+   "attributes": [
+    {
+     "information": {
+      "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "YEAR"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "MONTH_NUMBER"
+       }
+      },
+      {
+       "formCategory": {
+        "objectId": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "subType": "attribute_form_system",
+        "name": "DESC"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": false,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "MONTH_NAME"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "DATE_KEY"
+       }
+      },
+      {
+       "formCategory": {
+        "objectId": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "subType": "attribute_form_system",
+        "name": "DESC"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": false,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "FULL_DATE"
+       }
+      }
+     ]
+    }
+   ],
+   "primaryDataSource": {
+    "objectId": "B2ABAAB6EA4FE181C3BF43B09D0930FC",
+    "subType": "db_role",
+    "name": "Snowflake CSA"
+   },
+   "secondaryDataSources": []
+  },
+  "98D96DCF86D1494DA8F62DDB5A6A8482": {
+   "information": {
+    "dateCreated": "2026-06-11T01:34:19.851Z",
+    "dateModified": "2026-06-11T01:39:45.089Z",
+    "versionId": "B6C6654A01446E6F7D4C42BDD134E645",
+    "acg": 255,
+    "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+    "subType": "logical_table",
+    "name": "STORE_DIM"
+   },
+   "physicalTable": {
+    "information": {
+     "dateCreated": "2026-06-11T01:34:19.851Z",
+     "dateModified": "2026-06-11T01:34:19.851Z",
+     "versionId": "D84CD810B84204E035ADD5BF872EC621",
+     "acg": 255,
+     "objectId": "47AE6C5128A64F0FB312D9B5EAC84F22",
+     "subType": "physical_table",
+     "name": "STORE_DIM"
+    },
+    "tableName": "STORE_DIM",
+    "columns": [
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "C77D2175AF254A5C85709C45ECFA62ED",
+       "subType": "column",
+       "name": "ANNUAL_LEASE_COST"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "ANNUAL_LEASE_COST"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "9CE28E0180B7443CADBFBD7DB37E7FE5",
+       "subType": "column",
+       "name": "CITY"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 50,
+       "scale": -2147483648
+      },
+      "columnName": "CITY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "69188ED23ABC41E1B32ECE2B6AD80FDF",
+       "subType": "column",
+       "name": "CLOSE_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "CLOSE_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "FAF47F66F94349CF945911773FB44325",
+       "subType": "column",
+       "name": "DISTRICT"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 30,
+       "scale": -2147483648
+      },
+      "columnName": "DISTRICT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "120FA2DC07804DB586A155E9BF814939",
+       "subType": "column",
+       "name": "HAS_CAFE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "HAS_CAFE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D3EC8A6674484BC489483131D185A607",
+       "subType": "column",
+       "name": "HAS_CURBSIDE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "HAS_CURBSIDE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "9E4A20F1F6D84F259409F1A8617667EE",
+       "subType": "column",
+       "name": "IS_ACTIVE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_ACTIVE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "6E8637DEC6534B30A0CB423BC49E782D",
+       "subType": "column",
+       "name": "MANAGER_NAME"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 100,
+       "scale": -2147483648
+      },
+      "columnName": "MANAGER_NAME"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D7D8D64FDC3E4DFFB3532169E1D58E83",
+       "subType": "column",
+       "name": "OPEN_DATE"
+      },
+      "dataType": {
+       "type": "date",
+       "precision": 0,
+       "scale": -2147483648
+      },
+      "columnName": "OPEN_DATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "31FC4505562A431BBBB15D0B79514023",
+       "subType": "column",
+       "name": "REGION"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "REGION"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "90A0AE1E5DFC4774B00335784C9A9DBF",
+       "subType": "column",
+       "name": "SQUARE_FOOTAGE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "SQUARE_FOOTAGE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "5F24D32D23DB420397496C9B7880AF63",
+       "subType": "column",
+       "name": "STATE"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 2,
+       "scale": -2147483648
+      },
+      "columnName": "STATE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "BCD37EA759D64B8DB1E069B9F3E315CB",
+       "subType": "column",
+       "name": "STORE_ID"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 10,
+       "scale": -2147483648
+      },
+      "columnName": "STORE_ID"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "552771515DA84D10833176D8DBA883C9",
+       "subType": "column",
+       "name": "STORE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "STORE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "3395C2D0B6B3423F99B5B7E0937FEEC3",
+       "subType": "column",
+       "name": "STORE_NAME"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 100,
+       "scale": -2147483648
+      },
+      "columnName": "STORE_NAME"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "A52225949EEB49C8BB9754730EC747ED",
+       "subType": "column",
+       "name": "STORE_PHONE"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "STORE_PHONE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "BE4FD6C00FB24D13B9A6625D345C1B0C",
+       "subType": "column",
+       "name": "STORE_TYPE"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "STORE_TYPE"
+     }
+    ],
+    "namespace": "TJ",
+    "tablePrefix": "TJ.",
+    "type": "normal"
+   },
+   "logicalSize": 15,
+   "isLogicalSizeLocked": false,
+   "isTrueKey": true,
+   "isPartOfPartition": false,
+   "tableKey": [
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "attributes": [
+    {
+     "information": {
+      "objectId": "6140BFA7309B406AA76A90454BC7BB53",
+      "subType": "attribute",
+      "name": "Region"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+        "subType": "logical_table",
+        "name": "STORE_DIM"
+       },
+       "expression": {
+        "text": "REGION"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "9177026370BB44A3A0CD521FE5166500",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+        "subType": "logical_table",
+        "name": "STORE_DIM"
+       },
+       "expression": {
+        "text": "STORE_KEY"
+       }
+      },
+      {
+       "formCategory": {
+        "objectId": "CCFBE2A5EADB4F50941FB879CCF1721C",
+        "subType": "attribute_form_system",
+        "name": "DESC"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": false,
+       "lookupTable": {
+        "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+        "subType": "logical_table",
+        "name": "STORE_DIM"
+       },
+       "expression": {
+        "text": "STORE_NAME"
+       }
+      }
+     ]
+    }
+   ],
+   "primaryDataSource": {
+    "objectId": "B2ABAAB6EA4FE181C3BF43B09D0930FC",
+    "subType": "db_role",
+    "name": "Snowflake CSA"
+   },
+   "secondaryDataSources": []
+  },
+  "D9FC61279B1B493896B8D146734F3706": {
+   "information": {
+    "dateCreated": "2026-06-11T01:34:19.851Z",
+    "dateModified": "2026-06-11T01:40:36.959Z",
+    "versionId": "FDD46DC4DA4E620FD1FA029F3383A733",
+    "acg": 255,
+    "objectId": "D9FC61279B1B493896B8D146734F3706",
+    "subType": "logical_table",
+    "name": "ORDER_FACT"
+   },
+   "physicalTable": {
+    "information": {
+     "dateCreated": "2026-06-11T01:34:19.851Z",
+     "dateModified": "2026-06-11T01:34:19.851Z",
+     "versionId": "D84CD810B84204E035ADD5BF872EC621",
+     "acg": 255,
+     "objectId": "1474B0C677424416B11BD2A5B0CC2547",
+     "subType": "physical_table",
+     "name": "ORDER_FACT"
+    },
+    "tableName": "ORDER_FACT",
+    "columns": [
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4C7A7D12875E4F4098327715B0F21EB8",
+       "subType": "column",
+       "name": "CUSTOMER_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 0
+      },
+      "columnName": "CUSTOMER_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "EA1E5EA3AA2244B2A4E54C81B9E42A8C",
+       "subType": "column",
+       "name": "DAYS_TO_SHIP"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 4,
+       "scale": 0
+      },
+      "columnName": "DAYS_TO_SHIP"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "3F3F02DC39264F29A1AFF03069A641FB",
+       "subType": "column",
+       "name": "DISCOUNT_AMOUNT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "DISCOUNT_AMOUNT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "962C692A0DC748F2802B6479DC93756A",
+       "subType": "column",
+       "name": "GROSS_PROFIT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "GROSS_PROFIT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "CB1AB2B339DE4B28B0E6E2D6390BFFBE",
+       "subType": "column",
+       "name": "GROSS_REVENUE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "GROSS_REVENUE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "972BA50D709B4357A138F6B1983FF24D",
+       "subType": "column",
+       "name": "IS_CANCELLED"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_CANCELLED"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "AEB35B531C53417182CE74A3B2C6AD13",
+       "subType": "column",
+       "name": "IS_FIRST_ORDER"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_FIRST_ORDER"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "0180EFD155CA477AB0645696DC17CCEB",
+       "subType": "column",
+       "name": "IS_RETURNED"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 1,
+       "scale": 0
+      },
+      "columnName": "IS_RETURNED"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "A7978E37459449D1831DBE5631DDA7D1",
+       "subType": "column",
+       "name": "NET_PROFIT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "NET_PROFIT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "03E5DD935D8C4BB48FA2335D47921180",
+       "subType": "column",
+       "name": "NET_REVENUE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 12,
+       "scale": 2
+      },
+      "columnName": "NET_REVENUE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "6D2F6387F5624C3FA6D4F9CC5320D324",
+       "subType": "column",
+       "name": "ORDER_CHANNEL"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "ORDER_CHANNEL"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D8385C86002E4CC99F15963514C2D021",
+       "subType": "column",
+       "name": "ORDER_DATE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "ORDER_DATE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "B183B71282A94A5ABC04FEC48ABDE592",
+       "subType": "column",
+       "name": "ORDER_ID"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "ORDER_ID"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "B6FCDA0DFC2341148D2AFA04D29CB9EE",
+       "subType": "column",
+       "name": "ORDER_LINE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 4,
+       "scale": 0
+      },
+      "columnName": "ORDER_LINE"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "43B8E563195C41AAB52E269715A0D911",
+       "subType": "column",
+       "name": "ORDER_STATUS"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "ORDER_STATUS"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "FC60FB86414944DD92C531722810969D",
+       "subType": "column",
+       "name": "ORDER_STORE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "ORDER_STORE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "42FC35A6FBF248458F96D54C8404E071",
+       "subType": "column",
+       "name": "PRODUCT_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "PRODUCT_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "2FB5F360FFF14AA6A11F75444AFD0C97",
+       "subType": "column",
+       "name": "PROMO_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "PROMO_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "3FBBDD38F0174D8096AF8840C4740821",
+       "subType": "column",
+       "name": "QUANTITY_ORDERED"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "QUANTITY_ORDERED"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D9B0143462C14E9BAC286E197CE424B6",
+       "subType": "column",
+       "name": "QUANTITY_RETURNED"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "QUANTITY_RETURNED"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "11F75D9969E4401EA6C48D9C9C0174D9",
+       "subType": "column",
+       "name": "RETURN_DATE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "RETURN_DATE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "B5EDD927FCF94037A4E42288CC779839",
+       "subType": "column",
+       "name": "SHIPPING_AMOUNT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "SHIPPING_AMOUNT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "37635702709D4774B648E7B29628CAB0",
+       "subType": "column",
+       "name": "SHIP_DATE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 8,
+       "scale": 0
+      },
+      "columnName": "SHIP_DATE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "3B4F476C0326472BB7E0342CB3C995BE",
+       "subType": "column",
+       "name": "SHIP_METHOD"
+      },
+      "dataType": {
+       "type": "fixed_length_string",
+       "precision": 20,
+       "scale": -2147483648
+      },
+      "columnName": "SHIP_METHOD"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "DA75D433DD894A43A448F822083BBCDA",
+       "subType": "column",
+       "name": "SHIP_STORE_KEY"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 6,
+       "scale": 0
+      },
+      "columnName": "SHIP_STORE_KEY"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "DEF4C308852A4F8BA0C257AC41B13CC7",
+       "subType": "column",
+       "name": "TAX_AMOUNT"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "TAX_AMOUNT"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "D30824A0D0D54A4DB3B5300BAFB2D859",
+       "subType": "column",
+       "name": "UNIT_COST"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "UNIT_COST"
+     },
+     {
+      "information": {
+       "dateCreated": "2026-06-11T01:34:19.851Z",
+       "dateModified": "2026-06-11T01:34:19.851Z",
+       "versionId": "D84CD810B84204E035ADD5BF872EC621",
+       "acg": 255,
+       "objectId": "4A933FCF738D45B89787EF4E8D70053B",
+       "subType": "column",
+       "name": "UNIT_PRICE"
+      },
+      "dataType": {
+       "type": "decimal",
+       "precision": 10,
+       "scale": 2
+      },
+      "columnName": "UNIT_PRICE"
+     }
+    ],
+    "namespace": "TJ",
+    "tablePrefix": "TJ.",
+    "type": "normal"
+   },
+   "logicalSize": 60,
+   "isLogicalSizeLocked": false,
+   "isTrueKey": true,
+   "isPartOfPartition": false,
+   "tableKey": [
+    {
+     "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+     "subType": "attribute",
+     "name": "Customer"
+    },
+    {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    {
+     "objectId": "E951AA8437BF46BB860E98F0DB349617",
+     "subType": "attribute",
+     "name": "Order Channel"
+    },
+    {
+     "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+     "subType": "attribute",
+     "name": "Order Status"
+    },
+    {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    }
+   ],
+   "attributes": [
+    {
+     "information": {
+      "objectId": "FF3823C8E7284AA2B19B0F45551F4B6F",
+      "subType": "attribute",
+      "name": "Customer"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "CE414C694E64481AB6640AE63BBB2B50",
+        "subType": "logical_table",
+        "name": "CUSTOMER_DIM"
+       },
+       "expression": {
+        "text": "CUSTOMER_KEY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "9177026370BB44A3A0CD521FE5166500",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+        "subType": "logical_table",
+        "name": "STORE_DIM"
+       },
+       "expression": {
+        "text": "ORDER_STORE_KEY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+        "subType": "logical_table",
+        "name": "PRODUCT_DIM"
+       },
+       "expression": {
+        "text": "PRODUCT_KEY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+        "subType": "logical_table",
+        "name": "DATE_DIM"
+       },
+       "expression": {
+        "text": "ORDER_DATE_KEY"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "E951AA8437BF46BB860E98F0DB349617",
+      "subType": "attribute",
+      "name": "Order Channel"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "D9FC61279B1B493896B8D146734F3706",
+        "subType": "logical_table",
+        "name": "ORDER_FACT"
+       },
+       "expression": {
+        "text": "ORDER_CHANNEL"
+       }
+      }
+     ]
+    },
+    {
+     "information": {
+      "objectId": "7B5873A028BC49EFB9806373F4B6BAA7",
+      "subType": "attribute",
+      "name": "Order Status"
+     },
+     "forms": [
+      {
+       "formCategory": {
+        "objectId": "45C11FA478E745FEA08D781CEA190FE5",
+        "subType": "attribute_form_system",
+        "name": "ID"
+       },
+       "name": "",
+       "dataFormat": "number",
+       "isKeyForm": true,
+       "lookupTable": {
+        "objectId": "D9FC61279B1B493896B8D146734F3706",
+        "subType": "logical_table",
+        "name": "ORDER_FACT"
+       },
+       "expression": {
+        "text": "ORDER_STATUS"
+       }
+      }
+     ]
+    }
+   ],
+   "facts": [
+    {
+     "information": {
+      "objectId": "DDBF580D0AD14785A742CCC40EE2EE5C",
+      "subType": "fact",
+      "name": "Net Revenue"
+     },
+     "expression": {
+      "text": "NET_REVENUE"
+     }
+    },
+    {
+     "information": {
+      "objectId": "AE6CEAC55D054ABDAA3526C8931BD21B",
+      "subType": "fact",
+      "name": "Gross Profit"
+     },
+     "expression": {
+      "text": "GROSS_PROFIT"
+     }
+    },
+    {
+     "information": {
+      "objectId": "5BC47E4C35454EA5BD24C54AF3430577",
+      "subType": "fact",
+      "name": "Quantity"
+     },
+     "expression": {
+      "text": "QUANTITY_ORDERED"
+     }
+    },
+    {
+     "information": {
+      "objectId": "B5F33B1C52D74E95B98EB05A08DBFB59",
+      "subType": "fact",
+      "name": "Discount"
+     },
+     "expression": {
+      "text": "DISCOUNT_AMOUNT"
+     }
+    },
+    {
+     "information": {
+      "objectId": "313BB989028B430A9E8734AEB7432BF3",
+      "subType": "fact",
+      "name": "Order Id Fact"
+     },
+     "expression": {
+      "text": "ORDER_ID"
+     }
+    }
+   ],
+   "primaryDataSource": {
+    "objectId": "B2ABAAB6EA4FE181C3BF43B09D0930FC",
+    "subType": "db_role",
+    "name": "Snowflake CSA"
+   },
+   "secondaryDataSources": []
+  }
+ },
+ "relationships": {
+  "13AF74581AA84A46B8FD2D1BBA073150": [
+   {
+    "parent": {
+     "objectId": "13AF74581AA84A46B8FD2D1BBA073150",
+     "subType": "attribute",
+     "name": "Category"
+    },
+    "child": {
+     "objectId": "B612DBDE5A224C7CA19C1FC8967926C2",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    "relationshipTable": {
+     "objectId": "47E46839DEBB4EEF9B10CCA524E0C794",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ],
+  "6140BFA7309B406AA76A90454BC7BB53": [
+   {
+    "parent": {
+     "objectId": "6140BFA7309B406AA76A90454BC7BB53",
+     "subType": "attribute",
+     "name": "Region"
+    },
+    "child": {
+     "objectId": "9177026370BB44A3A0CD521FE5166500",
+     "subType": "attribute",
+     "name": "Store"
+    },
+    "relationshipTable": {
+     "objectId": "98D96DCF86D1494DA8F62DDB5A6A8482",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ],
+  "C025482DAE4C4BFDA72E8297D981ABAC": [
+   {
+    "parent": {
+     "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+     "subType": "attribute",
+     "name": "Year"
+    },
+    "child": {
+     "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "relationshipTable": {
+     "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ],
+  "C3292DAD4FAF404F88590CB19C3930F9": [
+   {
+    "parent": {
+     "objectId": "C025482DAE4C4BFDA72E8297D981ABAC",
+     "subType": "attribute",
+     "name": "Year"
+    },
+    "child": {
+     "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "relationshipTable": {
+     "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   },
+   {
+    "parent": {
+     "objectId": "C3292DAD4FAF404F88590CB19C3930F9",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "child": {
+     "objectId": "33C36CB28C804708AA0153E2D8B730C8",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    "relationshipTable": {
+     "objectId": "64D5C75E86F84FC78F39C8413018DF3D",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ]
+ }
+}

--- a/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/datamodel_definition.json
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/datamodel_definition.json
@@ -1,0 +1,3349 @@
+{
+ "dataModelId": "45D9150F17634F7AB43B00D5FC381951",
+ "dataModel": {
+  "information": {
+   "dateCreated": "2026-06-11T02:54:52.497Z",
+   "dateModified": "2026-06-11T02:55:03.048Z",
+   "versionId": "717D54A62B49024DA91D46B13AD2159E",
+   "acg": 255,
+   "objectId": "45D9150F17634F7AB43B00D5FC381951",
+   "subType": "report_emma_cube",
+   "name": "Orders Data Model"
+  },
+  "dataServeMode": "connect_live",
+  "schemaFolderId": "80808BA0E03949BD988ABBF0C116BE5E",
+  "enableWrangleRecommendations": true,
+  "enableAutoHierarchyRelationships": true,
+  "sampling": {
+   "type": "first",
+   "rowCount": 1000
+  },
+  "autoJoin": true
+ },
+ "tables": {
+  "offset": 0,
+  "limit": -1,
+  "total": 4,
+  "tables": [
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+     "subType": "logical_table",
+     "name": "ORDER_FACT"
+    }
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "7751DF0514D64104A56548A014AB7253",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    }
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    }
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    }
+   }
+  ]
+ },
+ "attributes": {
+  "offset": 0,
+  "limit": -1,
+  "total": 8,
+  "attributes": [
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+     "subType": "attribute",
+     "name": "Region",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 20,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "5CC8555A72484D539B52E16C481AD204",
+        "expression": {
+         "text": "REGION",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "REGION",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "75E5C96E03B244E8AD595A688E471C8E",
+            "subType": "column",
+            "name": "REGION"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+          "subType": "logical_table",
+          "name": "STORE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "REGION",
+      "lookupTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+       "subType": "attribute",
+       "name": "Region"
+      },
+      "child": {
+       "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+       "subType": "attribute",
+       "name": "Store"
+      },
+      "relationshipTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+     "subType": "attribute",
+     "name": "Category",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 50,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "5D079ED5FF744B478A940C7C9C5A47B8",
+        "expression": {
+         "text": "CATEGORY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "CATEGORY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "25AD0BE937304BDC962A1E2E12415B3D",
+            "subType": "column",
+            "name": "CATEGORY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "7751DF0514D64104A56548A014AB7253",
+          "subType": "logical_table",
+          "name": "PRODUCT_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "CATEGORY",
+      "lookupTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "7751DF0514D64104A56548A014AB7253",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+       "subType": "attribute",
+       "name": "Category"
+      },
+      "child": {
+       "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+       "subType": "attribute",
+       "name": "Product"
+      },
+      "relationshipTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+     "subType": "attribute",
+     "name": "Year",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "A0B18927EB7E4D30AF3AA080026A8F62",
+        "expression": {
+         "text": "YEAR",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "YEAR",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "D838C0CDF1A6417994AAFF651D5BF688",
+            "subType": "column",
+            "name": "YEAR"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "YEAR",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+       "subType": "attribute",
+       "name": "Year"
+      },
+      "child": {
+       "objectId": "FCC42217F759485DB03D155EAA9B727A",
+       "subType": "attribute",
+       "name": "Month"
+      },
+      "relationshipTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "FCC42217F759485DB03D155EAA9B727A",
+     "subType": "attribute",
+     "name": "Month",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "EAE34347A0A24E54A7703DE3E7C06C24",
+        "expression": {
+         "text": "MONTH_NUMBER",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "MONTH_NUMBER",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "DE981C8BAE544FC3AFEA415D5E646A73",
+            "subType": "column",
+            "name": "MONTH_NUMBER"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "MONTH_NUMBER",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     },
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+      "name": "DESC",
+      "category": "DESC",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 10,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "37D3B7BAA52A4B7DA22E0883EDBCE87D",
+        "expression": {
+         "text": "MONTH_NAME",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "MONTH_NAME",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "98D8A1F502F642839F380293EA18DD26",
+            "subType": "column",
+            "name": "MONTH_NAME"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "MONTH_NAME",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+       "subType": "attribute",
+       "name": "Year"
+      },
+      "child": {
+       "objectId": "FCC42217F759485DB03D155EAA9B727A",
+       "subType": "attribute",
+       "name": "Month"
+      },
+      "relationshipTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     },
+     {
+      "parent": {
+       "objectId": "FCC42217F759485DB03D155EAA9B727A",
+       "subType": "attribute",
+       "name": "Month"
+      },
+      "child": {
+       "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+       "subType": "attribute",
+       "name": "Day"
+      },
+      "relationshipTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+     "subType": "attribute",
+     "name": "Store",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "DED11BCA95284F3C8A4533DF64FD02B5",
+        "expression": {
+         "text": "ORDER_STORE_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "ORDER_STORE_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "1152FF8B98504D309747B883CE29D278",
+            "subType": "column",
+            "name": "ORDER_STORE_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+          "subType": "logical_table",
+          "name": "ORDER_FACT"
+         }
+        ]
+       },
+       {
+        "expressionId": "F6ADB88910D6438EBD338BAA386CEB30",
+        "expression": {
+         "text": "STORE_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "STORE_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "021BF7D49D1A41AE966A9739AA180D2D",
+            "subType": "column",
+            "name": "STORE_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+          "subType": "logical_table",
+          "name": "STORE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "STORE_KEY",
+      "lookupTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      }
+     },
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+      "name": "DESC",
+      "category": "DESC",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 100,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "4D13DE00C17941E888E41E99B6AAE5A8",
+        "expression": {
+         "text": "STORE_NAME",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "STORE_NAME",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "0C4BEEEB53DE4634A2BE0C79C0EB959C",
+            "subType": "column",
+            "name": "STORE_NAME"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+          "subType": "logical_table",
+          "name": "STORE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "STORE_NAME",
+      "lookupTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+       "subType": "attribute",
+       "name": "Region"
+      },
+      "child": {
+       "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+       "subType": "attribute",
+       "name": "Store"
+      },
+      "relationshipTable": {
+       "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+       "subType": "logical_table",
+       "name": "STORE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+     "subType": "attribute",
+     "name": "Product",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "E7456CDD660A442EA37899DF7138A2B8",
+        "expression": {
+         "text": "PRODUCT_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "PRODUCT_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "2C1EB4DE89F34373887F82F33961A1BE",
+            "subType": "column",
+            "name": "PRODUCT_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+          "subType": "logical_table",
+          "name": "ORDER_FACT"
+         }
+        ]
+       },
+       {
+        "expressionId": "9B4C7878CD594259B0C0E195F88543AB",
+        "expression": {
+         "text": "PRODUCT_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "PRODUCT_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "92AEFD8F75654F539739676266BE9F61",
+            "subType": "column",
+            "name": "PRODUCT_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "7751DF0514D64104A56548A014AB7253",
+          "subType": "logical_table",
+          "name": "PRODUCT_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "PRODUCT_KEY",
+      "lookupTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      }
+     },
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+      "name": "DESC",
+      "category": "DESC",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 150,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "86E10C0549FD409D9135AD213F684D3B",
+        "expression": {
+         "text": "PRODUCT_NAME",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "PRODUCT_NAME",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "80441289FD404F2C88A020BF04060D54",
+            "subType": "column",
+            "name": "PRODUCT_NAME"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "7751DF0514D64104A56548A014AB7253",
+          "subType": "logical_table",
+          "name": "PRODUCT_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "PRODUCT_NAME",
+      "lookupTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "7751DF0514D64104A56548A014AB7253",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+       "subType": "attribute",
+       "name": "Category"
+      },
+      "child": {
+       "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+       "subType": "attribute",
+       "name": "Product"
+      },
+      "relationshipTable": {
+       "objectId": "7751DF0514D64104A56548A014AB7253",
+       "subType": "logical_table",
+       "name": "PRODUCT_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+     "subType": "attribute",
+     "name": "Day",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "number",
+      "dataType": {
+       "type": "int64",
+       "precision": 8,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "63A512BCB4AC42ABA978EDB9902F1B2A",
+        "expression": {
+         "text": "ORDER_DATE_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "ORDER_DATE_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "871C62FBF0E04F968482C728084A50EB",
+            "subType": "column",
+            "name": "ORDER_DATE_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+          "subType": "logical_table",
+          "name": "ORDER_FACT"
+         }
+        ]
+       },
+       {
+        "expressionId": "B575DE5DF22342E988499C33DF2DB557",
+        "expression": {
+         "text": "DATE_KEY",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "DATE_KEY",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "B02BE2D4448640B79BF3169E849A4C9B",
+            "subType": "column",
+            "name": "DATE_KEY"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "DATE_KEY",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     },
+     {
+      "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+      "name": "DESC",
+      "category": "DESC",
+      "type": "system",
+      "displayFormat": "date",
+      "dataType": {
+       "type": "date",
+       "precision": 10,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "77464646F08D4C0FAC58A14B5E3F29E6",
+        "expression": {
+         "text": "FULL_DATE",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "FULL_DATE",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "501C00D4EE9D4017A90AF74478A3635D",
+            "subType": "column",
+            "name": "FULL_DATE"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+          "subType": "logical_table",
+          "name": "DATE_DIM"
+         }
+        ]
+       }
+      ],
+      "alias": "FULL_DATE",
+      "lookupTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [
+     {
+      "parent": {
+       "objectId": "FCC42217F759485DB03D155EAA9B727A",
+       "subType": "attribute",
+       "name": "Month"
+      },
+      "child": {
+       "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+       "subType": "attribute",
+       "name": "Day"
+      },
+      "relationshipTable": {
+       "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+       "subType": "logical_table",
+       "name": "DATE_DIM"
+      },
+      "relationshipType": "one_to_many"
+     }
+    ],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "A0B193BE721E4C10B161B49A5086F97F",
+     "subType": "attribute",
+     "name": "Order Channel",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "forms": [
+     {
+      "id": "45C11FA478E745FEA08D781CEA190FE5",
+      "name": "ID",
+      "category": "ID",
+      "type": "system",
+      "displayFormat": "text",
+      "dataType": {
+       "type": "utf8_char",
+       "precision": 20,
+       "scale": 0
+      },
+      "expressions": [
+       {
+        "expressionId": "2CB3D80EA5424A729428BF66C5ACFEA2",
+        "expression": {
+         "text": "ORDER_CHANNEL",
+         "tokens": [
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "ORDER_CHANNEL",
+           "type": "column_reference",
+           "target": {
+            "dateCreated": "2026-06-11T02:54:52.497Z",
+            "dateModified": "2026-06-11T02:54:52.497Z",
+            "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+            "acg": 255,
+            "objectId": "83D463BBD45E410B9873652078955B41",
+            "subType": "column",
+            "name": "ORDER_CHANNEL"
+           }
+          },
+          {
+           "level": "resolved",
+           "state": "initial",
+           "value": "",
+           "type": "end_of_text"
+          }
+         ]
+        },
+        "tables": [
+         {
+          "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+          "subType": "logical_table",
+          "name": "ORDER_FACT"
+         }
+        ]
+       }
+      ],
+      "alias": "ORDER_CHANNEL",
+      "lookupTable": {
+       "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+       "subType": "logical_table",
+       "name": "ORDER_FACT"
+      }
+     }
+    ],
+    "attributeLookupTable": {
+     "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+     "subType": "logical_table",
+     "name": "ORDER_FACT"
+    },
+    "keyForm": {
+     "id": "45C11FA478E745FEA08D781CEA190FE5",
+     "name": "ID"
+    },
+    "displays": {
+     "reportDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ],
+     "browseDisplays": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID"
+      }
+     ]
+    },
+    "sorts": {},
+    "relationships": [],
+    "nonAggregatable": false,
+    "autoDetectLookupTable": true
+   }
+  ]
+ },
+ "factMetrics": {
+  "offset": 0,
+  "limit": -1,
+  "total": 4,
+  "factMetrics": [
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "C3331A42A2054CC19665490F06554DDD",
+     "subType": "fact_metric",
+     "name": "NET_REVENUE",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "fact": {
+     "dataType": {
+      "type": "double",
+      "precision": 8,
+      "scale": 2
+     },
+     "expressions": [
+      {
+       "expressionId": "127B6FD1A37C4EDD9A22E8468947FA03",
+       "expression": {
+        "text": "NET_REVENUE",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "NET_REVENUE",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T02:54:52.497Z",
+           "dateModified": "2026-06-11T02:54:52.497Z",
+           "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+           "acg": 255,
+           "objectId": "2358BF7FA6BD44998507B95725612D64",
+           "subType": "column",
+           "name": "NET_REVENUE"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ]
+      }
+     ],
+     "extensions": [],
+     "entryLevel": []
+    },
+    "function": "sum",
+    "functionProperties": [
+     {
+      "name": "UseLookupForAttributes",
+      "value": {
+       "type": "boolean",
+       "value": "false"
+      }
+     }
+    ],
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "apply",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      },
+      "implementation": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     }
+    ],
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "metricFormatType": "reserved"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "4C2FA40DDACF483E909724459CECD0AC",
+     "subType": "fact_metric",
+     "name": "GROSS_PROFIT",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "fact": {
+     "dataType": {
+      "type": "double",
+      "precision": 8,
+      "scale": 2
+     },
+     "expressions": [
+      {
+       "expressionId": "68A5D6212D3B4CA3AE112F146E198733",
+       "expression": {
+        "text": "GROSS_PROFIT",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "GROSS_PROFIT",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T02:54:52.497Z",
+           "dateModified": "2026-06-11T02:54:52.497Z",
+           "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+           "acg": 255,
+           "objectId": "E411AA7426BC4FC69F13110FDB307362",
+           "subType": "column",
+           "name": "GROSS_PROFIT"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ]
+      }
+     ],
+     "extensions": [],
+     "entryLevel": []
+    },
+    "function": "sum",
+    "functionProperties": [
+     {
+      "name": "UseLookupForAttributes",
+      "value": {
+       "type": "boolean",
+       "value": "false"
+      }
+     }
+    ],
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "apply",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      },
+      "implementation": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     }
+    ],
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "metricFormatType": "reserved"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "2B54F0E3EE4F4E35A382B39C8433CAB6",
+     "subType": "fact_metric",
+     "name": "QUANTITY_ORDERED",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "fact": {
+     "dataType": {
+      "type": "int64",
+      "precision": 8,
+      "scale": 0
+     },
+     "expressions": [
+      {
+       "expressionId": "C2F94E4728154683B5DAAA206340CCB2",
+       "expression": {
+        "text": "QUANTITY_ORDERED",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "QUANTITY_ORDERED",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T02:54:52.497Z",
+           "dateModified": "2026-06-11T02:54:52.497Z",
+           "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+           "acg": 255,
+           "objectId": "691CED4C7ADE41258636AF79121CAA92",
+           "subType": "column",
+           "name": "QUANTITY_ORDERED"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ]
+      }
+     ],
+     "extensions": [],
+     "entryLevel": []
+    },
+    "function": "sum",
+    "functionProperties": [
+     {
+      "name": "UseLookupForAttributes",
+      "value": {
+       "type": "boolean",
+       "value": "false"
+      }
+     }
+    ],
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "apply",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      },
+      "implementation": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     }
+    ],
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "metricFormatType": "reserved"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:54:52.497Z",
+     "dateModified": "2026-06-11T02:54:52.497Z",
+     "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+     "acg": 255,
+     "objectId": "6CD8AF360D1B40259910F69C0122F3E5",
+     "subType": "fact_metric",
+     "name": "ORDER_ID",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "fact": {
+     "dataType": {
+      "type": "utf8_char",
+      "precision": 20,
+      "scale": 0
+     },
+     "expressions": [
+      {
+       "expressionId": "41139E0B57434355A14C1B555F0C8B83",
+       "expression": {
+        "text": "ORDER_ID",
+        "tokens": [
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "ORDER_ID",
+          "type": "column_reference",
+          "target": {
+           "dateCreated": "2026-06-11T02:54:52.497Z",
+           "dateModified": "2026-06-11T02:54:52.497Z",
+           "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+           "acg": 255,
+           "objectId": "217118E54335470FAF5BDB78FF07955A",
+           "subType": "column",
+           "name": "ORDER_ID"
+          }
+         },
+         {
+          "level": "resolved",
+          "state": "initial",
+          "value": "",
+          "type": "end_of_text"
+         }
+        ]
+       },
+       "tables": [
+        {
+         "objectId": "5D15CB80A04A4C8D997A9260A6E1A55A",
+         "subType": "logical_table",
+         "name": "ORDER_FACT"
+        }
+       ]
+      }
+     ],
+     "extensions": [],
+     "entryLevel": []
+    },
+    "function": "count",
+    "functionProperties": [
+     {
+      "name": "UseLookupForAttributes",
+      "value": {
+       "type": "boolean",
+       "value": "false"
+      }
+     },
+     {
+      "name": "Distinct",
+      "value": {
+       "type": "boolean",
+       "value": "true"
+      }
+     }
+    ],
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "apply",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      },
+      "implementation": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     }
+    ],
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "metricFormatType": "reserved"
+   }
+  ]
+ },
+ "metrics": {
+  "offset": 0,
+  "limit": -1,
+  "total": 3,
+  "metrics": [
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:55:03.048Z",
+     "dateModified": "2026-06-11T02:55:03.048Z",
+     "versionId": "717D54A62B49024DA91D46B13AD2159E",
+     "acg": 255,
+     "objectId": "11D0F479626041DAB61CFA7C349AE9DE",
+     "subType": "metric",
+     "name": "Total Net Revenue",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "expression": {
+     "text": "Sum(NET_REVENUE)",
+     "tokens": [
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "Sum",
+       "type": "function",
+       "target": {
+        "dateCreated": "2025-05-29T19:58:08.059Z",
+        "dateModified": "2025-05-29T19:58:08.059Z",
+        "versionId": "CD5315C011DF671600088AA0669A0C20",
+        "acg": 255,
+        "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+        "subType": "function",
+        "name": "Sum",
+        "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "<",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "UseLookupForAttributes",
+       "type": "identifier"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "=",
+       "type": "function"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "False",
+       "type": "boolean"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ">",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "(",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "NET_REVENUE",
+       "type": "object_reference",
+       "target": {
+        "dateCreated": "2026-06-11T02:54:52.497Z",
+        "dateModified": "2026-06-11T02:54:52.497Z",
+        "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+        "acg": 255,
+        "objectId": "C3331A42A2054CC19665490F06554DDD",
+        "subType": "fact_metric",
+        "name": "NET_REVENUE"
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ")",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "{",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "~",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "}",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "",
+       "type": "end_of_text"
+      }
+     ]
+    },
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "none",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "conditionality": {
+     "embedMethod": "report_into_metric_filter",
+     "removeElements": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      }
+     }
+    ],
+    "aggregateFromBase": true,
+    "formulaJoinType": "default",
+    "smartTotal": "decomposable_false",
+    "dataType": {
+     "type": "reserved",
+     "precision": 0,
+     "scale": 0
+    },
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "subtotalFromBase": false,
+    "metricFormatType": "reserved",
+    "thresholds": [],
+    "embeddedObjects": [
+     {
+      "id": "7DB65280B549A50D078991BECBDF82ED",
+      "subType": "agg_metric",
+      "expression": {
+       "text": "Sum(NET_REVENUE)",
+       "tokens": [
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "Sum",
+         "type": "function",
+         "target": {
+          "dateCreated": "2025-05-29T19:58:08.059Z",
+          "dateModified": "2025-05-29T19:58:08.059Z",
+          "versionId": "CD5315C011DF671600088AA0669A0C20",
+          "acg": 255,
+          "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+          "subType": "function",
+          "name": "Sum",
+          "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "<",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "UseLookupForAttributes",
+         "type": "identifier"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "=",
+         "type": "function"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "False",
+         "type": "boolean"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ">",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "(",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "NET_REVENUE",
+         "type": "object_reference",
+         "target": {
+          "dateCreated": "2026-06-11T02:54:52.497Z",
+          "dateModified": "2026-06-11T02:54:52.497Z",
+          "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+          "acg": 255,
+          "objectId": "C3331A42A2054CC19665490F06554DDD",
+          "subType": "fact_metric",
+          "name": "NET_REVENUE"
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ")",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "",
+         "type": "end_of_text"
+        }
+       ]
+      }
+     }
+    ],
+    "pushDownBehavior": "automatic"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:55:03.048Z",
+     "dateModified": "2026-06-11T02:55:03.048Z",
+     "versionId": "717D54A62B49024DA91D46B13AD2159E",
+     "acg": 255,
+     "objectId": "003ECB8FC2CB4336B8BD403570B0AA00",
+     "subType": "metric",
+     "name": "Total Gross Profit",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "expression": {
+     "text": "Sum(GROSS_PROFIT)",
+     "tokens": [
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "Sum",
+       "type": "function",
+       "target": {
+        "dateCreated": "2025-05-29T19:58:08.059Z",
+        "dateModified": "2025-05-29T19:58:08.059Z",
+        "versionId": "CD5315C011DF671600088AA0669A0C20",
+        "acg": 255,
+        "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+        "subType": "function",
+        "name": "Sum",
+        "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "<",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "UseLookupForAttributes",
+       "type": "identifier"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "=",
+       "type": "function"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "False",
+       "type": "boolean"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ">",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "(",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "GROSS_PROFIT",
+       "type": "object_reference",
+       "target": {
+        "dateCreated": "2026-06-11T02:54:52.497Z",
+        "dateModified": "2026-06-11T02:54:52.497Z",
+        "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+        "acg": 255,
+        "objectId": "4C2FA40DDACF483E909724459CECD0AC",
+        "subType": "fact_metric",
+        "name": "GROSS_PROFIT"
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ")",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "{",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "~",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "}",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "",
+       "type": "end_of_text"
+      }
+     ]
+    },
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "none",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "conditionality": {
+     "embedMethod": "report_into_metric_filter",
+     "removeElements": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      }
+     }
+    ],
+    "aggregateFromBase": true,
+    "formulaJoinType": "default",
+    "smartTotal": "decomposable_false",
+    "dataType": {
+     "type": "reserved",
+     "precision": 0,
+     "scale": 0
+    },
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "subtotalFromBase": false,
+    "metricFormatType": "reserved",
+    "thresholds": [],
+    "embeddedObjects": [
+     {
+      "id": "C50B6BA202403656344063913F5C67D8",
+      "subType": "agg_metric",
+      "expression": {
+       "text": "Sum(GROSS_PROFIT)",
+       "tokens": [
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "Sum",
+         "type": "function",
+         "target": {
+          "dateCreated": "2025-05-29T19:58:08.059Z",
+          "dateModified": "2025-05-29T19:58:08.059Z",
+          "versionId": "CD5315C011DF671600088AA0669A0C20",
+          "acg": 255,
+          "objectId": "8107C31BDD9911D3B98100C04F2233EA",
+          "subType": "function",
+          "name": "Sum",
+          "description": "Returns the sum of all values in the ValueList.  This is a group-value function."
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "<",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "UseLookupForAttributes",
+         "type": "identifier"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "=",
+         "type": "function"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "False",
+         "type": "boolean"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ">",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "(",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "GROSS_PROFIT",
+         "type": "object_reference",
+         "target": {
+          "dateCreated": "2026-06-11T02:54:52.497Z",
+          "dateModified": "2026-06-11T02:54:52.497Z",
+          "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+          "acg": 255,
+          "objectId": "4C2FA40DDACF483E909724459CECD0AC",
+          "subType": "fact_metric",
+          "name": "GROSS_PROFIT"
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ")",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "",
+         "type": "end_of_text"
+        }
+       ]
+      }
+     }
+    ],
+    "pushDownBehavior": "automatic"
+   },
+   {
+    "information": {
+     "dateCreated": "2026-06-11T02:55:03.048Z",
+     "dateModified": "2026-06-11T02:55:03.048Z",
+     "versionId": "717D54A62B49024DA91D46B13AD2159E",
+     "acg": 255,
+     "objectId": "9F428B57068E4DA5BD4D0E45B0FF75E5",
+     "subType": "metric",
+     "name": "Order Count",
+     "destinationFolderId": "80808BA0E03949BD988ABBF0C116BE5E"
+    },
+    "expression": {
+     "text": "Count(ORDER_ID)",
+     "tokens": [
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "Count",
+       "type": "function",
+       "target": {
+        "dateCreated": "2025-05-29T19:58:08.059Z",
+        "dateModified": "2025-05-29T19:58:08.059Z",
+        "versionId": "CD5315C011DF671600088AA0669A0C20",
+        "acg": 255,
+        "objectId": "8107C31CDD9911D3B98100C04F2233EA",
+        "subType": "function",
+        "name": "Count",
+        "description": "Returns the number of values the ValueList. This is a group-value function."
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "<",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "Distinct",
+       "type": "identifier"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "=",
+       "type": "function"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "True",
+       "type": "boolean"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ",",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "UseLookupForAttributes",
+       "type": "identifier"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "=",
+       "type": "function"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "False",
+       "type": "boolean"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ">",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "(",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "ORDER_ID",
+       "type": "object_reference",
+       "target": {
+        "dateCreated": "2026-06-11T02:54:52.497Z",
+        "dateModified": "2026-06-11T02:54:52.497Z",
+        "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+        "acg": 255,
+        "objectId": "6CD8AF360D1B40259910F69C0122F3E5",
+        "subType": "fact_metric",
+        "name": "ORDER_ID"
+       }
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": ")",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "{",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "~",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "}",
+       "type": "character"
+      },
+      {
+       "level": "resolved",
+       "state": "initial",
+       "value": "",
+       "type": "end_of_text"
+      }
+     ]
+    },
+    "dimty": {
+     "dimtyUnits": [
+      {
+       "dimtyUnitType": "report_base_level",
+       "aggregation": "normal",
+       "filtering": "none",
+       "groupBy": true
+      }
+     ],
+     "excludeAttribute": false,
+     "allowAddingUnit": true
+    },
+    "conditionality": {
+     "embedMethod": "report_into_metric_filter",
+     "removeElements": true
+    },
+    "metricSubtotals": [
+     {
+      "definition": {
+       "objectId": "96C487AF4D12472A910C1ACACFB56EFB",
+       "subType": "system_subtotal",
+       "name": "Total"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "078C50834B484EE29948FA9DD5300ADF",
+       "subType": "system_subtotal",
+       "name": "Count"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B328C60462634223B2387D4ADABEEB53",
+       "subType": "system_subtotal",
+       "name": "Average"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "00B7BFFF967F42C4B71A4B53D90FB095",
+       "subType": "system_subtotal",
+       "name": "Minimum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "B1F4AA7DE683441BA559AA6453C5113E",
+       "subType": "system_subtotal",
+       "name": "Maximum"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "54E7BFD129514717A92BC44CF1FE5A32",
+       "subType": "system_subtotal",
+       "name": "Product"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "83A663067F7E43B2ABF67FD38ECDC7FE",
+       "subType": "system_subtotal",
+       "name": "Median"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "36226A4048A546139BE0AF5F24737BA8",
+       "subType": "system_subtotal",
+       "name": "Mode"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "7FBA414995194BBAB2CF1BB599209824",
+       "subType": "system_subtotal",
+       "name": "Standard Deviation"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "1769DBFCCF2D4392938E40418C6E065E",
+       "subType": "system_subtotal",
+       "name": "Variance"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "E1853D5A36C74F59A9F8DEFB3F9527A1",
+       "subType": "system_subtotal",
+       "name": "Geometric Mean"
+      }
+     },
+     {
+      "definition": {
+       "objectId": "F225147A4CA0BB97368A5689D9675E73",
+       "subType": "system_subtotal",
+       "name": "Aggregation"
+      }
+     }
+    ],
+    "aggregateFromBase": true,
+    "formulaJoinType": "default",
+    "smartTotal": "decomposable_false",
+    "dataType": {
+     "type": "reserved",
+     "precision": 0,
+     "scale": 0
+    },
+    "format": {
+     "header": [],
+     "values": []
+    },
+    "subtotalFromBase": true,
+    "metricFormatType": "reserved",
+    "thresholds": [],
+    "embeddedObjects": [
+     {
+      "id": "FB08BE7FED4883046261C2A95D2BE8BB",
+      "subType": "agg_metric",
+      "expression": {
+       "text": "Count(ORDER_ID)",
+       "tokens": [
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "Count",
+         "type": "function",
+         "target": {
+          "dateCreated": "2025-05-29T19:58:08.059Z",
+          "dateModified": "2025-05-29T19:58:08.059Z",
+          "versionId": "CD5315C011DF671600088AA0669A0C20",
+          "acg": 255,
+          "objectId": "8107C31CDD9911D3B98100C04F2233EA",
+          "subType": "function",
+          "name": "Count",
+          "description": "Returns the number of values the ValueList. This is a group-value function."
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "<",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "Distinct",
+         "type": "identifier"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "=",
+         "type": "function"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "True",
+         "type": "boolean"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ",",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "UseLookupForAttributes",
+         "type": "identifier"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "=",
+         "type": "function"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "False",
+         "type": "boolean"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ">",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "(",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "ORDER_ID",
+         "type": "object_reference",
+         "target": {
+          "dateCreated": "2026-06-11T02:54:52.497Z",
+          "dateModified": "2026-06-11T02:54:52.497Z",
+          "versionId": "84B42A0C924A8022105EC3BFDBA5539B",
+          "acg": 255,
+          "objectId": "6CD8AF360D1B40259910F69C0122F3E5",
+          "subType": "fact_metric",
+          "name": "ORDER_ID"
+         }
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": ")",
+         "type": "character"
+        },
+        {
+         "level": "resolved",
+         "state": "initial",
+         "value": "",
+         "type": "end_of_text"
+        }
+       ]
+      }
+     }
+    ],
+    "pushDownBehavior": "automatic"
+   }
+  ]
+ },
+ "links": {
+  "offset": 0,
+  "limit": -1,
+  "total": 0,
+  "links": []
+ },
+ "hierarchy": {
+  "relationships": [
+   {
+    "parent": {
+     "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+     "subType": "attribute",
+     "name": "Year"
+    },
+    "child": {
+     "objectId": "FCC42217F759485DB03D155EAA9B727A",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "relationshipTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   },
+   {
+    "parent": {
+     "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+     "subType": "attribute",
+     "name": "Region"
+    },
+    "child": {
+     "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+     "subType": "attribute",
+     "name": "Store"
+    },
+    "relationshipTable": {
+     "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+     "subType": "logical_table",
+     "name": "STORE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   },
+   {
+    "parent": {
+     "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+     "subType": "attribute",
+     "name": "Category"
+    },
+    "child": {
+     "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+     "subType": "attribute",
+     "name": "Product"
+    },
+    "relationshipTable": {
+     "objectId": "7751DF0514D64104A56548A014AB7253",
+     "subType": "logical_table",
+     "name": "PRODUCT_DIM"
+    },
+    "relationshipType": "one_to_many"
+   },
+   {
+    "parent": {
+     "objectId": "FCC42217F759485DB03D155EAA9B727A",
+     "subType": "attribute",
+     "name": "Month"
+    },
+    "child": {
+     "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+     "subType": "attribute",
+     "name": "Day"
+    },
+    "relationshipTable": {
+     "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+     "subType": "logical_table",
+     "name": "DATE_DIM"
+    },
+    "relationshipType": "one_to_many"
+   }
+  ],
+  "isolatedAttributes": [
+   {
+    "objectId": "A0B193BE721E4C10B161B49A5086F97F",
+    "subType": "attribute",
+    "name": "Order Channel"
+   }
+  ]
+ },
+ "attributeRelationships": {
+  "Region": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+      "subType": "attribute",
+      "name": "Region"
+     },
+     "child": {
+      "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "relationshipTable": {
+      "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+      "subType": "logical_table",
+      "name": "STORE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Category": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+      "subType": "attribute",
+      "name": "Category"
+     },
+     "child": {
+      "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "relationshipTable": {
+      "objectId": "7751DF0514D64104A56548A014AB7253",
+      "subType": "logical_table",
+      "name": "PRODUCT_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Year": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "child": {
+      "objectId": "FCC42217F759485DB03D155EAA9B727A",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "relationshipTable": {
+      "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Month": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "8A31FB1D1D454A7D943C5D18DA2F3F1B",
+      "subType": "attribute",
+      "name": "Year"
+     },
+     "child": {
+      "objectId": "FCC42217F759485DB03D155EAA9B727A",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "relationshipTable": {
+      "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    },
+    {
+     "parent": {
+      "objectId": "FCC42217F759485DB03D155EAA9B727A",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "child": {
+      "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "relationshipTable": {
+      "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Store": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "EAD7F93400BF440C83C41419DBF2E17E",
+      "subType": "attribute",
+      "name": "Region"
+     },
+     "child": {
+      "objectId": "854CFD98AC1E4CD68FC0FA75B9A17594",
+      "subType": "attribute",
+      "name": "Store"
+     },
+     "relationshipTable": {
+      "objectId": "AB1D7AAA17A74767AD5866D5D335C690",
+      "subType": "logical_table",
+      "name": "STORE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Product": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "D2A1321AC2AE45CAA719BC68730D8317",
+      "subType": "attribute",
+      "name": "Category"
+     },
+     "child": {
+      "objectId": "9B0445D348354586AA1EBA2DBC97032B",
+      "subType": "attribute",
+      "name": "Product"
+     },
+     "relationshipTable": {
+      "objectId": "7751DF0514D64104A56548A014AB7253",
+      "subType": "logical_table",
+      "name": "PRODUCT_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Day": {
+   "relationships": [
+    {
+     "parent": {
+      "objectId": "FCC42217F759485DB03D155EAA9B727A",
+      "subType": "attribute",
+      "name": "Month"
+     },
+     "child": {
+      "objectId": "A9DB3C84879F4F57819A7A7BFB518507",
+      "subType": "attribute",
+      "name": "Day"
+     },
+     "relationshipTable": {
+      "objectId": "BA9F072B540349BCA4A66E8FA184DDA8",
+      "subType": "logical_table",
+      "name": "DATE_DIM"
+     },
+     "relationshipType": "one_to_many"
+    }
+   ]
+  },
+  "Order Channel": {
+   "relationships": []
+  }
+ }
+}

--- a/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/dossier_definition.json
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/dossier_definition.json
@@ -1,0 +1,396 @@
+{
+ "id": "77EFB43F5B441BA7B6EEECAB4D92A7EF",
+ "name": "Orders Performance Overview",
+ "datasets": [
+  {
+   "name": "Revenue by Region and Category",
+   "id": "5C8ABD78BC4EA7F4AF876E97091E6BA5",
+   "availableObjects": [
+    {
+     "id": "6140BFA7309B406AA76A90454BC7BB53",
+     "name": "Region",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "13AF74581AA84A46B8FD2D1BBA073150",
+     "name": "Category",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "413D98E4993B4D6ABB2DC440F7B31971",
+     "name": "Total Net Revenue",
+     "type": "metric"
+    },
+    {
+     "id": "653830C2CB684809B7030FBBEA498C8C",
+     "name": "Total Gross Profit",
+     "type": "metric"
+    },
+    {
+     "id": "5393F49A94A443E79E38CB3855B0272F",
+     "name": "Profit Margin Pct",
+     "type": "metric"
+    }
+   ],
+   "rows": [
+    {
+     "id": "6140BFA7309B406AA76A90454BC7BB53",
+     "name": "Region",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "13AF74581AA84A46B8FD2D1BBA073150",
+     "name": "Category",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    }
+   ],
+   "columns": [
+    {
+     "id": "00000000000000000000000000000000",
+     "name": "Metrics",
+     "type": "templateMetrics",
+     "elements": [
+      {
+       "name": "Total Net Revenue",
+       "id": "413D98E4993B4D6ABB2DC440F7B31971",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Total Gross Profit",
+       "id": "653830C2CB684809B7030FBBEA498C8C",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Profit Margin Pct",
+       "id": "5393F49A94A443E79E38CB3855B0272F",
+       "type": "metric",
+       "dataType": "reserved"
+      }
+     ]
+    }
+   ],
+   "pageBy": []
+  },
+  {
+   "name": "Monthly Revenue Trend",
+   "id": "864205BFBA4B4E6E863C3FB42FB0A406",
+   "availableObjects": [
+    {
+     "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+     "name": "Year",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "decimal",
+       "baseFormCategory": "ID",
+       "baseFormType": "number"
+      }
+     ]
+    },
+    {
+     "id": "C3292DAD4FAF404F88590CB19C3930F9",
+     "name": "Month",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC",
+       "dataType": "varChar",
+       "baseFormCategory": "DESC",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "413D98E4993B4D6ABB2DC440F7B31971",
+     "name": "Total Net Revenue",
+     "type": "metric"
+    },
+    {
+     "id": "145746BAC65E4BF39E83149A843A3DF7",
+     "name": "Order Count",
+     "type": "metric"
+    }
+   ],
+   "rows": [
+    {
+     "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+     "name": "Year",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "decimal",
+       "baseFormCategory": "ID",
+       "baseFormType": "number"
+      }
+     ]
+    },
+    {
+     "id": "C3292DAD4FAF404F88590CB19C3930F9",
+     "name": "Month",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "CCFBE2A5EADB4F50941FB879CCF1721C",
+       "name": "DESC",
+       "dataType": "varChar",
+       "baseFormCategory": "DESC",
+       "baseFormType": "text"
+      }
+     ]
+    }
+   ],
+   "columns": [
+    {
+     "id": "00000000000000000000000000000000",
+     "name": "Metrics",
+     "type": "templateMetrics",
+     "elements": [
+      {
+       "name": "Total Net Revenue",
+       "id": "413D98E4993B4D6ABB2DC440F7B31971",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Order Count",
+       "id": "145746BAC65E4BF39E83149A843A3DF7",
+       "type": "metric",
+       "dataType": "reserved"
+      }
+     ]
+    }
+   ],
+   "pageBy": []
+  },
+  {
+   "name": "Channel Performance",
+   "id": "69759BAD734F3EB9308219B61D916432",
+   "availableObjects": [
+    {
+     "id": "E951AA8437BF46BB860E98F0DB349617",
+     "name": "Order Channel",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    },
+    {
+     "id": "413D98E4993B4D6ABB2DC440F7B31971",
+     "name": "Total Net Revenue",
+     "type": "metric"
+    },
+    {
+     "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+     "name": "Units Sold",
+     "type": "metric"
+    },
+    {
+     "id": "145746BAC65E4BF39E83149A843A3DF7",
+     "name": "Order Count",
+     "type": "metric"
+    }
+   ],
+   "rows": [
+    {
+     "id": "E951AA8437BF46BB860E98F0DB349617",
+     "name": "Order Channel",
+     "type": "attribute",
+     "forms": [
+      {
+       "id": "45C11FA478E745FEA08D781CEA190FE5",
+       "name": "ID",
+       "dataType": "varChar",
+       "baseFormCategory": "ID",
+       "baseFormType": "text"
+      }
+     ]
+    }
+   ],
+   "columns": [
+    {
+     "id": "00000000000000000000000000000000",
+     "name": "Metrics",
+     "type": "templateMetrics",
+     "elements": [
+      {
+       "name": "Total Net Revenue",
+       "id": "413D98E4993B4D6ABB2DC440F7B31971",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Units Sold",
+       "id": "3BF64C66D95D41888EE5EEDEFAFB7C69",
+       "type": "metric",
+       "dataType": "reserved"
+      },
+      {
+       "name": "Order Count",
+       "id": "145746BAC65E4BF39E83149A843A3DF7",
+       "type": "metric",
+       "dataType": "reserved"
+      }
+     ]
+    }
+   ],
+   "pageBy": []
+  }
+ ],
+ "currentChapter": "K123",
+ "chapters": [
+  {
+   "key": "K65",
+   "name": "Revenue by Region and Category",
+   "pages": [
+    {
+     "key": "K85",
+     "name": "Page 1",
+     "visualizations": [
+      {
+       "key": "K86",
+       "name": "Visualization 1",
+       "visualizationType": "grid"
+      }
+     ]
+    }
+   ],
+   "filters": [
+    {
+     "key": "K201",
+     "name": "Region",
+     "source": {
+      "id": "6140BFA7309B406AA76A90454BC7BB53",
+      "name": "Region"
+     }
+    }
+   ]
+  },
+  {
+   "key": "K69",
+   "name": "Monthly Revenue Trend",
+   "pages": [
+    {
+     "key": "K120",
+     "name": "Page 1",
+     "visualizations": [
+      {
+       "key": "K121",
+       "name": "Visualization 1",
+       "visualizationType": "grid"
+      }
+     ],
+     "selectors": [
+      {
+       "key": "K124",
+       "name": "Year",
+       "selectorType": "attribute_selector_lists",
+       "source": {
+        "id": "C025482DAE4C4BFDA72E8297D981ABAC",
+        "name": "Year"
+       },
+       "multiSelectionAllowed": true,
+       "hasAll": true,
+       "targets": [
+        {
+         "key": "K121"
+        }
+       ]
+      }
+     ]
+    }
+   ],
+   "filters": []
+  },
+  {
+   "key": "K123",
+   "name": "Channel Performance",
+   "pages": [
+    {
+     "key": "K158",
+     "name": "Page 1",
+     "visualizations": [
+      {
+       "key": "K159",
+       "name": "Visualization 1",
+       "visualizationType": "grid"
+      }
+     ],
+     "selectors": [
+      {
+       "key": "K160",
+       "name": "Order Channel",
+       "selectorType": "attribute_selector_lists",
+       "source": {
+        "id": "E951AA8437BF46BB860E98F0DB349617",
+        "name": "Order Channel"
+       },
+       "multiSelectionAllowed": true,
+       "hasAll": true,
+       "targets": [
+        {
+         "key": "K159"
+        }
+       ]
+      },
+      {
+       "key": "K162",
+       "name": "Panel Selector 1",
+       "selectorType": "panel_selector_button_bar",
+       "targets": []
+      }
+     ]
+    }
+   ],
+   "filters": []
+  }
+ ]
+}

--- a/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/expected_parity.json
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/fixtures/expected_parity.json
@@ -1,0 +1,547 @@
+{
+ "Revenue by Region and Category": [
+  {
+   "keys": [
+    "Midwest",
+    "Apparel"
+   ],
+   "values": {
+    "Total Net Revenue": 1338.56,
+    "Total Gross Profit": 904.0,
+    "Profit Margin Pct": 0.67535262
+   }
+  },
+  {
+   "keys": [
+    "Midwest",
+    "Beauty"
+   ],
+   "values": {
+    "Total Net Revenue": 961.05,
+    "Total Gross Profit": 728.0,
+    "Profit Margin Pct": 0.75750481
+   }
+  },
+  {
+   "keys": [
+    "Midwest",
+    "Electronics"
+   ],
+   "values": {
+    "Total Net Revenue": 434.91,
+    "Total Gross Profit": 287.91,
+    "Profit Margin Pct": 0.66199903
+   }
+  },
+  {
+   "keys": [
+    "Midwest",
+    "Home"
+   ],
+   "values": {
+    "Total Net Revenue": 351.8,
+    "Total Gross Profit": 240.95,
+    "Profit Margin Pct": 0.6849062
+   }
+  },
+  {
+   "keys": [
+    "Midwest",
+    "Sports"
+   ],
+   "values": {
+    "Total Net Revenue": 382.41,
+    "Total Gross Profit": 291.41,
+    "Profit Margin Pct": 0.76203551
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Apparel"
+   ],
+   "values": {
+    "Total Net Revenue": 882.81,
+    "Total Gross Profit": 539.0,
+    "Profit Margin Pct": 0.6105504
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Beauty"
+   ],
+   "values": {
+    "Total Net Revenue": 216.48,
+    "Total Gross Profit": 168.0,
+    "Profit Margin Pct": 0.77605322
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Electronics"
+   ],
+   "values": {
+    "Total Net Revenue": 2711.3,
+    "Total Gross Profit": 1737.72,
+    "Profit Margin Pct": 0.64091764
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Home"
+   ],
+   "values": {
+    "Total Net Revenue": 864.82,
+    "Total Gross Profit": 583.87,
+    "Profit Margin Pct": 0.67513471
+   }
+  },
+  {
+   "keys": [
+    "Northeast",
+    "Sports"
+   ],
+   "values": {
+    "Total Net Revenue": 706.31,
+    "Total Gross Profit": 486.91,
+    "Profit Margin Pct": 0.68937152
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Apparel"
+   ],
+   "values": {
+    "Total Net Revenue": 3012.85,
+    "Total Gross Profit": 1968.0,
+    "Profit Margin Pct": 0.65320212
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Beauty"
+   ],
+   "values": {
+    "Total Net Revenue": 928.88,
+    "Total Gross Profit": 728.0,
+    "Profit Margin Pct": 0.78373956
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Electronics"
+   ],
+   "values": {
+    "Total Net Revenue": 4450.83,
+    "Total Gross Profit": 2753.72,
+    "Profit Margin Pct": 0.61869809
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Home"
+   ],
+   "values": {
+    "Total Net Revenue": 3045.65,
+    "Total Gross Profit": 2164.96,
+    "Profit Margin Pct": 0.71083677
+   }
+  },
+  {
+   "keys": [
+    "South",
+    "Sports"
+   ],
+   "values": {
+    "Total Net Revenue": 2239.54,
+    "Total Gross Profit": 1614.69,
+    "Profit Margin Pct": 0.72099181
+   }
+  },
+  {
+   "keys": [
+    "West",
+    "Apparel"
+   ],
+   "values": {
+    "Total Net Revenue": 2696.87,
+    "Total Gross Profit": 1711.0,
+    "Profit Margin Pct": 0.63443918
+   }
+  },
+  {
+   "keys": [
+    "West",
+    "Electronics"
+   ],
+   "values": {
+    "Total Net Revenue": 2771.95,
+    "Total Gross Profit": 1739.81,
+    "Profit Margin Pct": 0.62764841
+   }
+  },
+  {
+   "keys": [
+    "West",
+    "Home"
+   ],
+   "values": {
+    "Total Net Revenue": 2799.81,
+    "Total Gross Profit": 1914.74,
+    "Profit Margin Pct": 0.68388212
+   }
+  },
+  {
+   "keys": [
+    "West",
+    "Sports"
+   ],
+   "values": {
+    "Total Net Revenue": 1167.35,
+    "Total Gross Profit": 842.0,
+    "Profit Margin Pct": 0.72129181
+   }
+  }
+ ],
+ "Monthly Revenue Trend": [
+  {
+   "keys": [
+    "2024",
+    "January"
+   ],
+   "values": {
+    "Total Net Revenue": 2947.38,
+    "Order Count": 19
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "Feb"
+   ],
+   "values": {
+    "Total Net Revenue": 3309.41,
+    "Order Count": 13
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "March"
+   ],
+   "values": {
+    "Total Net Revenue": 3255.74,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "Apr"
+   ],
+   "values": {
+    "Total Net Revenue": 3243.79,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "May"
+   ],
+   "values": {
+    "Total Net Revenue": 16176.6,
+    "Order Count": 133
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "June"
+   ],
+   "values": {
+    "Total Net Revenue": 3345.98,
+    "Order Count": 22
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "July"
+   ],
+   "values": {
+    "Total Net Revenue": 3068.53,
+    "Order Count": 17
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "August"
+   ],
+   "values": {
+    "Total Net Revenue": 3043.97,
+    "Order Count": 15
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "September"
+   ],
+   "values": {
+    "Total Net Revenue": 2982.02,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "October"
+   ],
+   "values": {
+    "Total Net Revenue": 2000.41,
+    "Order Count": 14
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "November"
+   ],
+   "values": {
+    "Total Net Revenue": 5020.6,
+    "Order Count": 22
+   }
+  },
+  {
+   "keys": [
+    "2024",
+    "December"
+   ],
+   "values": {
+    "Total Net Revenue": 2685.91,
+    "Order Count": 20
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "January"
+   ],
+   "values": {
+    "Total Net Revenue": 2947.38,
+    "Order Count": 19
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "Feb"
+   ],
+   "values": {
+    "Total Net Revenue": 3309.41,
+    "Order Count": 13
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "March"
+   ],
+   "values": {
+    "Total Net Revenue": 3255.74,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "Apr"
+   ],
+   "values": {
+    "Total Net Revenue": 3243.79,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "May"
+   ],
+   "values": {
+    "Total Net Revenue": 16176.6,
+    "Order Count": 133
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "June"
+   ],
+   "values": {
+    "Total Net Revenue": 3345.98,
+    "Order Count": 22
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "July"
+   ],
+   "values": {
+    "Total Net Revenue": 3068.53,
+    "Order Count": 17
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "August"
+   ],
+   "values": {
+    "Total Net Revenue": 3043.97,
+    "Order Count": 15
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "September"
+   ],
+   "values": {
+    "Total Net Revenue": 2982.02,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "October"
+   ],
+   "values": {
+    "Total Net Revenue": 2000.41,
+    "Order Count": 14
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "November"
+   ],
+   "values": {
+    "Total Net Revenue": 5020.6,
+    "Order Count": 22
+   }
+  },
+  {
+   "keys": [
+    "2025",
+    "December"
+   ],
+   "values": {
+    "Total Net Revenue": 2685.91,
+    "Order Count": 20
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "January"
+   ],
+   "values": {
+    "Total Net Revenue": 2947.38,
+    "Order Count": 19
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "Feb"
+   ],
+   "values": {
+    "Total Net Revenue": 3309.41,
+    "Order Count": 13
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "March"
+   ],
+   "values": {
+    "Total Net Revenue": 3255.74,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "Apr"
+   ],
+   "values": {
+    "Total Net Revenue": 3243.79,
+    "Order Count": 16
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "May"
+   ],
+   "values": {
+    "Total Net Revenue": 16176.6,
+    "Order Count": 133
+   }
+  },
+  {
+   "keys": [
+    "2026",
+    "June"
+   ],
+   "values": {
+    "Total Net Revenue": 3345.98,
+    "Order Count": 22
+   }
+  }
+ ],
+ "Channel Performance": [
+  {
+   "keys": [
+    "App"
+   ],
+   "values": {
+    "Total Net Revenue": 16507.39,
+    "Units Sold": 228,
+    "Order Count": 93
+   }
+  },
+  {
+   "keys": [
+    "In-Store"
+   ],
+   "values": {
+    "Total Net Revenue": 31964.18,
+    "Units Sold": 411,
+    "Order Count": 173
+   }
+  },
+  {
+   "keys": [
+    "Online"
+   ],
+   "values": {
+    "Total Net Revenue": 62316.78,
+    "Units Sold": 842,
+    "Order Count": 387
+   }
+  }
+ ]
+}

--- a/microstrategy-migration-skills/microstrategy-to-sigma/refs/ae-row-collapse.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/refs/ae-row-collapse.md
@@ -1,0 +1,48 @@
+# Analytical-Engine row collapse — why `resolve_ae_winners.py` exists
+
+## The behavior
+
+When an attribute's **key (ID) form is non-unique in its lookup table**,
+MicroStrategy's Analytical Engine does something no clean SQL GROUP BY
+reproduces: it collapses the per-(parent, key) result to **one
+arbitrary-but-stable representative row per key element** and cross-tabs that
+row's label + metric values across the parent attribute.
+
+Fixture example: `Month.key = MONTH_NUMBER` while `DATE_DIM` carries multiple
+`MONTH_NAME` spellings and repeats month numbers across years. The grid shows
+one `MONTH_NAME` spelling per month number — which one is a **hash artifact of
+the engine**. It cannot be derived from the model bundle, only observed.
+
+A report is **affected** when one of its attribute units has a DESC form
+distinct from its grouping key (`convert.py` → `attribute_unit_cols`). Reports
+without such attributes produce clean grids — no resolution needed.
+
+## The resolution workflow (`scripts/resolve_ae_winners.py`)
+
+1. **Re-execute** each affected report via
+   `POST /api/v2/reports/{id}/instances?limit=N` — the MSTR grid is ground
+   truth for which representative won.
+2. Compute the **clean** per-(parents, key) aggregates from the warehouse —
+   the same SQL MicroStrategy generated (`Bundle.build_clean_group_sql`) — via
+   a temporary Sigma workbook with a `sql` element (deleted afterward).
+3. **Match** each key's MSTR-reported label + metric values to the unique
+   clean row. Ambiguity is a hard error, never a guess.
+4. Emit `ae_winners.json`
+   (`{report: {quirkKeyCol, quirkDescCol, parentKeyCols, winners[]}}`) for
+   `convert.py --ae-winners`.
+
+`convert.py` then emits a **SQL element** per affected report
+(`Bundle.build_ae_sql`): a CTE of the clean groups self-joined so every
+parent-key row takes the pinned winner row's label + metric values — exactly
+reproducing the AE grid, deterministic and parity-verifiable.
+
+## Related converter patterns (clean reports)
+
+- **Grouping by key, labeling by DESC**: MSTR grids group by the attribute's
+  KEY form and render the DESC form; when they differ, the converter emits the
+  key as the grouping column and `Max([DESC])` as the rendered label.
+- **Inner-join semantics**: MicroStrategy inner-joins lookup tables, so fact
+  rows with no matching dim row never appear in its grid. The converted Sigma
+  DM join is left-outer (other consumers need all fact rows) — so the
+  converter adds a per-element `exclude [null]` list filter on each dim-keyed
+  grouping column to mirror MSTR.

--- a/microstrategy-migration-skills/microstrategy-to-sigma/refs/control-parity.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/refs/control-parity.md
@@ -1,0 +1,99 @@
+# Control parity — lint, flip test, and the MCP/export answer
+
+SHARED ref, vendored byte-identical into every covered plugin's `refs/`
+(md5 discipline). Companion to `scripts/lib/control_lint.rb` (gate 7 /
+post-and-readback control lint) and `scripts/probe-controls.rb` (flip test).
+
+## Why this exists
+
+A migrated workbook can pass data parity, the column-type guard, and the
+layout lint and still ship **broken interactivity**. The 2026-06 estate audit
+of tj-wells-1989 found 86 controls across 36 kept workbooks: 8 DEAD (no
+filter target, no formula reference — pure furniture), 18 PARTIAL (same-page
+charts outside the control's reach; 8 of them bugs), and the Qlik class
+(source dashboards full of listboxes migrated with zero controls). None of
+the existing gates noticed, because every existing gate evaluates elements in
+their default state.
+
+## The three layers
+
+1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
+   dead controls, ghost filter targets, source-closure reach vs same-page
+   queryable elements, and source-signal coverage via the
+   `control-scope.json` sidecar. Runs automatically in
+   `post-and-readback.rb --type workbook` (exit 4) and as
+   `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
+2. **control-scope.json contract** — emitted by the builder next to the
+   workbook spec. Carries (a) `sourceFilterSignals`: how many filter-like
+   signals the SOURCE artifact had (Tableau quick filters + actions, PBI
+   slicers, Qlik listboxes, QuickSight/Cognos parameters+prompts, Looker
+   dashboard filters, TS Liveboard filters) — `>0` with zero spec controls
+   FAILS the lint; (b) per-control intent: `scope: "page"` (default — the
+   control must reach every same-page queryable element) or
+   `scope: ["Element name or id", ...]` (the **single-chart-switcher
+   allowlist** for intentional narrow controls like grain/geo-level toggles)
+   plus optional `mustReach` hard assertions. Full schema in the
+   `control_lint.rb` header CONTRACT block. The in-spec `controlScope` key on
+   a control element means the same thing but does NOT survive Sigma
+   readback — the sidecar is the durable form.
+3. **Flip test** (`scripts/probe-controls.rb`) — OPTIONAL Phase-6 runtime
+   evidence, not the mandatory inner loop. Exports one in-closure element CSV
+   with and without `parameters:{<controlId>: <first non-default value>}` —
+   they must differ; with `--check-out-of-closure`, an out-of-closure element
+   must NOT differ. Use it after hand-wiring controls, after estate repairs,
+   or when the lint's static reach needs runtime confirmation.
+
+## The MCP question — definitive answer (verified 2026-06-12, tj-wells-1989)
+
+Tested by setting a saved default (`values: ["West"]`) on a live workbook's
+Region list control (PHASEE, `64e78398`), then querying/exporting the same
+in-closure bar chart every way available:
+
+| Path | Control defaults applied? | Can set a control value? |
+|---|---|---|
+| `mcp__sigma-mcp-v2__query` (type=workbook) | **YES** — returned only the West row | **NO** — schema is `{type, workbookId, sql}` only; no parameter mechanism exists in the MCP query path |
+| REST export, no `parameters` | **YES** — only the West row | n/a |
+| REST `POST /v2/workbooks/{id}/export` with `"parameters": {"<controlId>": "<value>"}` | starts from defaults | **YES** — and the parameter **REPLACES** the saved default (parameters `{"ctl-region":"South"}` over a West default returned only South — no intersection) |
+
+Consequences:
+
+- MCP is fine for **default-state parity** (Phase 6 uses exactly that), and
+  default-state MCP rows DO move if you change a control's saved default.
+- MCP can NOT exercise a non-default control value — flip testing MUST go
+  through the export API's `parameters` map. That is why probe-controls.rb is
+  built on export.
+- A parameter value that matches no data row returns an EMPTY (header-only)
+  CSV, not an error — pick flip values from the column's actual domain
+  (probe-controls.rb auto-picks from the control's value-source column).
+
+## Repair recipes (what the lint tells you to do)
+
+- **dead control, column exists on a master** → add
+  `filters: [{source: {kind: "table", elementId: "<master>"}, columnId: "<col>"}]`
+  (and point the control's own `source` at the same column for its value
+  list).
+- **dead control, column does NOT exist anywhere** → REMOVE the control.
+  Honest beats decorative; do not fake-wire to an unrelated column.
+- **partial reach, multi-master page** → add one filter target per master the
+  control should govern (the column must exist on each); elements sourcing
+  from those masters inherit via the closure.
+- **partial reach, chart bypasses the master** (sources the DM directly) →
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
+- **intentional narrow control** (grain switcher driving one chart by
+  formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
+
+After any repair: flip-test the workbook
+(`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/microstrategy-migration-skills/microstrategy-to-sigma/refs/datamodels.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/refs/datamodels.md
@@ -1,0 +1,53 @@
+# Strategy One "Data Models" (Mosaic) — extraction + authoring, live-validated
+
+Strategy One has a newer semantic-layer object alongside the classic project
+schema: the **Data Model** (subType `report_emma_cube`, "Mosaic model").
+Customers on current versions may model in these instead of classic
+attributes/facts. Both paths are handled; this doc covers the Data Model side.
+Everything below was validated live (build + query, exact parity vs the
+classic-schema fixture: same 19/19 Region×Category cells).
+
+## Why it matters for migration
+- Maps almost 1:1 to a Sigma data model: tables + key-joined star +
+  metrics, with `dataServeMode: connect_live` (live warehouse SQL — same
+  execution model as Sigma) or `in_memory` (cube — migrate as the underlying
+  tables, not the cache).
+- Has `securityFilters` (RLS) with member assignment — extractable via
+  `GET /api/dataModels/{id}/securityFilters` (+ `/members`).
+
+## Extraction (converter input)
+`extract_datamodel.py <dataModelId>` → `datamodel_definition.json`:
+dataModel info + tables (with token expressions) + attributes + factMetrics +
+metrics + hierarchy + per-attribute relationships + links. See
+`fixtures/datamodel_definition.json` for the shape.
+- Joins are NOT in `/links` — in-model star joins are classic-style
+  **shared multi-table key attributes** (e.g. Store ID = `STORE_KEY`@dim +
+  `ORDER_STORE_KEY`@fact). Derive Sigma joins exactly like the classic path.
+- `/links` is **cross-data-model linking only** ("target objects must come
+  from different Mosaic models"); also the only GET that requires an
+  `X-MSTR-MS-Changeset` header.
+- Query for parity: `POST /api/v2/cubes/{dmId}/instances` — synchronous,
+  data inline in the response. Do NOT poll `.../instances/{iid}/status`
+  (500s for connect_live instances).
+
+## Authoring (fixture building) — flow that works
+`build_datamodel.py` (phased: core|metrics|query|all; state in
+`datamodel_ids.json`):
+1. dataServer pipeline first, NO changeset: `POST /api/dataServer/workspaces`
+   → `.../pipelines` → `.../pipelines/{pid}/tables` with
+   `importSource:{type:"single_table", dataSourceId, namespace, tableName}`
+   (the data server introspects warehouse columns itself). Workspaces are
+   session-bound — never reuse across logins (401 "trusted communication").
+2. ONE `schemaEdit=false` changeset: create DM (+ `destinationFolderId` —
+   enforced at COMMIT, not POST) → add tables with
+   `physicalTable:{pipeline:"<stringified pipeline JSON>"}` (classic logical
+   tables are rejected: "not from pipeline") → attributes → relationships →
+   factMetrics → commit. An EMPTY DM cannot commit; DM + tables share the
+   changeset. Inline `attributes`/`factMetrics` in the table POST are
+   silently ignored — use the dedicated endpoints. `isKeyForm` on a form is
+   rejected; key is the attribute-level `keyForm:{name:'ID'}`.
+3. Second changeset for metrics (one-token formula text, e.g.
+   `Sum([NET_REVENUE]) {~}`; distinct count via `function:"count"` +
+   `functionProperties:[{name:"Distinct", value:{type:"boolean", value:"true"}}]`).
+4. No `/model/schema/reload` needed; connect_live DMs have NO publish
+   workflow (`POST /api/dataModels/{id}/publish` → 400 — skip it).

--- a/microstrategy-migration-skills/microstrategy-to-sigma/refs/design-notes.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/refs/design-notes.md
@@ -1,0 +1,74 @@
+# Design notes — MicroStrategy → Sigma converter
+
+## Architecture (one-way data flow)
+
+```
+MSTR REST ──extract.py──> bundle.json ──convert.py──> sigma_dm_spec.json
+                                              │            sigma_workbook_spec.json
+              resolve_ae_winners.py ──────────┘  (ae_winners.json, when needed)
+```
+
+- **`bundle.json` is the contract.** `extract.py` walks a dossier definition →
+  its dataset reports (templates, `showExpressionAs=tokens`) → the schema
+  objects they reference (attributes incl. forms/expressions/lookup tables,
+  facts, metrics incl. compound bases via a second pass, logical tables,
+  hierarchy relationships). The converter never talks to MicroStrategy.
+- **Everything in the output is derived from the bundle** — sources (one DM
+  table element per logical table), the fact table (the logical table carrying
+  fact expressions), joins (attribute key forms mapped to BOTH the fact table
+  and a lookup table become left-outer join legs), a consumable join element
+  with de-duplicated columns (each join's own key column is skipped on the
+  lookup side — a cross-element passthrough of a join key compiles to type
+  `error` in Sigma), metrics (token-parsed; `Count<Distinct=True>` →
+  `CountDistinct`), and one workbook page per dossier chapter.
+- Display formats: MSTR bundle format blocks come back empty, so formats are
+  derived from semantics (count/quantity → integer, pct/margin/ratio →
+  percent, money-named facts → currency).
+
+## Validated scope (live trial, exact parity)
+
+- Classic-schema path: star schema (fact + dims, incl. heterogeneous key
+  columns like `ORDER_STORE_KEY = STORE_KEY`), 3 grid reports in a dossier →
+  Sigma DM + workbook, **19/19 + 30/30 + 3/3 rows exact** (money/counts exact,
+  ratios rel 1e-6). Includes a `Count<Distinct=True>` metric, a compound
+  margin metric, and one AE-collapse report (see `ae-row-collapse.md`).
+
+## Modeling gotchas that bite conversions (verified)
+
+- **Attribute-count metrics cause cartesian-join governance aborts.** A metric
+  like `Count(Customer)` (counting an *attribute*) makes the SQL engine join
+  the attribute's lookup table without a constraining fact path — on a real
+  warehouse the resulting cross join trips MicroStrategy's governance limits
+  and kills the report. Count a **fact column** instead (e.g. a
+  `CUSTOMER_KEY` fact on the fact table) — same number, sane SQL. The same
+  applies on the Sigma side: count the key column of the join element.
+- **Compound-metric denominators need `ZeroToNull()`.** A ratio like
+  `[Profit] / [Revenue]` dies with a Snowflake division-by-zero error on any
+  zero-denominator group. In MSTR wrap the denominator
+  (`ZeroToNull([Total Net Revenue])`); the converter's Sigma output should
+  use the equivalent null-guard if the source metric did.
+
+## Roadmap (deliberately not in the validated path)
+
+1. **Chart visualization emission** — the viz-type lookup
+   (`viz-type-mapping.md`) is extraction-validated; emitting non-table Sigma
+   elements (kpi/bar/line/combo + layout) is the long tail. Author the
+   `fixtures/BUILD_SPEC.md` dossier on a trial to drive it.
+2. **The newer "Data Model" object** (`/api/model/dataModels`) — fully
+   REST-authorable (incl. `securityFilters`, publish, `connect_live`), unlike
+   the classic schema. Two implications: (a) a richer, cleaner extraction
+   source for customers who've adopted it; (b) `securityFilters` is the
+   surface for an RLS detect→ask→port flow (same principles as the sibling
+   converters: never silently dropped, never silently ported).
+3. **Page-by, prompts, metric-condition selectors** — extracted structurally
+   but not converted (metric-condition selectors land in
+   `control-scope.json` `unbound` as MANUAL). Chapter filters + attribute
+   selectors ARE converted (2026-06-12): selectors' declared `targets` viz
+   lists drive the Sigma control filter wiring, `control-scope.json` is the
+   intended-scope contract, and gate 7 (`scripts/lib/control_lint.rb`) +
+   `scripts/probe-controls.rb` enforce/prove it. Verified strip gotcha: a
+   list-control filter target on a DATETIME or NUMERIC column posts 200 and
+   reads back `filters: null` — dates become date-range controls, numbers
+   bind through a hidden `Text()` cast column. (The numeric variant is NOT
+   yet in the shared `refs/control-parity.md` — candidate for the next
+   cross-plugin sync.)

--- a/microstrategy-migration-skills/microstrategy-to-sigma/refs/layout-visual-qa.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/refs/layout-visual-qa.md
@@ -1,0 +1,74 @@
+# Layout Visual QA — mandatory render-and-inspect gate
+
+Shared across all `*-to-sigma` migration plugins. A workbook that POSTs cleanly (HTTP 200)
+and passes numeric/CSV parity can still be visually broken — **overlapping tiles, clipped
+titles, dead zones, orphaned filters**. The export API renders exactly what a user sees, so
+the only reliable check is to **render each page to PNG and actually read the image** before
+declaring the migration done.
+
+> **The rule that triggered this gate:** Sigma's grid layout has **no z-order**. Source tools
+> with floating/absolute canvases (Qlik's associative listboxes & filterpanes, Power BI free-form
+> visuals, QuickSight FreeForm, Tableau floating zones) routinely place a **filter/legend/listbox
+> on top of a chart**. Preserving those coordinates 1:1 makes the two elements render *stacked on
+> the same cell*. The build scripts now resolve this deterministically (controls lifted to their
+> own band; `decollide_bands` tiles any remaining 2-D overlap edge-to-edge) — but novel layouts
+> can still slip through, which is why this human/agent visual gate is mandatory.
+
+## Mandatory loop (run after the workbook is POSTed, before you call it done)
+
+1. **Render every page** to PNG at a realistic width:
+   `python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/<page>.png --w 1600`
+   (Plugins that ship their own renderer — `export-chart-png.rb`, `compare.py` — may use it;
+   the contract is identical: `POST /v2/workbooks/{id}/export` → poll `/v2/query/{q}/download`.)
+2. **Read each PNG** and check it against the rubric below.
+3. **Fix** any failure (re-band, resize, move a control into its chart's container, shorten a
+   map title) by editing the spec — for large multi-page workbooks use
+   `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit element files → push) — then
+   **re-render and re-read**.
+4. **Loop until the render passes inspection.** Declare the migration done on a *clean render*,
+   never on an HTTP 200.
+
+## Pass/fail rubric (read the PNG against every item)
+
+- [ ] **No overlaps / no stacking.** No two elements occupy the same cell; no filter, legend, or
+      listbox sits on top of a chart or KPI. (This is the #1 failure for floating-canvas sources.)
+- [ ] **No dead zones.** The page title never shares a band with a chart; bands are stacked edge
+      to edge; no giant empty tile (usually an over-tall table — size to content).
+- [ ] **Controls placed correctly.** A global filter sits in a top control band; a control scoped
+      to one chart lives *inside that chart's container*, never floating loose on the page.
+- [ ] **No clipped titles/values.** KPI bands are ≥ 5 grid rows (titles hide below that); side
+      charts are ≥ 6 columns wide (narrower truncates the title); table tiles show all rows
+      without cutting off the summary bar.
+- [ ] **Even heights.** Charts in one band share an inner row span; sibling chart bands match.
+- [ ] **Right chart kind & formatting.** The rendered viz matches the source (no silently-dropped
+      log scale, data labels, `$`/`%` formats, or palette).
+
+## Building clean in the first place (so the gate rarely fails)
+
+Group every page into horizontal **band containers** — never a flat list of `<LayoutElement>`s:
+header band → control band → KPI band → chart rows → detail row. Verified container contract:
+
+- Spec side: a `kind: container` placeholder element per band.
+- Layout side: a `<GridContainer>` (NOT `<LayoutElement type="grid">`, which silently drops
+  children); child `gridRow`/`gridColumn` are **container-relative** (restart at 1);
+  `gridTemplateRows="auto"`; every `elementId` must match a real spec element (mismatch =
+  silent drop); GET before a layout PUT (POST reassigns ids; PUT preserves them).
+
+| Band | Container span | Children |
+|---|---|---|
+| Header | rows `1 / 4`, style `#0F172A` + `round` | full-width title text, inner `1 / 25` |
+| Control row | 3 rows | controls side-by-side, inner row `1 / 4` |
+| KPI row | ≥ 5 rows | N KPIs side-by-side, equal col spans |
+| Chart row | 11–12 rows | 2–3 charts side-by-side, identical inner row span, each ≥ 6 cols |
+| Detail table | content + summary (~4 rows + ~0.7/row) | never a fixed 20 (dead space) |
+
+## Known render caveats (not fixable via spec — keep titles short, drop redundant legends)
+
+- **point-map / region-map**: the element `name` and legend render *overlaid on the map canvas*;
+  a long title collides with legend chips. No legend/title-position knob in the OpenAPI.
+- KPI titles hide below ~5 grid rows. Container style knobs that round-trip: backgroundColor,
+  borderRadius, borderColor, borderWidth, padding (`borderColor/Width` incompatible with
+  `padding: none`).
+
+_Base patterns verified 2026-06-10 on tj-wells-1989 (workbooks bc24d476, 3e23b761, 9733fcd9)
+against a known-good native layout (Chart Zoo Enhanced v4, 39a8f826)._

--- a/microstrategy-migration-skills/microstrategy-to-sigma/refs/mstr-rest-api.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/refs/mstr-rest-api.md
@@ -1,0 +1,115 @@
+# MicroStrategy (Strategy One) REST API — verified behaviors & gotchas
+
+Everything below was verified live on a Strategy One 2026 cloud trial during the
+validated end-to-end migration. `scripts/mstr.py` bakes the session/changeset
+mechanics in; this doc is the why.
+
+## Auth & plumbing
+
+- **Login**: `POST /api/auth/login` `{username, password, loginMode: 1}` →
+  session token in the `X-MSTR-AuthToken` **response header** + cookies. Send
+  both on every call, plus `X-MSTR-ProjectID` for project-scoped endpoints.
+  There is **no API-key concept** — sessions only.
+- **OpenAPI**: the full spec is served by the instance itself at
+  `GET /api/openapi.json` (~6 MB). The hosted docs URL serves a stub — trust
+  the instance.
+- **Response headers matter**: several flows return required handles only as
+  response headers (see report saving below). `mstr.py` exposes them as
+  `session.last_headers`, **lowercased** (e.g. `x-mstr-ms-instance`).
+- **Python 3.13+ TLS**: some MicroStrategy cloud CA certs lack the key-usage
+  extension; Python 3.13+ rejects them under `VERIFY_X509_STRICT` (on by
+  default — curl accepts the same cert). `mstr.py` clears only that flag and
+  keeps verification on.
+
+## Datasources
+
+- `GET /api/dbmss` can be **404** on current builds — use `GET /api/gateways`;
+  a gateway id **works as the dbms id** in `POST /api/datasources`
+  (e.g. Snowflake gateway, `dbType: snow_flake`).
+- Creating a warehouse datasource is a **trio**:
+  1. `POST /api/datasources/logins` (username/password)
+  2. `POST /api/datasources/connections` (connectionString + `database.type` +
+     login id) — test first via `POST /api/datasources/connections/test`
+     (accepts an inline login)
+  3. `POST /api/datasources` (dbms + connection id)
+  then attach to a project:
+  `PATCH /api/projects/{id}/datasources`
+  `{"operationList":[{"op":"add","path":"/id","value":"<dsId>"}]}`.
+- On cloud trials, **JDBC connection strings work where ODBC driver names all
+  fail** (`IM002`), e.g.
+  `JDBC;DRIVER=net.snowflake.client.jdbc.SnowflakeDriver;URL={jdbc:snowflake://<account>.snowflakecomputing.com/?...};`
+
+## Changesets (schema edits)
+
+- Creating/editing **tables, attributes, facts, metrics** requires a changeset:
+  `POST /api/model/changesets?schemaEdit=true` → use the returned id as the
+  `X-MSTR-MS-Changeset` header on each modeling call → commit. `mstr.py`'s
+  `schema_edit(fn)` wraps create/commit/abort.
+- **A failed call inside a changeset dangles the schema lock** ("Schema
+  editing is in use by another user") unless you `DELETE` the changeset.
+  If a lock is already stuck: `DELETE /api/model/schema/lock`.
+- Objects created in an **uncommitted** changeset are **not name-resolvable by
+  later calls in the same changeset** — compound metrics that reference newly
+  created base metrics need a **second changeset** after committing the first.
+- Attribute/fact form-expression `tables` entries **require**
+  `subType: "logical_table"`.
+- Metric formulas accept **one token carrying the whole formula text**
+  (`Sum([Net Revenue]) {~}`, `Count<Distinct=True>([Order Id Fact]) {~}`) —
+  the server tokenizes it.
+- After schema changes, reload with a **required body**:
+  `POST /api/model/schema/reload`
+  `{"updateTypes":["table_key","entry_level","logical_size","clear_element_cache"]}`.
+
+## Hierarchy relationships
+
+- `PUT /api/model/systemHierarchy/attributes/{id}/relationships` requires an
+  explicit `child` ref **alongside** `parent`, else a 500 NPE
+  (`getJointChild`).
+- **The PUT REPLACES the attribute's entire parent list.** Writing one new
+  relationship silently drops existing ones — GET the current relationships
+  and merge before every write.
+
+## Reports (the dossier datasets)
+
+- **Reports do NOT use changesets** — the header is rejected.
+- `POST /api/model/reports` only **stages in-memory** (the response's
+  `versionId` is all zeros and the object is NOT in metadata yet). Persist via
+  `POST /api/model/reports/{id}/instances/save` with the `X-MSTR-MS-Instance`
+  header taken from the **creation response header** (lowercase
+  `x-mstr-ms-instance` via `session.last_headers`).
+- The save body needs `dataSource.dataTemplate.units` mirroring
+  `grid.viewTemplate`.
+- **Execution**: `POST /api/v2/reports/{id}/instances?limit=N` returns data
+  directly; the `sqlView` endpoint on an instance exposes the generated
+  warehouse SQL + the Analytical Engine steps (essential for parity debugging
+  — see `ae-row-collapse.md`).
+
+## Dossiers
+
+- **Extraction**: `GET /api/v2/dossiers/{id}/definition` returns
+  `{datasets, chapters[].pages[]}`. Walk each page's `visualizations` **and**
+  `panelStacks[].panels[]` **recursively** — panels nest further `panelStacks`
+  — plus free-form `fields` (images / text boxes), or you silently miss
+  content. Non-dossier documents 404/error on this endpoint (useful as a
+  dossier-vs-document probe).
+- **Per-viz definition is shallow**: a visualization exposes ONLY
+  `visualizationType` + `definition.grid` (`rows` / `columns` / `metrics` /
+  `crossTab` / `metricsPosition`). There is no slot/encoding detail beyond the
+  grid — the converter maps `visualizationType` → Sigma chart kind via lookup
+  with a flagged-table fallback (see `viz-type-mapping.md`).
+- **Authoring is REST-hostile**: `POST /api/dossiers/instances`
+  `{objects:[{id, type:3}]}` wraps reports into an in-memory dossier (returns
+  `mid`); save via `POST /api/documents/{id}/instances/{mid}/saveAs` — but the
+  flow is **session-bound** (create + saveAs must share one auth session). The
+  public manipulations API supports ONLY `setFilter` / `setCurrentPanel`; viz
+  types can't be set via REST (UI only). Chart-rich fixtures must be authored
+  in the Library UI (see `../fixtures/BUILD_SPEC.md`).
+
+## Roadmap: the newer "Data Model" object
+
+Strategy One also ships a **newer Data Model object**
+(`/api/model/dataModels`) that is **fully REST-authorable** — including
+`securityFilters`, publish, and `connect_live`. The validated converter targets
+the classic schema path (attributes/facts/metrics + reports + dossiers); the
+Data Model object is not yet exercised and is the natural next extraction
+source (and the RLS port surface). Tracked as roadmap in `design-notes.md`.

--- a/microstrategy-migration-skills/microstrategy-to-sigma/refs/viz-type-mapping.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/refs/viz-type-mapping.md
@@ -1,0 +1,69 @@
+# Dossier visualization types → Sigma element kinds
+
+What the dossier API exposes per visualization is **shallow**: only
+`visualizationType` + `definition.grid` (`rows` / `columns` / `metrics` /
+`crossTab` / `metricsPosition`). There are no slot/encoding details beyond
+which attributes and metrics sit on which grid axis. The converter therefore
+maps `visualizationType` → a Sigma element kind via this lookup, feeds the
+grid axes into the closest Sigma slots, and falls back to a **flagged table**
+(data preserved, loud warning) for anything unmapped — never silently wrong.
+
+**Status legend** — *extraction validated*: the type was pulled from real
+demo-content dossiers and its `definition.grid` parsed as documented.
+*Build*: whether the Sigma-element emission is part of the validated path
+(the live-validated fixture used grid reports; chart emission is roadmap).
+
+Counts below are from a 365-dossier / ~7,400-viz sweep of MicroStrategy's
+public demo environment (Tutorial, MobileDashboards, Embedded Analytics,
+AI Auto projects, 2026-06) — the extractor walker parsed **all** of them,
+so every listed type is extraction-validated. Counts double as gap priority.
+
+| MSTR `visualizationType` | n | Sigma element kind | Build |
+|---|---|---|---|
+| `grid` | 1893 | `table` (pivot when `crossTab: true`) | **validated (parity-verified)** |
+| `kpi` | 1633 | `kpi-chart` | roadmap (top priority by volume) |
+| `bar_chart` | 810 | `bar` | roadmap |
+| `geospatial_service` | 331 | `region-map` / `point-map` (by geo attribute granularity — cognos `tiledmap` precedent) | roadmap |
+| `line_chart` | 252 | `line` | roadmap |
+| `bubble_chart` | 221 | `scatter` (size slot) | roadmap |
+| `heat_map` | 188 | flagged `table` (size+color tile grid has no Sigma analog) | fallback |
+| `combo_chart` | 182 | `combo` | roadmap |
+| `area_chart` | 170 | `area` | roadmap |
+| `multi_metric_kpi` | 168 | one `kpi-chart` per metric | roadmap |
+| `compound_grid` | 155 | `table` | roadmap |
+| `microcharts` | 113 | `table` + flagged sparkline columns | fallback |
+| `ring_chart` | 111 | `pie` (donut variant) | roadmap |
+| `google_map` | 104 | `region-map` / `point-map` | roadmap |
+| `pie_chart` | 90 | `pie` | roadmap |
+| `comparison_kpi` | 67 | `kpi-chart` (comparison value flagged) | roadmap |
+| `sankey` | 42 | flagged `table` | fallback |
+| `gauge` | 33 | `kpi-chart` (gauge bands flagged) | fallback |
+| `histogram` | 27 | `bar` (pre-binned) or flagged | fallback |
+| `network` | 25 | flagged `table` | fallback |
+| `waterfall` | 23 | flagged `table` | fallback |
+| `esri_map` | 21 | `region-map` / `point-map` | roadmap |
+| `box_plot` | 16 | `box` if available, else flagged | fallback |
+| `key_driver`, `time_series`, `auto_narratives`, `sequences_sunburst`, `forecast_line_chart`, `PageBy`, `ImageOverlay` | ≤12 ea | flagged `table` | fallback |
+| **custom/marketplace vizzes** — any `HC*` (Highcharts), `D3*`, `Vitara*`, `EChart*`, `Arria*`, `Google*`, `CardWidget`, `RadarChart`, `SimpleKPIChart`, … | ~230 total | flagged `table` — third-party viz plugins, unconvertible by definition | fallback |
+| *anything else* | — | flagged `table` fallback | fallback |
+
+Custom-viz names are not a closed set (they're marketplace plugins) — treat
+any type not in this table as custom and flag it.
+
+**Structural-feature frequencies** from the same sweep (extractor handles all
+of these; converter coverage noted): selectors 51% of dossiers, chapter
+filters 49%, multi-dataset 42%, free-form `fields` — text 65% / image 54% /
+shape 33% / **html 11%** — and nested panelStacks 23%. Free-form text →
+Sigma `text` elements; images/shapes/html are flagged; **attribute selectors
++ chapter filters → Sigma controls** (CONVERTED — wired to the selectors'
+declared `targets` viz lists, `control-scope.json` sidecar, gate 7 +
+flip-test; panel selectors and metric-condition selectors are flagged MANUAL
+in the sidecar); multi-dataset chapters → one Sigma element per dataset-backed
+viz (each viz names its dataset).
+
+`fixtures/BUILD_SPEC.md` is the drag-and-drop spec for an "every viz type"
+fixture dossier (REST cannot author visualizations — Library UI only); use it
+to extend the validated set.
+
+Keep `VIZ_MAPPED` in `../../microstrategy-assessment/scripts/assess.py` in
+sync with this table — the assessment classifies estates against it.

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,0 +1,554 @@
+#!/usr/bin/env ruby
+# Hard gate that proves a tableau-to-sigma conversion is actually complete.
+# The subagent MUST run this script before declaring GREEN. It checks seven
+# independent things — failing ANY of them blocks the GREEN declaration:
+#
+#   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
+#      → beads-sigma-4pm
+#   2. No orphan workbooks left in the customer's My Documents
+#      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
+#      cleanup ran with no failed deletes)  → beads-sigma-38a
+#   3. The live workbook's /columns endpoint shows no column with
+#      type=error (catches circular refs / runtime errors introduced
+#      AFTER the initial POST's column-type guard ran)  → beads-sigma-38a
+#   4. The workbook has a non-empty layout XML applied (catches the
+#      "elements just listed in a single column" regression where the
+#      agent forgot to PUT a layout)  → beads-sigma-bw3
+#   5. Tile census — parity-final.json's `tile_census` field (emitted by the
+#      converter's phase6 finalize when a dashboard zone tree is available)
+#      shows no unexplained dashboard zones without a matching chart in the
+#      parity plan. Catches the "empty view CSV silently dropped a tile and
+#      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
+#      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the GridContainer bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
+#   7. Control lint (scripts/lib/control_lint.rb, shared) — no dead controls
+#      (a control with no resolving `filters` target AND no [controlId]
+#      formula reference is furniture: the "Orders Overview (from Looker)"
+#      estate shipped three of them), no ghost filter targets, and no control
+#      whose source-closure misses same-page queryable elements (the PHASEE
+#      "Action(Region) -> Monthly Revenue Trend" escape). Honors the
+#      control-scope sidecar (<workdir>/control-scope.json or
+#      --control-scope) for source-signal coverage (zero controls built from
+#      an interactive source = FAIL, the Qlik class) and per-control
+#      scope:[...] allowlists (intentional single-chart switchers like grain
+#      controls). See the lib header CONTRACT.
+#
+# Usage:
+#   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
+#     [--workbook-id <id>]     # override; default = read from wb-ids.json
+#     [--min-pass-rate 1.0]    # default 1.0 (every chart must PASS)
+#     [--allow-extract]        # treat extract-mode as acceptable
+#     [--skip-column-check]    # skip the live /columns type=error scan
+#     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
+#                              # that genuinely want multiple workbooks)
+#     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--skip-control-lint]    # skip gate 7 (control-wiring lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--control-scope PATH]   # control-scope.json sidecar for gate 7
+#                              # (default: <workdir>/control-scope.json)
+#     [--min-layout-elements N] default 2 — single-page bare-element layouts
+#                              # often have just the page wrapper; require this
+#                              # many <LayoutElement> tags
+#     [--allow-missing-tiles N] default 0 — tolerate up to N unmatched dashboard
+#                              # zones in the tile census (for legitimately
+#                              # unbuildable zones; name them in your report)
+#
+# Exit codes:
+#   0  every gate passes — conversion is allowed to declare GREEN
+#   1  parity-final.json missing (Phase 6 skipped — the regression case)
+#   2  parity-final.json exists but status=FAIL / pass-rate below min /
+#      extract-mode without --allow-extract / charts_total==0
+#   3  parity-final.json malformed
+#   4  orphan workbooks left uncleaned (beads-sigma-38a)
+#   5  live workbook has column(s) with type=error (beads-sigma-38a)
+#   6  live workbook has no layout applied — single-column fallback
+#      (beads-sigma-bw3)
+#   7  tile census shows unexplained unmatched dashboard zones beyond
+#      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
+#   9  control lint violations — dead controls / ghost targets / partial
+#      reach / source filter signals with zero controls
+#      (gate 7; scripts/lib/control_lint.rb)
+#
+# Prints a per-gate summary to stdout regardless of exit code.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
+         allow_missing_tiles: 0 }
+OptionParser.new do |p|
+  p.on('--tableau DIR')              { |v| opts[:tab] = v }
+  p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
+  p.on('--workbook-id ID')           { |v| opts[:wb] = v }
+  p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--allow-extract')            { opts[:allow_extract] = true }
+  p.on('--skip-column-check')        { opts[:skip_column] = true }
+  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
+  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
+  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+  p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
+  p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
+end.parse!
+abort('--workdir (or --tableau) required') unless opts[:tab]
+
+summary_path = File.join(opts[:tab], 'parity-final.json')
+
+if opts[:skip_parity]
+  puts "[SKIP] gate 1/7: Phase 6 source-parity WAIVED via --skip-parity-gate (#{opts[:skip_parity]})."
+  puts "       This waiver MUST be named in the migration report — the workbook was NOT numerically verified vs the source."
+else
+  unless File.exist?(summary_path)
+    warn "[FAIL] Phase 6 skipped — #{summary_path} does not exist."
+    warn "       Run: ruby scripts/phase6-parity.rb --tableau #{opts[:tab]} --workbook-id <id>"
+    warn "       then collect actuals via mcp__sigma-mcp-v2__query and re-run with --finalize."
+    warn "       See SKILL.md Phase 6. This is the hard gate (beads-sigma-4pm)."
+    warn "       If source parity is genuinely unavailable (no workspace/dataset/warehouse access), waive"
+    warn "       with --skip-parity-gate \"<reason>\" and name it in the report."
+    exit 1
+  end
+
+  begin
+    summary = JSON.parse(File.read(summary_path))
+  rescue JSON::ParserError => e
+    warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
+    exit 3
+  end
+
+  total = summary['charts_total'].to_i
+  passed = summary['charts_pass'].to_i
+  status = summary['status'].to_s
+  mode = summary['mode'].to_s
+
+  if total <= 0
+    warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
+    warn "       This usually means auto-parity-plan.rb matched zero Tableau views."
+    warn "       Phase 6 must verify at least one chart to declare GREEN."
+    exit 2
+  end
+
+  if mode == 'extract' && !opts[:allow_extract]
+    warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
+    warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
+    warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
+    exit 2
+  end
+
+  pass_rate = passed.to_f / total
+  # status=PASS requires 100% — when the caller explicitly accepts a lower
+  # pass-rate (--min-pass-rate, for honest NAMED divergences like LOD
+  # placeholders / cross-grain semantics), the rate is the gate, not the status.
+  rate_gate_only = opts[:min_pass_rate] < 1.0
+  if (rate_gate_only ? pass_rate < opts[:min_pass_rate] : (status != 'PASS' || pass_rate < opts[:min_pass_rate]))
+    warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
+    warn "       Required: #{rate_gate_only ? '' : 'status=PASS and '}pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
+    if (fail_names = summary['fail_names']) && !fail_names.empty?
+      warn "       Failing charts: #{fail_names.join(', ')}"
+    end
+    exit 2
+  end
+
+  if rate_gate_only && status != 'PASS'
+    puts "[OK] gate 1/7: Phase 6 ran — #{passed}/#{total} charts PASS (>= #{(opts[:min_pass_rate] * 100).to_i}% accepted); " \
+         "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
+  else
+    puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 2 — orphan workbooks (beads-sigma-38a)
+# ---------------------------------------------------------------------------
+unless opts[:skip_orphan]
+  log = File.join(opts[:tab], 'posted-workbooks.jsonl')
+  if File.exist?(log)
+    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    unique_ids = posted.map { |e| e['id'] }.uniq
+    if unique_ids.length > 1
+      marker_path = File.join(opts[:tab], 'cleanup-marker.json')
+      unless File.exist?(marker_path)
+        warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "       posted-workbooks.jsonl entries:"
+        unique_ids.each { |id| warn "         - #{id}" }
+        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        warn "       See beads-sigma-38a."
+        exit 4
+      end
+      marker = JSON.parse(File.read(marker_path)) rescue {}
+      if marker['failed'] && !marker['failed'].empty?
+        warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "       Orphan workbooks are still in the customer's My Documents:"
+        marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
+        exit 4
+      end
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+        exit 4
+      end
+      kept = marker['kept'] || '(unknown)'
+      deleted = (marker['deleted'] || []).length
+      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+    else
+      puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+    end
+  else
+    puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+  end
+else
+  puts "[SKIP] gate 2/7: --skip-orphan-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 3 — live /columns type=error scan (beads-sigma-38a)
+# Catches circular references and runtime errors that the initial post-and-
+# readback column-type guard missed because they were introduced by later
+# PUTs (layout updates, spec edits during error recovery).
+# ---------------------------------------------------------------------------
+unless opts[:skip_column]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 3/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        cols = (JSON.parse(res.body)['entries'] rescue []) || []
+        error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
+        if error_cols.any?
+          warn "[FAIL] gate 3/7: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
+          warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
+          error_cols.first(10).each do |c|
+            warn "         element=#{c['elementId']} col=#{c['columnId']} label=#{c['label'].inspect}"
+            warn "           formula: #{c['formula']}"
+          end
+          warn "       See beads-sigma-38a."
+          exit 5
+        end
+        puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+      else
+        warn "[SKIP] gate 3/7: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 3/7: --skip-column-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 4 — layout applied (beads-sigma-bw3)
+# Fetches the live workbook spec and confirms a non-empty top-level `layout`
+# XML is set, with at least --min-layout-elements <LayoutElement> tags.
+# Catches the "agent forgot to PUT a layout" regression where elements
+# render as a single-column stack instead of the dashboard grid.
+# ---------------------------------------------------------------------------
+unless opts[:skip_layout]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 4/7: no workbook ID resolvable for layout check"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 4/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        body = res.body.to_s
+        spec =
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+          end
+        layout_xml = spec['layout'].to_s
+        elem_count = layout_xml.scan(/<LayoutElement\b/).length
+
+        # Detect the Sigma "auto-generated single-column stack" layout that
+        # the server produces when a workbook is POSTed without a layout.
+        # Signature: every non-Data page has all its elements at the same
+        # gridColumn value (typically "1 / 13" — left half, vertically stacked).
+        # Note: per-page detection — a workbook with one element per content
+        # page is structurally fine (degenerate case, not a stack).
+        # Container-banded pages (<GridContainer> bands per layout-playbook.md)
+        # are exempt: full-width band containers (and single-chart rows inside
+        # them) legitimately share gridColumn="1 / 25" — that is deliberate
+        # banding, not the auto-stack regression.
+        non_data_stack_pages = []
+        # Walk one page at a time using the <Page id="..."> blocks
+        layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
+          next if page_id.to_s.downcase.include?('data')
+          next if page_body.include?('<GridContainer')
+          cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
+          elems_on_page = page_body.scan(/<LayoutElement\b/).length
+          if elems_on_page >= 2 && cols_on_page.length == 1
+            non_data_stack_pages << [page_id, cols_on_page.first, elems_on_page]
+          end
+        end
+
+        if layout_xml.empty?
+          warn "[FAIL] gate 4/7: live workbook #{wb_id} has NO top-level layout XML."
+          warn "       Elements render as a single-column stack instead of the"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
+          warn "       then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
+          warn "           --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        elsif elem_count < opts[:min_layout_elements]
+          warn "[FAIL] gate 4/7: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
+          warn "       The layout likely covers only the Data page — chart page is unstyled."
+          exit 6
+        elsif non_data_stack_pages.any?
+          warn "[FAIL] gate 4/7: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "       single-column stack layout (multiple elements at the same gridColumn"
+          warn "       on a non-Data page). This is what Sigma defaults to when you POST"
+          warn "       a workbook without a layout — exactly the CoCo regression."
+          non_data_stack_pages.each do |pid, col, n|
+            warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
+          end
+          warn "       Rebuild the layout with this skill's layout builder (see SKILL.md —"
+          warn "       layout phase) into #{opts[:tab]}/layout.xml, then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        else
+          puts "[OK] gate 4/7: layout XML applied with #{elem_count} positioned element(s)"
+        end
+      else
+        warn "[SKIP] gate 4/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 4/7: --skip-layout-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 5 — tile census (bead gjhe)
+# parity-final.json's `tile_census` field compares the source dashboard's
+# chart-zone count against the charts that made it into the parity plan.
+# Catches the empty-view-CSV escape where the builder silently emits N-1
+# charts and parity still reports PASS (every chart it knows about passes —
+# it just doesn't know about the dropped one).
+# ---------------------------------------------------------------------------
+census = summary && summary['tile_census']  # summary is nil when gate 1 was waived
+if census.nil?
+  puts "[SKIP] gate 5/7: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+else
+  zones     = census['zones_total'].to_i
+  built     = census['charts_built'].to_i
+  unmatched = census['zones_unmatched'].to_i
+  names     = Array(census['unmatched_zone_names'])
+  if unmatched > opts[:allow_missing_tiles]
+    warn "[FAIL] gate 5/7: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    names.each { |n| warn "         - #{n}" }
+    warn "       A zone that rendered in the source dashboard has NO matching chart in the"
+    warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
+    warn "       (re-fetch the view data and rebuild), or the tile was renamed without"
+    warn "       passing --rename to phase6-parity.rb / build-dashboard-layout.rb."
+    warn "       If #{unmatched} zone(s) are legitimately unbuildable, re-run with"
+    warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
+    exit 7
+  elsif unmatched > 0
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+  else
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/7: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/7: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/7: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts '[OK] gate 6/7: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
+      else
+        warn "[SKIP] gate 6/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7 — control-wiring lint (scripts/lib/control_lint.rb, shared)
+# A workbook can pass every gate above and still ship controls that do
+# NOTHING (dead controls: no resolving filter target, no [controlId] formula
+# reference — the "Orders Overview (from Looker)" estate escape) or controls
+# that silently skip same-page charts (the PHASEE "Action(Region) ->
+# Monthly Revenue Trend" escape). This gate mechanizes those checks on the
+# LIVE spec, plus source-signal coverage when a control-scope sidecar exists
+# (zero controls built from an interactive source = FAIL, the Qlik class).
+# ---------------------------------------------------------------------------
+if opts[:skip_control_lint]
+  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 7/7: no workbook ID resolvable for control lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 7/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/control_lint'
+    rescue LoadError
+      warn "[SKIP] gate 7/7: scripts/lib/control_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(ControlLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        scope_path = opts[:control_scope] || File.join(opts[:tab], 'control-scope.json')
+        scope = nil
+        if File.exist?(scope_path)
+          scope = JSON.parse(File.read(scope_path)) rescue nil
+          warn "[WARN] gate 7/7: #{scope_path} is not valid JSON — linting without source scope" if scope.nil?
+        end
+        violations = ControlLint.lint(spec, scope: scope)
+        if violations.any?
+          warn "[FAIL] gate 7/7: control lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the control wiring and re-PUT (dead controls -> add filters targets"
+          warn "       ({source:{elementId}, columnId}) or remove the control; partial reach ->"
+          warn "       wire the uncovered elements or annotate controlScope in control-scope.json;"
+          warn "       see scripts/lib/control_lint.rb CONTRACT), then re-run this gate."
+          warn "       Flip-test the wiring live with: ruby scripts/probe-controls.rb --workbook-id #{wb_id}"
+          warn "       Escape hatch (legacy workbooks only): --skip-control-lint."
+          exit 9
+        end
+        n_controls = ControlLint.controls_report(spec).length
+        puts "[OK] gate 7/7: control lint clean (#{n_controls} control(s); no dead controls, no ghost " \
+             "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
+      else
+        warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+puts "[OK] all gates pass — conversion may declare GREEN"
+exit 0

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/build_datamodel.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/build_datamodel.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Build + validate a Strategy One Data Model ("Orders Data Model") via REST.
+
+Flow (all learned by probing; see final report):
+  Phase A  dataServer workspace -> per-table pipelines (this is the ONLY way to
+           bind a data-model table to a datasource; classic physical tables are
+           rejected with "not from pipeline").
+  Phase B  one changeset: create DM (connect_live) + 4 tables + attributes
+           (+ hierarchy relationships) + factMetrics, then commit.  An EMPTY
+           data model cannot be committed, so DM + tables share a changeset.
+  Phase C  second changeset: /metrics (token text resolves committed names).
+  Phase D  publish (instances -> publish -> poll publishStatus).
+  Phase E  query validation via /api/v2/cubes/{id}/instances (revenue by region).
+
+State in datamodel_ids.json; re-running skips completed phases.
+NOTE: /links is cross-data-model only — in-model joins come from shared
+multi-table key attributes (Store/Product/Day below).
+"""
+import json
+import sys
+import time
+
+import mstr, os
+
+DS = os.environ['MSTR_DATASOURCE_ID']  # Snowflake datasource (GET /api/datasources)
+TABLES = ['ORDER_FACT', 'PRODUCT_DIM', 'STORE_DIM', 'DATE_DIM']
+STATE_PATH = 'datamodel_ids.json'
+
+s = mstr.Session()
+try:
+    state = json.load(open(STATE_PATH))
+except FileNotFoundError:
+    state = {'tables': {}, 'attributes': {}, 'factMetrics': {}, 'metrics': {}}
+
+
+def save():
+    json.dump(state, open(STATE_PATH, 'w'), indent=1)
+
+
+# ---------- Phase A: pipelines ----------
+def make_pipelines():
+    wid = s.post('/dataServer/workspaces', {})['id']
+    pipelines = {}
+    for t in TABLES:
+        p = s.post(f'/dataServer/workspaces/{wid}/pipelines', {})
+        pid = p['id']
+        s.post(f'/dataServer/workspaces/{wid}/pipelines/{pid}/tables',
+               {'type': 'source', 'name': t,
+                'importSource': {'type': 'single_table', 'dataSourceId': DS,
+                                 'namespace': 'TJ', 'tableName': t}})
+        pipelines[t] = s.get(f'/dataServer/workspaces/{wid}/pipelines/{pid}')
+        print('pipeline', t, 'ok')
+    return pipelines
+
+
+# ---------- Phase B: DM + tables + attributes + factMetrics ----------
+def tref(name):
+    return {'objectId': state['tables'][name], 'subType': 'logical_table',
+            'name': name}
+
+
+def aref(name):
+    return {'objectId': state['attributes'][name], 'subType': 'attribute',
+            'name': name}
+
+
+def form(name, fmt, exprs, lookup, category=None):
+    """exprs: list of (column, table)."""
+    f = {'name': name, 'displayFormat': fmt, 'lookupTable': tref(lookup),
+         'expressions': [{'expression': {'tokens': [{'value': col}]},
+                          'tables': [tref(t)]} for col, t in exprs]}
+    if category:
+        f['category'] = category
+    return f
+
+
+def build_core(cs):
+    pipelines = make_pipelines()
+    # destinationFolderId is REQUIRED at commit time ("The destination folder
+    # is not provided"), even though POST succeeds without it.
+    reports_folder = json.load(open('folder_ids.json'))['reports']
+    r = s.cs_post('/model/dataModels',
+                  {'information': {'name': 'Orders Data Model',
+                                   'destinationFolderId': reports_folder},
+                   'dataServeMode': 'connect_live'}, cs)
+    state['dataModelId'] = r['information']['objectId']
+    state['schemaFolderId'] = r.get('schemaFolderId')
+    dm = state['dataModelId']
+    print('dataModel:', dm)
+
+    for t in TABLES:
+        rt = s.cs_post(f'/model/dataModels/{dm}/tables',
+                       {'information': {'name': t},
+                        'physicalTable': {'pipeline': json.dumps(pipelines[t])}},
+                       cs)
+        state['tables'][t] = rt['information']['objectId']
+        print('table', t, '->', state['tables'][t])
+
+    # (name, lookup, forms, display form, parent-or-None)
+    attrs = [
+        ('Region', 'STORE_DIM',
+         [form('ID', 'text', [('REGION', 'STORE_DIM')], 'STORE_DIM', 'ID')],
+         'ID', None),
+        ('Category', 'PRODUCT_DIM',
+         [form('ID', 'text', [('CATEGORY', 'PRODUCT_DIM')], 'PRODUCT_DIM', 'ID')],
+         'ID', None),
+        ('Year', 'DATE_DIM',
+         [form('ID', 'number', [('YEAR', 'DATE_DIM')], 'DATE_DIM', 'ID')],
+         'ID', None),
+        ('Month', 'DATE_DIM',
+         [form('ID', 'number', [('MONTH_NUMBER', 'DATE_DIM')], 'DATE_DIM', 'ID'),
+          form('DESC', 'text', [('MONTH_NAME', 'DATE_DIM')], 'DATE_DIM', 'DESC')],
+         'DESC', 'Year'),
+        # multi-table key attributes below carry the star joins
+        ('Store', 'STORE_DIM',
+         [form('ID', 'number', [('STORE_KEY', 'STORE_DIM'),
+                                ('ORDER_STORE_KEY', 'ORDER_FACT')],
+               'STORE_DIM', 'ID'),
+          form('DESC', 'text', [('STORE_NAME', 'STORE_DIM')], 'STORE_DIM', 'DESC')],
+         'DESC', 'Region'),
+        ('Product', 'PRODUCT_DIM',
+         [form('ID', 'number', [('PRODUCT_KEY', 'PRODUCT_DIM'),
+                                ('PRODUCT_KEY', 'ORDER_FACT')],
+               'PRODUCT_DIM', 'ID'),
+          form('DESC', 'text', [('PRODUCT_NAME', 'PRODUCT_DIM')], 'PRODUCT_DIM',
+               'DESC')],
+         'DESC', 'Category'),
+        ('Day', 'DATE_DIM',
+         [form('ID', 'number', [('DATE_KEY', 'DATE_DIM'),
+                                ('ORDER_DATE_KEY', 'ORDER_FACT')],
+               'DATE_DIM', 'ID'),
+          form('DESC', 'date', [('FULL_DATE', 'DATE_DIM')], 'DATE_DIM', 'DESC')],
+         'DESC', 'Month'),
+        ('Order Channel', 'ORDER_FACT',
+         [form('ID', 'text', [('ORDER_CHANNEL', 'ORDER_FACT')], 'ORDER_FACT',
+               'ID')],
+         'ID', None),
+    ]
+    rels = []
+    for name, lookup, forms, disp, parent in attrs:
+        body = {'information': {'name': name}, 'forms': forms,
+                'attributeLookupTable': tref(lookup),
+                'keyForm': {'name': forms[0]['name']},
+                'displays': {'reportDisplays': [{'name': disp}],
+                             'browseDisplays': [{'name': disp}]}}
+        ra = s.cs_post(f'/model/dataModels/{dm}/attributes', body, cs)
+        state['attributes'][name] = ra['information']['objectId']
+        print('attribute', name, '->', state['attributes'][name])
+        if parent:
+            rels.append((name, parent, lookup))
+
+    for child, parent, table in rels:
+        body = {'relationships': [{'parent': aref(parent), 'child': aref(child),
+                                   'relationshipTable': tref(table),
+                                   'relationshipType': 'one_to_many'}]}
+        s.put(f'/model/dataModels/{dm}/attributes/'
+              f'{state["attributes"][child]}/relationships',
+              body, headers={'X-MSTR-MS-Changeset': cs})
+        print('relationship', parent, '>', child)
+
+    fms = [
+        ('NET_REVENUE', 'NET_REVENUE', 'sum',
+         {'type': 'double', 'precision': 8, 'scale': 2}, None),
+        ('GROSS_PROFIT', 'GROSS_PROFIT', 'sum',
+         {'type': 'double', 'precision': 8, 'scale': 2}, None),
+        ('QUANTITY_ORDERED', 'QUANTITY_ORDERED', 'sum',
+         {'type': 'int64', 'precision': 8, 'scale': 0}, None),
+        ('ORDER_ID', 'ORDER_ID', 'count',
+         {'type': 'utf8_char', 'precision': 20, 'scale': 0},
+         [{'name': 'Distinct', 'value': {'type': 'boolean', 'value': 'true'}}]),
+    ]
+    for name, col, fn, dt, props in fms:
+        body = {'information': {'name': name},
+                'fact': {'dataType': dt,
+                         'expressions': [{'expression': {'tokens': [{'value': col}]},
+                                          'tables': [tref('ORDER_FACT')]}]},
+                'function': fn}
+        if props:
+            body['functionProperties'] = props
+        try:
+            rf = s.cs_post(f'/model/dataModels/{dm}/factMetrics', body, cs)
+        except RuntimeError as e:
+            if props:
+                print('factMetric', name, 'with Distinct failed:', str(e)[:200])
+                body.pop('functionProperties')
+                rf = s.cs_post(f'/model/dataModels/{dm}/factMetrics', body, cs)
+            else:
+                raise
+        state['factMetrics'][name] = rf['information']['objectId']
+        print('factMetric', name, '->', state['factMetrics'][name])
+
+
+# ---------- Phase C: metrics ----------
+def build_metrics(cs):
+    dm = state['dataModelId']
+    metrics = [
+        ('Total Net Revenue', ['Sum([NET_REVENUE]) {~}',
+                               '[NET_REVENUE]']),
+        ('Total Gross Profit', ['Sum([GROSS_PROFIT]) {~}',
+                                '[GROSS_PROFIT]']),
+        ('Order Count', ['Count<Distinct=True>([ORDER_ID]) {~}',
+                         '[ORDER_ID]']),
+    ]
+    for name, variants in metrics:
+        if name in state['metrics']:
+            continue
+        last = None
+        for v in variants:
+            body = {'information': {'name': name},
+                    'expression': {'tokens': [{'value': v}]}}
+            try:
+                rm = s.cs_post(f'/model/dataModels/{dm}/metrics', body, cs)
+                state['metrics'][name] = rm['information']['objectId']
+                print('metric', name, '->', state['metrics'][name],
+                      'formula:', v)
+                last = None
+                break
+            except RuntimeError as e:
+                last = e
+                print('metric', name, 'variant failed:', v, '|', str(e)[:200])
+        if last:
+            raise last
+
+
+# ---------- Phase D: publish ----------
+def publish():
+    dm = state['dataModelId']
+    s.post(f'/dataModels/{dm}/instances')
+    inst = (s.last_headers.get('x-mstr-ms-instance')
+            or s.last_headers.get('x-mstr-datamodelinstanceid'))
+    print('instance:', inst, {k: v for k, v in s.last_headers.items()
+                              if 'mstr' in k})
+    body = {'tables': [{'id': tid, 'refreshPolicy': 'replace'}
+                       for tid in state['tables'].values()]}
+    try:
+        s.post(f'/dataModels/{dm}/publish', body,
+               headers={'X-MSTR-DataModelInstanceId': inst})
+    except RuntimeError as e:
+        if 'no publish workflow' in str(e):
+            # connect_live data models are live — nothing to publish
+            print('publish skipped:', str(e)[:120])
+            state['published'] = 'skipped (connect_live has no publish workflow)'
+            return
+    for _ in range(60):
+        st = s.get(f'/dataModels/{dm}/publishStatus')
+        print('publishStatus:', json.dumps(st)[:200])
+        if st.get('status') == 1:   # DssXmlStatusResult = ready
+            break
+        time.sleep(2)
+    state['published'] = True
+
+
+# ---------- Phase E: query validation ----------
+def query():
+    dm = state['dataModelId']
+    body = {'requestedObjects': {
+        'attributes': [{'id': state['attributes']['Region']}],
+        'metrics': [{'id': state['metrics']['Total Net Revenue']},
+                    {'id': state['metrics']['Order Count']}]}}
+    out = s.post(f'/v2/cubes/{dm}/instances', body)
+    # connect_live executes synchronously: status==1 with data inline.
+    # (GET /v2/cubes/{id}/instances/{iid}/status 500s "Catastrophic failure"
+    # for these instances — do not poll.)
+    iid = out['instanceId']
+    for _ in range(30):
+        if out.get('status') == 1 and 'data' in out:
+            break
+        time.sleep(1)
+        out = s.get(f'/v2/cubes/{dm}/instances/{iid}')
+    json.dump(out, open('query_validation.json', 'w'), indent=1)
+    rows = out['data']['headers']['rows']
+    attr_el = out['definition']['grid']['rows'][0]['elements']
+    vals = out['data']['metricValues']['raw']
+    print('\nRevenue by Region (live Snowflake via data model):')
+    for i, hr in enumerate(rows):
+        region = attr_el[hr[0]]['formValues'][0]
+        print(f'  {region:10s}  net_rev={vals[i][0]:>10}  orders={vals[i][1]}')
+    return out
+
+
+if __name__ == '__main__':
+    step = sys.argv[1] if len(sys.argv) > 1 else 'all'
+    if 'dataModelId' not in state and step in ('all', 'core'):
+        cs = s.changeset(schema_edit=False)
+        try:
+            build_core(cs)
+        except Exception:
+            s.abort(cs)
+            state.pop('dataModelId', None)
+            state['tables'].clear(); state['attributes'].clear()
+            state['factMetrics'].clear()
+            raise
+        s.commit(cs)
+        save()
+        print('core committed')
+    if step in ('all', 'metrics') and len(state['metrics']) < 3:
+        cs = s.changeset(schema_edit=False)
+        try:
+            build_metrics(cs)
+        except Exception:
+            s.abort(cs)
+            raise
+        s.commit(cs)
+        save()
+        print('metrics committed')
+    if step in ('all', 'publish') and not state.get('published'):
+        publish()
+        save()
+    if step in ('all', 'query'):
+        query()

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/convert.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/convert.py
@@ -1,0 +1,1164 @@
+#!/usr/bin/env python3
+"""
+convert.py — MicroStrategy bundle.json -> Sigma data-model spec + workbook spec.
+
+Everything is derived programmatically from the bundle:
+  - Sources: every logical table in bundle["tables"], path [<database>, <namespace>, <tableName>].
+  - Base/fact table: the logical table that carries fact expressions.
+  - Joins: attributes whose ID (key) form has expressions mapped to BOTH the fact
+    table and a different lookup table that is present in the bundle. The fact-side
+    expression and the lookup-side expression become the left/right join keys.
+  - Metrics: parsed from bundle["metrics"] expression tokens (function + fact /
+    metric object references + Distinct=True parameter -> CountDistinct).
+  - Workbook pages: one page per dossier chapter; each chapter's dataset report's
+    dataTemplate units give the grouping attributes + metric columns.
+  - Controls: dossier chapter filters + page/panel selectors -> Sigma controls.
+    MSTR selectors DECLARE their targets (targets: [{key}] viz refs) — the
+    strongest source-scope signal of any BI tool — so each control's filter
+    targets are wired to exactly the table elements built from the declared
+    vizzes (chapter filters reach every viz in their chapter). The intended
+    scope is emitted as control-scope.json (contract:
+    scripts/lib/control_lint.rb header + refs/control-parity.md).
+  - Layout: container-banded pages (header band titled from the chapter /
+    dossier name, controls band, full-width tables) -> layout.xml, applied
+    after the workbook POST via scripts/put-layout.rb.
+
+Usage:
+  python3 convert.py --connection-id <uuid> --database CSA --folder-id <uuid> \
+      [--inode-map inodes.json] [--bundle bundle.json] \
+      [--dm-name "..."] [--wb-name "..."] \
+      [--data-model-id <uuid>] [--orders-element-id <id>]
+
+Outputs sigma_dm_spec.json and sigma_workbook_spec.json. The workbook spec uses
+placeholders {{DATA_MODEL_ID}} / {{ORDERS_ELEMENT_ID}} unless the corresponding
+args are given.
+"""
+import argparse
+import json
+import re
+
+
+def friendly(col: str) -> str:
+    """Sigma friendly-name normalization for ALL_CAPS_UNDERSCORE warehouse names."""
+    return " ".join(p.capitalize() for p in col.split("_"))
+
+
+def slug(s: str) -> str:
+    return re.sub(r"[^a-z0-9]+", "-", s.lower()).strip("-")
+
+
+# ---------------------------------------------------------------- bundle model
+class Bundle:
+    def __init__(self, raw):
+        self.raw = raw
+        self.tables = raw["tables"]          # logical table id -> def
+        self.attributes = raw["attributes"]  # attribute id -> def
+        self.metrics = raw["metrics"]        # metric id -> def
+        self.facts = raw["facts"]            # fact id -> def
+        self.reports = raw["reports"]
+        self.dossier = raw["dossier"]
+
+        # logical table id -> (name, schema/namespace, physical table name)
+        self.table_info = {}
+        for tid, t in self.tables.items():
+            pt = t["physicalTable"]
+            self.table_info[tid] = {
+                "name": t["information"]["name"],
+                "tableName": pt["tableName"],
+                "namespace": pt.get("namespace"),
+            }
+
+        # fact table = the logical table that carries fact expressions
+        fact_tids = set()
+        for f in self.facts.values():
+            for de in f["expressions"]:
+                for tb in de.get("tables", []):
+                    fact_tids.add(tb["objectId"])
+        if len(fact_tids) != 1:
+            raise SystemExit(f"expected exactly 1 fact table, found {fact_tids}")
+        self.fact_tid = next(iter(fact_tids))
+
+        # per logical table: attribute id -> list of forms
+        #   form := {category, expr(column), isKeyForm}
+        self.table_attr_forms = {}   # tid -> {attr_id: [form,...]}
+        for tid, t in self.tables.items():
+            am = {}
+            for a in t.get("attributes", []):
+                aid = a["information"]["objectId"]
+                forms = []
+                for f in a.get("forms", []):
+                    forms.append({
+                        "category": f["formCategory"]["name"],
+                        "expr": f["expression"]["text"],
+                        "isKeyForm": f.get("isKeyForm", False),
+                        "lookupTable": f["lookupTable"]["objectId"],
+                    })
+                am[aid] = forms
+            self.table_attr_forms[tid] = am
+
+        # fact id -> physical column on the fact table
+        self.fact_col = {}
+        for fid, f in self.facts.items():
+            for de in f["expressions"]:
+                for tb in de.get("tables", []):
+                    if tb["objectId"] == self.fact_tid:
+                        self.fact_col[fid] = de["expression"]["text"]
+        # name -> fact id (metric text sometimes references facts by bare name)
+        self.fact_by_name = {f["information"]["name"]: fid
+                             for fid, f in self.facts.items()}
+        self.metric_by_name = {m["information"]["name"]: mid
+                               for mid, m in self.metrics.items()}
+
+    # ---- joins: attribute key form mapped to BOTH fact table and lookup table
+    def derive_joins(self):
+        joins = []
+        fact_forms = self.table_attr_forms[self.fact_tid]
+        for aid, forms in fact_forms.items():
+            key_fact = next((f for f in forms if f["isKeyForm"]), None)
+            if not key_fact:
+                continue
+            lookup_tid = key_fact["lookupTable"]
+            if lookup_tid == self.fact_tid or lookup_tid not in self.tables:
+                continue  # degenerate (fact-resident attr) or table not extracted
+            lookup_forms = self.table_attr_forms.get(lookup_tid, {}).get(aid, [])
+            key_lookup = next((f for f in lookup_forms if f["isKeyForm"]), None)
+            if not key_lookup:
+                continue
+            joins.append({
+                "attribute": aid,
+                "lookup_tid": lookup_tid,
+                "fact_col": key_fact["expr"],
+                "lookup_col": key_lookup["expr"],
+            })
+        return joins
+
+    # ---- columns each table contributes (any expression mapped to it)
+    def table_columns(self, tid):
+        cols = []
+        seen = set()
+        for aid, forms in self.table_attr_forms.get(tid, {}).items():
+            for f in forms:
+                c = f["expr"]
+                if f["lookupTable"] == tid and c not in seen:
+                    seen.add(c)
+                    cols.append(c)
+        if tid == self.fact_tid:
+            for fid, c in self.fact_col.items():
+                if c not in seen:
+                    seen.add(c)
+                    cols.append(c)
+            # join keys on the fact side
+            for j in self.derive_joins():
+                if j["fact_col"] not in seen:
+                    seen.add(j["fact_col"])
+                    cols.append(j["fact_col"])
+        return cols
+
+    # ---- metric expression -> Sigma formula
+    def metric_formula(self, mid, ref, expand_metrics=False):
+        """ref(column_friendly) -> bracketed reference string.
+        expand_metrics: inline referenced metrics (workbook context) instead of
+        emitting [Metric Name] (data-model context)."""
+        m = self.metrics[mid]
+        toks = m["expression"]["tokens"]
+        out = []
+        i = 0
+        while i < len(toks):
+            t = toks[i]
+            v, ty = t.get("value"), t.get("type")
+            if ty == "function" and v not in ("=",):
+                fname = v
+                # peek a <...> parameter block for Distinct=True
+                j = i + 1
+                distinct = False
+                if j < len(toks) and toks[j].get("value") == "<":
+                    while j < len(toks) and toks[j].get("value") != ">":
+                        if (toks[j].get("value") == "Distinct"
+                                and j + 2 < len(toks)
+                                and toks[j + 2].get("value") == "True"):
+                            distinct = True
+                        j += 1
+                    i = j  # skip past the parameter block
+                if fname == "Count" and distinct:
+                    fname = "CountDistinct"
+                out.append(fname)
+            elif ty == "object_reference":
+                tgt = t.get("target", {})
+                sub = tgt.get("subType")
+                oid = tgt.get("objectId")
+                if sub == "fact":
+                    out.append(ref(friendly(self.fact_col[oid])))
+                elif sub == "metric":
+                    if expand_metrics:
+                        out.append("(" + self.metric_formula(
+                            oid, ref, expand_metrics=True) + ")")
+                    else:
+                        out.append(f"[{self.metrics[oid]['information']['name']}]")
+                else:
+                    raise SystemExit(f"unhandled object_reference {sub} in metric "
+                                     f"{m['information']['name']}")
+            elif ty == "character":
+                if v in ("<", ">"):
+                    pass  # parameter block delimiters already handled
+                elif v in ("(", ")", ",", "+", "-", "*", "/"):
+                    out.append(v)
+            elif ty == "identifier" or ty == "boolean":
+                pass  # parameter names/values inside <...>
+            i += 1
+        # join with spaces around operators, none around parens
+        f = ""
+        for tok in out:
+            if tok in ("+", "-", "*", "/"):
+                f += f" {tok} "
+            elif tok == ",":
+                f += ", "
+            else:
+                f += tok
+        return f
+
+    # ---- metric expression -> warehouse SQL (for AE-emulation sql elements)
+    def metric_sql(self, mid, fact_alias="ORDER_FACT"):
+        m = self.metrics[mid]
+        toks = m["expression"]["tokens"]
+        FN = {"Sum": "SUM", "Count": "COUNT", "Avg": "AVG", "Max": "MAX",
+              "Min": "MIN"}
+        out = []
+        distinct_pending = False
+        i = 0
+        while i < len(toks):
+            t = toks[i]
+            v, ty = t.get("value"), t.get("type")
+            if ty == "function" and v not in ("=",):
+                fname, distinct = v, False
+                j = i + 1
+                if j < len(toks) and toks[j].get("value") == "<":
+                    while j < len(toks) and toks[j].get("value") != ">":
+                        if (toks[j].get("value") == "Distinct"
+                                and j + 2 < len(toks)
+                                and toks[j + 2].get("value") == "True"):
+                            distinct = True
+                        j += 1
+                    i = j
+                out.append(FN.get(fname, fname.upper()))
+                distinct_pending = distinct
+            elif ty == "object_reference":
+                tgt = t.get("target", {})
+                if tgt.get("subType") == "fact":
+                    out.append(f"{fact_alias}.{self.fact_col[tgt['objectId']]}")
+                elif tgt.get("subType") == "metric":
+                    out.append("(" + self.metric_sql(tgt["objectId"],
+                                                     fact_alias) + ")")
+            elif ty == "character":
+                if v == "(":
+                    out.append("(DISTINCT " if distinct_pending else "(")
+                    distinct_pending = False
+                elif v in (")", ",", "+", "-", "*", "/"):
+                    out.append(v)
+        # NB: '<'/'>' parameter blocks skipped above
+            i += 1
+        sql = ""
+        for tok in out:
+            if tok in ("+", "-", "*", "/"):
+                sql += f" {tok} "
+            elif tok == ",":
+                sql += ", "
+            else:
+                sql += tok
+        return sql
+
+    # ---- clean per-(attribute keys) aggregation SQL for a report
+    def report_attr_units(self, report):
+        units = report["dataSource"]["dataTemplate"]["units"]
+        return ([u for u in units if u.get("type") == "attribute"],
+                [el for u in units if u.get("type") == "metrics"
+                 for el in u["elements"]])
+
+    def clean_group_aliases(self, report):
+        attr_units, metric_units = self.report_attr_units(report)
+        aliases = []
+        for u in attr_units:
+            key_col, desc_col = self.attribute_unit_cols(u["id"])
+            aliases.append(friendly(key_col))
+            if desc_col:
+                aliases.append(friendly(desc_col))
+        aliases += [el["name"] for el in metric_units]
+        return aliases
+
+    def build_clean_group_sql(self, database, report):
+        """SELECT <attr keys>, MAX(<desc>) per desc form, <metric aggs>
+        FROM fact JOIN needed dims GROUP BY keys — the same statement
+        MicroStrategy generates for the report."""
+        attr_units, metric_units = self.report_attr_units(report)
+        fact = self.table_info[self.fact_tid]
+        fq = lambda tid: ".".join([database,
+                                   self.table_info[tid]["namespace"],
+                                   self.table_info[tid]["tableName"]])
+        joins_by_tid = {j["lookup_tid"]: j for j in self.derive_joins()}
+
+        select, group_pos, needed_tids = [], [], []
+        pos = 0
+        for u in attr_units:
+            key_col, desc_col = self.attribute_unit_cols(u["id"])
+            a = self.attributes[u["id"]]
+            lookup_tid = a["attributeLookupTable"]["objectId"]
+            alias = self.table_info[lookup_tid]["tableName"]
+            if lookup_tid != self.fact_tid and lookup_tid not in needed_tids:
+                needed_tids.append(lookup_tid)
+            pos += 1
+            select.append(f'{alias}.{key_col} AS "{friendly(key_col)}"')
+            group_pos.append(str(pos))
+            if desc_col:
+                pos += 1
+                select.append(f'MAX({alias}.{desc_col}) AS "{friendly(desc_col)}"')
+        for el in metric_units:
+            select.append(f'{self.metric_sql(el["id"], fact["tableName"])} '
+                          f'AS "{el["name"]}"')
+
+        from_sql = f'{fq(self.fact_tid)} {fact["tableName"]}'
+        for tid in needed_tids:
+            j = joins_by_tid[tid]
+            dim = self.table_info[tid]["tableName"]
+            from_sql += (f'\n  JOIN {fq(tid)} {dim} ON '
+                         f'{fact["tableName"]}.{j["fact_col"]} = '
+                         f'{dim}.{j["lookup_col"]}')
+        return ("SELECT " + ",\n       ".join(select)
+                + f"\nFROM {from_sql}\nGROUP BY " + ", ".join(group_pos))
+
+    def build_ae_sql(self, database, report, ae_cfg):
+        """AE-emulation: clean groups, then every parent-key row takes the
+        pinned representative row's label + metric values for its quirk key."""
+        attr_units, metric_units = self.report_attr_units(report)
+        qkey_f = friendly(ae_cfg["quirkKeyCol"])
+        qdesc_f = friendly(ae_cfg["quirkDescCol"])
+        parent_f = [friendly(c) for c in ae_cfg["parentKeyCols"]]
+
+        def lit(v):
+            s = str(v)
+            try:
+                float(s)
+                return s
+            except ValueError:
+                return "'" + s.replace("'", "''") + "'"
+
+        conds = []
+        for w in ae_cfg["winners"]:
+            parts = [f'w."{qkey_f}" = {lit(w[qkey_f])}']
+            parts += [f'w."{p}" = {lit(w[p])}' for p in parent_f]
+            conds.append("(" + " AND ".join(parts) + ")")
+
+        out_cols = [f'f."{p}" AS "{p}"' for p in parent_f]
+        out_cols.append(f'w."{qkey_f}" AS "{qkey_f}"')
+        out_cols.append(f'w."{qdesc_f}" AS "{qdesc_f}"')
+        out_cols += [f'w."{el["name"]}" AS "{el["name"]}"'
+                     for el in metric_units]
+        return (
+            "WITH F AS (\n" + self.build_clean_group_sql(database, report)
+            + "\n)\nSELECT " + ",\n       ".join(out_cols)
+            + f'\nFROM F f\nJOIN F w ON w."{qkey_f}" = f."{qkey_f}"\n  AND ('
+            + "\n    OR ".join(conds) + ")")
+
+    # ---- display format for a metric (MSTR bundle format blocks are empty,
+    # so derive from semantics: count/quantity -> integer, ratio/pct -> percent,
+    # money facts -> currency)
+    def metric_display_format(self, mid):
+        m = self.metrics[mid]
+        name = m["information"]["name"]
+        if re.search(r"pct|percent|margin|ratio|rate", name, re.I):
+            return {"kind": "number", "formatString": ",.2%"}
+        toks = m["expression"]["tokens"]
+        funcs = [t["value"] for t in toks if t.get("type") == "function"
+                 and t.get("value") not in ("=",)]
+        fact_cols = [self.fact_col[t["target"]["objectId"]] for t in toks
+                     if t.get("type") == "object_reference"
+                     and t.get("target", {}).get("subType") == "fact"]
+        if any(f.startswith("Count") for f in funcs):
+            return {"kind": "number", "formatString": ",.0f"}
+        if any(re.search(r"REVENUE|PROFIT|COST|AMOUNT|PRICE", c) for c in fact_cols):
+            return {"kind": "number", "formatString": "$,.2f"}
+        if any(re.search(r"QUANTITY|UNITS|COUNT", c) for c in fact_cols):
+            return {"kind": "number", "formatString": ",.0f"}
+        return None
+
+    # ---- dossier filter signals (chapter filters + selectors)
+    @staticmethod
+    def _walk_selectors(node):
+        """Selectors on a dossier page/panel, panelStacks walked recursively
+        (panels nest further panelStacks — same walk as the assessment)."""
+        out = list(node.get("selectors") or [])
+        for ps in node.get("panelStacks") or []:
+            for p in ps.get("panels") or []:
+                out.extend(Bundle._walk_selectors(p))
+        return out
+
+    @staticmethod
+    def _walk_viz_keys(node):
+        out = [v["key"] for v in node.get("visualizations") or [] if v.get("key")]
+        for ps in node.get("panelStacks") or []:
+            for p in ps.get("panels") or []:
+                out.extend(Bundle._walk_viz_keys(p))
+        return out
+
+    def filter_signals(self):
+        """Every filter-like signal in the dossier, normalized:
+        {kind: chapter-filter|selector, chapter, name, selectorType,
+         source_id, targets: [viz keys] or None (None = whole chapter)}.
+        Panel selectors are navigation, not data filters — returned with
+        kind=panel-selector so the caller can flag them MANUAL without
+        counting them as filter signals."""
+        signals = []
+        for ch in self.dossier.get("chapters", []):
+            for f in ch.get("filters") or []:
+                signals.append({
+                    "kind": "chapter-filter", "chapter": ch["name"],
+                    "name": f.get("name"), "key": f.get("key"),
+                    "source_id": (f.get("source") or {}).get("id"),
+                    "targets": None,
+                })
+            for pg in ch.get("pages") or []:
+                for sel in self._walk_selectors(pg):
+                    st = sel.get("selectorType", "")
+                    kind = ("panel-selector" if st.startswith("panel_selector")
+                            else "selector")
+                    signals.append({
+                        "kind": kind, "chapter": ch["name"],
+                        "name": sel.get("name"), "key": sel.get("key"),
+                        "selectorType": st,
+                        "source_id": (sel.get("source") or {}).get("id"),
+                        "targets": [t["key"] for t in sel.get("targets") or []]
+                                   or None,
+                    })
+        return signals
+
+    def viz_chapter(self):
+        """visualization key -> chapter name (declared selector targets are
+        viz keys; the converter builds one table element per chapter)."""
+        out = {}
+        for ch in self.dossier.get("chapters", []):
+            for pg in ch.get("pages") or []:
+                for k in self._walk_viz_keys(pg):
+                    out[k] = ch["name"]
+        return out
+
+    def resolve_attribute(self, source_id=None, name=None):
+        if source_id and source_id in self.attributes:
+            return source_id
+        if name:
+            for aid, a in self.attributes.items():
+                if a["information"]["name"] == name:
+                    return aid
+        return None
+
+    def attribute_ctl_type(self, aid):
+        """'date' | 'number' | 'text' for the column the control binds (the
+        rendered DESC form, falling back to the key). Drives the control
+        shape: a Sigma `list` control whose filter target is a DATETIME *or
+        NUMERIC* column posts 200 but Sigma SILENTLY STRIPS the target
+        (datetime: cross-plugin estate gotcha in refs/control-parity.md;
+        numeric: live-verified on this converter 2026-06-12 — re-PUTting the
+        filter returns 200 and reads back `filters: null`). Dates become
+        date-range controls; numbers bind through a hidden Text() cast."""
+        a = self.attributes[aid]
+        forms = a["forms"]
+        key = next((f for f in forms if f.get("category") == "ID"), forms[0])
+        desc = next((f for f in forms if f.get("category") == "DESC"), None)
+        f = desc or key  # the control filters the rendered (DESC) column
+        dt = ((f.get("dataType") or {}).get("type") or "").lower()
+        if dt in ("date", "time", "timestamp") or f.get("displayFormat") == "date":
+            return "date"
+        if dt and not any(t in dt for t in ("char", "text", "string", "binary")):
+            return "number"
+        return "text"
+
+    # ---- attribute key + display columns for a report unit
+    def attribute_unit_cols(self, aid):
+        """Returns (key_col, desc_col_or_None) physical column names.
+
+        MicroStrategy grids group by the attribute's KEY (ID) form and render
+        the DESC form. When the DESC form differs from the key, the rendered
+        label per element resolves to the max DESC value over the joined fact
+        rows — so the converter emits the key as the grouping column and the
+        DESC as a Max() calculation."""
+        a = self.attributes[aid]
+        forms = a["forms"]
+        key = next((f for f in forms if f.get("category") == "ID"), forms[0])
+        desc = next((f for f in forms if f.get("category") == "DESC"), None)
+        key_col = key["expressions"][0]["expression"]["text"]
+        desc_col = desc["expressions"][0]["expression"]["text"] if desc else None
+        return key_col, desc_col
+
+
+# ------------------------------------------------------------------- emitters
+def ae_element_name(report_name):
+    return f"{report_name} (MSTR AE)"
+
+
+def join_column_names(b: "Bundle"):
+    """Display names available on the consumable join element (mirrors
+    build_dm_spec's add_join_col walk)."""
+    names = {friendly(c) for c in b.table_columns(b.fact_tid)}
+    join_key_lookup = {(j["lookup_tid"], j["lookup_col"]) for j in b.derive_joins()}
+    for j in b.derive_joins():
+        for c in b.table_columns(j["lookup_tid"]):
+            if (j["lookup_tid"], c) in join_key_lookup:
+                continue
+            names.add(friendly(c))
+    return names
+
+
+# ---- dossier selectors / chapter filters -> Sigma controls ------------------
+def emit_controls(b: "Bundle", pages, page_ctx, warnings):
+    """Wire every dossier filter signal to Sigma controls (verified shapes:
+    refs/control-parity.md). MSTR selectors carry DECLARED viz targets, so
+    filter targets go to exactly the table elements built from those vizzes;
+    chapter filters cover every element on their chapter's page. Controls are
+    appended AFTER their target tables in spec order (POST requirement).
+    Returns (n_signals, scope_entries, unbound) for control-scope.json."""
+    viz_ch = b.viz_chapter()
+    scope_entries, unbound, used_ctl_ids = [], [], set()
+    n_signals = 0
+
+    def ctl_id_for(name):
+        base = re.sub(r"[^A-Za-z0-9]", "", str(name).title()) + "Filter"
+        cid, n = base, 2
+        while cid in used_ctl_ids:
+            cid, n = f"{base}{n}", n + 1
+        used_ctl_ids.add(cid)
+        return cid
+
+    def find_or_add_col(ctx, col, as_text=False):
+        """Column for `friendly(col)` on the target element — reuse the
+        grouping passthrough when present, else add a hidden passthrough.
+        as_text wraps the reference in Text() (always a fresh hidden column):
+        a list-control filter target on a NUMERIC column is silently stripped
+        by Sigma (200 on POST/PUT, `filters: null` on readback — live-
+        verified 2026-06-12), so numeric attribute selectors bind through a
+        text cast. Returns columnId or None when the element can't carry the
+        column."""
+        fr = friendly(col)
+        if fr not in ctx["available"]:
+            # the grouping column may still exist (e.g. AE alias) — check
+            if not any(c.get("formula") == ctx["ref"](fr)
+                       for c in ctx["element"]["columns"]):
+                return None
+        if as_text:
+            formula = f"Text({ctx['ref'](fr)})"
+            for c in ctx["element"]["columns"]:
+                if c.get("formula") == formula:
+                    return c["id"]
+            cid = f"ctlt-{slug(ctx['element']['id'])}-{slug(col)}"
+            ctx["element"]["columns"].append(
+                {"id": cid, "name": f"{fr} (Filter)", "formula": formula,
+                 "hidden": True})
+            return cid
+        formula = ctx["ref"](fr)
+        for c in ctx["element"]["columns"]:
+            if c.get("formula") == formula:
+                return c["id"]
+        cid = f"ctlc-{slug(ctx['element']['id'])}-{slug(col)}"
+        ctx["element"]["columns"].append(
+            {"id": cid, "name": fr, "formula": formula, "hidden": True})
+        return cid
+
+    for sig in b.filter_signals():
+        label = sig.get("name") or "Selector"
+        src = f"{sig['kind']} '{label}' (chapter '{sig['chapter']}')"
+        if sig["kind"] == "panel-selector":
+            # navigation between panels, not a data filter — flagged MANUAL,
+            # not counted as a filter signal
+            unbound.append({"sourceName": src, "status": "manual",
+                            "reason": "panel selector switches panels (navigation), "
+                                      "not a data filter — no Sigma control emitted; "
+                                      "panels land as separate elements"})
+            continue
+        n_signals += 1
+        st = sig.get("selectorType", "")
+        aid = b.resolve_attribute(sig.get("source_id"), sig.get("name"))
+        if aid is None:
+            reason = ("metric qualification selector — Sigma has no direct "
+                      "equivalent; port by hand (e.g. a number-range control "
+                      "wired to the metric's base column)"
+                      if "metric" in st else
+                      "source attribute not resolvable in the bundle — wire "
+                      "manually rather than guessing a column")
+            warnings.append(f"control {src}: {reason}")
+            unbound.append({"sourceName": src, "status": "unbound",
+                            "reason": reason})
+            continue
+
+        # targets: declared viz keys -> chapter tables; none -> own chapter
+        if sig["targets"]:
+            tgt_chapters, dropped = [], []
+            for k in sig["targets"]:
+                (tgt_chapters if k in viz_ch else dropped).append(
+                    viz_ch.get(k, k))
+            if dropped:
+                warnings.append(f"control {src}: declared target viz key(s) "
+                                f"{dropped} not found in the dossier — skipped")
+            tgt_chapters = list(dict.fromkeys(tgt_chapters))
+        else:
+            tgt_chapters = [sig["chapter"]]
+        ctxs = [page_ctx[c] for c in tgt_chapters if c in page_ctx]
+        if not ctxs:
+            warnings.append(f"control {src}: no target elements resolvable — "
+                            "not emitted")
+            unbound.append({"sourceName": src, "status": "unbound",
+                            "reason": "declared targets resolve to no built element"})
+            continue
+
+        key_col, desc_col = b.attribute_unit_cols(aid)
+        ctl_col = desc_col or key_col   # what MSTR renders in the selector
+        ctl_type = b.attribute_ctl_type(aid)
+        filters, wired = [], []
+        for ctx in ctxs:
+            cid = find_or_add_col(ctx, ctl_col, as_text=(ctl_type == "number"))
+            if cid is None:
+                warnings.append(
+                    f"control {src}: column {friendly(ctl_col)!r} not available "
+                    f"on element '{ctx['element']['name']}' — target skipped")
+                continue
+            filters.append({"source": {"kind": "table",
+                                       "elementId": ctx["element"]["id"]},
+                            "columnId": cid})
+            wired.append({"elementId": ctx["element"]["id"], "columnId": cid})
+        if not filters:
+            unbound.append({"sourceName": src, "status": "unbound",
+                            "reason": f"column {friendly(ctl_col)!r} not on any "
+                                      "target element — dropped loudly rather "
+                                      "than wired to a wrong column"})
+            continue
+
+        ctl = {"id": f"ctl-{slug(sig['chapter'])}-{slug(label)}",
+               "kind": "control", "controlId": ctl_id_for(label),
+               "name": label,
+               "filters": filters}
+        if ctl_type == "date":
+            # date-range needs no `source` but DOES require a flat `mode` —
+            # without it the POST fails with the misleading "Invalid kind:
+            # control" (live-verified cross-plugin; see control-parity.md)
+            ctl.update({"controlType": "date-range", "mode": "between",
+                        "includeNulls": "when-no-value-is-selected"})
+        else:
+            ctl.update({"controlType": "list", "mode": "include",
+                        "selectionMode": "multiple", "values": [],
+                        "source": {"kind": "source",
+                                   "source": filters[0]["source"],
+                                   "columnId": filters[0]["columnId"]}})
+
+        # the control lives on its own chapter's page, AFTER the tables
+        home = page_ctx[sig["chapter"]]["page"]
+        home["elements"].append(ctl)
+
+        # CONTRACT entry (lib/control_lint.rb header): declared targets that
+        # cover every queryable element on the control's page = scope "page";
+        # a narrower declared set = the scope allowlist (selector-scoped-by-
+        # design). mustReach always asserts the DECLARED targets.
+        target_ids = [c["element"]["id"] for c in ctxs]
+        page_tables = [e["id"] for e in home["elements"]
+                       if e.get("kind") == "table"]
+        full_page = set(page_tables) <= set(target_ids)
+        scope_entries.append({
+            "controlId": ctl["controlId"], "sourceName": src,
+            "status": "wired", "controlType": ctl["controlType"],
+            "scope": "page" if full_page else target_ids,
+            "mustReach": target_ids, "wired": wired,
+        })
+    return n_signals, scope_entries, unbound
+
+
+# ---- container-banded layout (layout-playbook.md shapes, shared across
+# plugins; python port of the qlik builder's banded_page) ---------------------
+HEADER_STYLE = {"backgroundColor": "#0F172A", "borderRadius": "round"}
+HEADER_ROWS = 3
+GENERIC_TITLE = re.compile(r"^(?:page|sheet|dashboard)\s*\d+$", re.I)
+
+
+def _le(eid, c0, c1, r0, r1):
+    return (f'  <LayoutElement elementId="{eid}" gridColumn="{c0} / {c1}" '
+            f'gridRow="{r0} / {r1}"/>')
+
+
+def _gc(cid, c0, c1, r0, r1, inner):
+    return (f'<GridContainer elementId="{cid}" type="grid" '
+            f'gridColumn="{c0} / {c1}" gridRow="{r0} / {r1}" '
+            f'gridTemplateColumns="repeat(24, 1fr)" '
+            f'gridTemplateRows="auto">\n{inner}\n</GridContainer>')
+
+
+def _cluster_bands(items):
+    bands = []
+    for it in sorted(items, key=lambda i: (i[3], i[1])):
+        if bands and it[3] < bands[-1]["r1"]:
+            bands[-1]["items"].append(it)
+            bands[-1]["r1"] = max(bands[-1]["r1"], it[4])
+        else:
+            bands.append({"r0": it[3], "r1": it[4], "items": [it]})
+    return [bb["items"] for bb in bands]
+
+
+def banded_page(page_id, items, title, id_prefix=None):
+    """Header band + one full-width GridContainer per row band, children
+    container-relative. Returns (page_xml, extra_spec_elements)."""
+    pfx = id_prefix or f"band-{page_id}"
+    extra, children = [], []
+    offset = 0
+    if title:
+        hdr, txt = f"{pfx}-hdr", f"{pfx}-hdrtext"
+        extra.append({"id": hdr, "kind": "container",
+                      "style": dict(HEADER_STYLE)})
+        extra.append({"id": txt, "kind": "text",
+                      "body": f'# <span style="color: #FFFFFF">{title}</span>'})
+        children.append(_gc(hdr, 1, 25, 1, 1 + HEADER_ROWS,
+                            _le(txt, 1, 25, 1, 1 + HEADER_ROWS)))
+        offset = HEADER_ROWS
+    if items:
+        offset += 1 - min(i[3] for i in items)
+    for n, band in enumerate(_cluster_bands(items), 1):
+        cid = f"{pfx}-{n}"
+        extra.append({"id": cid, "kind": "container"})
+        r0 = min(i[3] for i in band)
+        r1 = max(i[4] for i in band)
+        inner = "\n".join(_le(i[0], i[1], i[2], i[3] - r0 + 1, i[4] - r0 + 1)
+                          for i in band)
+        children.append(_gc(cid, 1, 25, r0 + offset, r1 + offset, inner))
+    body = "\n".join(children)
+    return (f'<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" '
+            f'gridTemplateRows="auto" id="{page_id}">\n{body}\n</Page>', extra)
+
+
+def build_layout(pages, dossier_name):
+    """Banded layout for every workbook page: controls band (split evenly),
+    then full-width tables. Header title = the chapter name (never a generic
+    "Page N" auto-name — those fall back to the dossier name). Mutates each
+    page's elements to add the container/header placeholders and returns the
+    layout XML for scripts/put-layout.rb."""
+    xml_pages = []
+    for pg in pages:
+        ctls = [e for e in pg["elements"] if e.get("kind") == "control"]
+        tables = [e for e in pg["elements"] if e.get("kind") != "control"]
+        items, row = [], 1
+        if ctls:
+            w = 24 // len(ctls)
+            for i, e in enumerate(ctls):
+                c0 = 1 + i * w
+                c1 = c0 + w if i < len(ctls) - 1 else 25
+                items.append([e["id"], c0, c1, row, row + 3])
+            row += 3
+        for e in tables:
+            items.append([e["id"], 1, 25, row, row + 12])
+            row += 12
+        title = pg["name"]
+        if not title or GENERIC_TITLE.match(title.strip()):
+            title = dossier_name
+        xml, extra = banded_page(pg["id"], items, title)
+        pg["elements"] = pg["elements"] + extra
+        xml_pages.append(xml)
+    return ('<?xml version="1.0" encoding="utf-8"?>\n' + "\n".join(xml_pages))
+
+
+def build_dm_spec(b: Bundle, args, inode_map, ae_winners=None):
+    conn = args.connection_id
+    elements = []
+    el_id = {}    # tid -> element id
+    el_name = {}  # tid -> element name (= logical table name)
+
+    def col_id(tid, col):
+        tail = inode_map.get(b.table_info[tid]["tableName"])
+        if tail:
+            return f"inode-{tail}/{col}"
+        return f"{slug(b.table_info[tid]['name'])}-{slug(col)}"
+
+    for tid, info in b.table_info.items():
+        eid = f"el-{slug(info['name'])}"
+        el_id[tid], el_name[tid] = eid, info["name"]
+        cols = b.table_columns(tid)
+        elements.append({
+            "id": eid,
+            "kind": "table",
+            "name": info["name"],
+            "source": {
+                "kind": "warehouse-table",
+                "connectionId": conn,
+                "path": [args.database, info["namespace"], info["tableName"]],
+            },
+            "columns": [
+                {
+                    "id": col_id(tid, c),
+                    "name": friendly(c),
+                    "formula": f"[{info['tableName']}/{friendly(c)}]",
+                }
+                for c in cols
+            ],
+        })
+
+    # ---- join element (the consumable "Orders" view)
+    joins = b.derive_joins()
+    join_legs = [
+        {
+            "left": {"kind": "table", "elementId": el_id[b.fact_tid]},
+            "right": {"kind": "table", "elementId": el_id[j["lookup_tid"]]},
+            "columns": [{
+                "left": f"[{friendly(j['fact_col'])}]",
+                "right": f"[{friendly(j['lookup_col'])}]",
+            }],
+            "joinType": "left-outer",
+        }
+        for j in joins
+    ]
+
+    join_cols = []
+    seen_names = set()
+
+    def add_join_col(src_tid, col):
+        name = friendly(col)
+        if name in seen_names:
+            return
+        seen_names.add(name)
+        join_cols.append({
+            "id": f"ord-{slug(col)}",
+            "name": name,
+            "formula": f"[{el_name[src_tid]}/{name}]",
+        })
+
+    join_key_lookup_cols = {(j["lookup_tid"], j["lookup_col"]) for j in joins}
+    # fact columns first (skip nothing on the fact side)
+    for c in b.table_columns(b.fact_tid):
+        add_join_col(b.fact_tid, c)
+    # dim columns, skipping each join's own key column on the lookup side
+    for j in joins:
+        for c in b.table_columns(j["lookup_tid"]):
+            if (j["lookup_tid"], c) in join_key_lookup_cols:
+                continue
+            add_join_col(j["lookup_tid"], c)
+
+    # ---- metrics on the join element
+    def dm_ref(col_friendly):
+        return f"[{col_friendly}]"
+
+    metrics = []
+    for mid, m in b.metrics.items():
+        md = {
+            "id": f"m-{slug(m['information']['name'])}",
+            "name": m["information"]["name"],
+            "formula": b.metric_formula(mid, dm_ref, expand_metrics=False),
+        }
+        fmt = b.metric_display_format(mid)
+        if fmt:
+            md["format"] = fmt
+        metrics.append(md)
+
+    elements.append({
+        "id": "el-orders",
+        "kind": "table",
+        "name": args.join_element_name,
+        "source": {
+            "kind": "join",
+            "joins": join_legs,
+            "primarySource": {"kind": "table", "elementId": el_id[b.fact_tid]},
+        },
+        "columns": join_cols,
+        "metrics": metrics,
+    })
+
+    # ---- AE-emulation sql elements (MicroStrategy non-unique-key collapse)
+    report_by_name = {r["information"]["name"]: r for r in b.reports.values()}
+    for rname, cfg in (ae_winners or {}).items():
+        report = report_by_name[rname]
+        attr_units, metric_units = b.report_attr_units(report)
+        aliases = ([friendly(c) for c in cfg["parentKeyCols"]]
+                   + [friendly(cfg["quirkKeyCol"]), friendly(cfg["quirkDescCol"])]
+                   + [el["name"] for el in metric_units])
+        elements.append({
+            "id": f"el-ae-{slug(rname)}",
+            "kind": "table",
+            "name": ae_element_name(rname),
+            "source": {
+                "kind": "sql",
+                "connectionId": args.connection_id,
+                "statement": b.build_ae_sql(args.database, report, cfg),
+            },
+            "columns": [
+                {"id": f"ae-{slug(rname)}-{slug(a)}", "name": a,
+                 "formula": f"[Custom SQL/{a}]"}
+                for a in aliases
+            ],
+        })
+
+    return {
+        "name": args.dm_name,
+        "folderId": args.folder_id,
+        "schemaVersion": 1,
+        "pages": [{"id": "page-1", "name": "Model", "elements": elements}],
+    }
+
+
+def build_ae_page(b: Bundle, args, ch_name, report, cfg, dm_id, el_ref,
+                  report_keys):
+    """Page backed by the AE-emulation sql element. Groups by parent keys +
+    quirk key; label and metric values are already representative-resolved
+    in the element's SQL, so metric columns aggregate the (single) row with
+    Sum() and the label with Max()."""
+    rname = report["information"]["name"]
+    el_name = ae_element_name(rname)
+    _attr_units, metric_units = b.report_attr_units(report)
+    qkey_f = friendly(cfg["quirkKeyCol"])
+    qdesc_f = friendly(cfg["quirkDescCol"])
+    parent_f = [friendly(c) for c in cfg["parentKeyCols"]]
+
+    columns, group_ids, calc_ids = [], [], []
+    for p in parent_f:
+        cid = f"c-{slug(ch_name)}-{slug(p)}"
+        columns.append({"id": cid, "name": p, "formula": f"[{el_name}/{p}]"})
+        group_ids.append(cid)
+    kid = f"c-{slug(ch_name)}-{slug(qkey_f)}"
+    columns.append({"id": kid, "name": qkey_f,
+                    "formula": f"[{el_name}/{qkey_f}]"})
+    group_ids.append(kid)
+    did = f"c-{slug(ch_name)}-{slug(qdesc_f)}"
+    columns.append({"id": did, "name": qdesc_f,
+                    "formula": f"Max([{el_name}/{qdesc_f}])"})
+    calc_ids.append(did)
+    for el in metric_units:
+        mname = el["name"]
+        cid = f"c-{slug(ch_name)}-{slug(mname)}"
+        col = {"id": cid, "name": mname,
+               "formula": f"Sum([{el_name}/{mname}])"}
+        fmt = b.metric_display_format(el["id"])
+        if fmt:
+            col["format"] = fmt
+        columns.append(col)
+        calc_ids.append(cid)
+
+    report_keys[rname] = parent_f + [qdesc_f]
+    return {
+        "id": f"pg-{slug(ch_name)}",
+        "name": ch_name,
+        "elements": [{
+            "id": f"tbl-{slug(ch_name)}",
+            "kind": "table",
+            "name": rname,
+            "source": {"kind": "data-model", "dataModelId": dm_id,
+                       "elementId": el_ref(el_name)},
+            "columns": columns,
+            "groupings": [{
+                "id": f"g-{slug(ch_name)}",
+                "groupBy": group_ids,
+                "calculations": calc_ids,
+            }],
+        }],
+    }
+
+
+def build_workbook_spec(b: Bundle, args, ae_winners=None, dm_element_ids=None):
+    dm_id = args.data_model_id or "{{DATA_MODEL_ID}}"
+    dm_element_ids = dm_element_ids or {}
+    join_name = args.join_element_name
+
+    def el_ref(name):
+        if name == join_name and args.orders_element_id:
+            return args.orders_element_id
+        return dm_element_ids.get(name, "{{ELEMENT_" + slug(name) + "}}")
+
+    def wb_ref(col_friendly):
+        return f"[{join_name}/{col_friendly}]"
+
+    pages = []
+    report_keys = {}  # report name -> ordered display column names of its keys
+    page_ctx = {}     # chapter name -> {page, element, ref, available}
+    avail_join = join_column_names(b)
+    # chapter -> dataset/report mapping comes from the dossier datasets by name
+    report_by_name = {r["information"]["name"]: (rid, r)
+                      for rid, r in b.reports.items()}
+    for ch in b.dossier["chapters"]:
+        ch_name = ch["name"]
+        rid, report = report_by_name[ch_name]
+        rname = report["information"]["name"]
+        units = report["dataSource"]["dataTemplate"]["units"]
+
+        if ae_winners and rname in ae_winners:
+            page = build_ae_page(b, args, ch_name, report,
+                                 ae_winners[rname], dm_id, el_ref,
+                                 report_keys)
+            pages.append(page)
+            ae_name = ae_element_name(rname)
+            cfg = ae_winners[rname]
+            _au, metric_units = b.report_attr_units(report)
+            ae_avail = ({friendly(c) for c in cfg["parentKeyCols"]}
+                        | {friendly(cfg["quirkKeyCol"]),
+                           friendly(cfg["quirkDescCol"])}
+                        | {el["name"] for el in metric_units})
+            page_ctx[ch_name] = {
+                "page": page, "element": page["elements"][0],
+                "ref": (lambda n, _e=ae_name: f"[{_e}/{n}]"),
+                "available": ae_avail,
+            }
+            continue
+
+        columns, group_ids, calc_ids, key_names = [], [], [], []
+        filters = []
+        for u in units:
+            if u.get("type") == "attribute":
+                key_col, desc_col = b.attribute_unit_cols(u["id"])
+                cid = f"c-{slug(ch_name)}-{slug(key_col)}"
+                columns.append({
+                    "id": cid,
+                    "name": friendly(key_col),
+                    "formula": wb_ref(friendly(key_col)),
+                })
+                group_ids.append(cid)
+                # MicroStrategy inner-joins the lookup table, so fact rows
+                # with no matching dim row never appear in its grid. The DM
+                # join is left-outer (other reports need all fact rows), so
+                # drop the null group keys per-element to mirror MSTR.
+                a = b.attributes[u["id"]]
+                if a["attributeLookupTable"]["objectId"] != b.fact_tid:
+                    filters.append({
+                        "id": f"f-{slug(ch_name)}-{slug(key_col)}",
+                        "columnId": cid,
+                        "kind": "list",
+                        "mode": "exclude",
+                        "values": [None],
+                    })
+                if desc_col:
+                    # DESC label rendered per key element = Max over fact rows
+                    did = f"c-{slug(ch_name)}-{slug(desc_col)}"
+                    columns.append({
+                        "id": did,
+                        "name": friendly(desc_col),
+                        "formula": f"Max({wb_ref(friendly(desc_col))})",
+                    })
+                    calc_ids.append(did)
+                    key_names.append(friendly(desc_col))
+                else:
+                    key_names.append(friendly(key_col))
+            elif u.get("type") == "metrics":
+                for el in u["elements"]:
+                    mid = el["id"]
+                    mname = b.metrics[mid]["information"]["name"]
+                    cid = f"c-{slug(ch_name)}-{slug(mname)}"
+                    col = {
+                        "id": cid,
+                        "name": mname,
+                        "formula": b.metric_formula(mid, wb_ref,
+                                                    expand_metrics=True),
+                    }
+                    fmt = b.metric_display_format(mid)
+                    if fmt:
+                        col["format"] = fmt
+                    columns.append(col)
+                    calc_ids.append(cid)
+
+        report_keys[report["information"]["name"]] = key_names
+        element = {
+            "id": f"tbl-{slug(ch_name)}",
+            "kind": "table",
+            "name": report["information"]["name"],
+            "source": {
+                "kind": "data-model",
+                "dataModelId": dm_id,
+                "elementId": el_ref(join_name),
+            },
+            "columns": columns,
+            "groupings": [{
+                "id": f"g-{slug(ch_name)}",
+                "groupBy": group_ids,
+                "calculations": calc_ids,
+            }],
+        }
+        if filters:
+            element["filters"] = filters
+        page = {
+            "id": f"pg-{slug(ch_name)}",
+            "name": ch_name,
+            "elements": [element],
+        }
+        pages.append(page)
+        page_ctx[ch_name] = {"page": page, "element": element,
+                             "ref": wb_ref, "available": avail_join}
+
+    # dossier selectors / chapter filters -> Sigma controls (+ sidecar data),
+    # then the banded layout (mutates pages: containers + header text)
+    warnings = []
+    n_signals, scope_entries, unbound = emit_controls(b, pages, page_ctx,
+                                                      warnings)
+    layout_xml = build_layout(pages, b.dossier.get("name", "MicroStrategy"))
+    control_scope = {"version": 1, "source": "microstrategy",
+                     "sourceFilterSignals": n_signals,
+                     "controls": scope_entries, "unbound": unbound}
+
+    return {
+        "name": args.wb_name,
+        "folderId": args.folder_id,
+        "schemaVersion": 1,
+        "pages": pages,
+    }, report_keys, layout_xml, control_scope, warnings
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bundle", default="bundle.json")
+    ap.add_argument("--connection-id", required=True)
+    ap.add_argument("--database", required=True,
+                    help="warehouse database the Sigma connection reads")
+    ap.add_argument("--folder-id", required=True)
+    ap.add_argument("--inode-map", default=None,
+                    help="JSON file: physical table name -> inode tail")
+    ap.add_argument("--dm-name", default=None,
+                    help="default: '<dossier name> (MSTR Model)'")
+    ap.add_argument("--wb-name", default=None,
+                    help="default: '<dossier name> (MSTR)'")
+    ap.add_argument("--join-element-name", default="Orders")
+    ap.add_argument("--data-model-id", default=None)
+    ap.add_argument("--orders-element-id", default=None)
+    ap.add_argument("--dm-element-ids", default=None,
+                    help="JSON file: DM element name -> server element id")
+    ap.add_argument("--ae-winners", default=None,
+                    help="ae_winners.json from resolve_ae_winners.py")
+    ap.add_argument("--out-dm", default="sigma_dm_spec.json")
+    ap.add_argument("--out-wb", default="sigma_workbook_spec.json")
+    ap.add_argument("--out-layout", default="layout.xml",
+                    help="banded layout XML for scripts/put-layout.rb")
+    ap.add_argument("--control-scope-out", default="control-scope.json",
+                    help="intended-scope contract for the control lint "
+                         "(scripts/lib/control_lint.rb CONTRACT)")
+    args = ap.parse_args()
+
+    b = Bundle(json.load(open(args.bundle)))
+    dossier_name = b.dossier.get("name", "MicroStrategy")
+    args.dm_name = args.dm_name or f"{dossier_name} (MSTR Model)"
+    args.wb_name = args.wb_name or f"{dossier_name} (MSTR)"
+    inode_map = json.load(open(args.inode_map)) if args.inode_map else {}
+    ae_winners = json.load(open(args.ae_winners)) if args.ae_winners else None
+    dm_element_ids = (json.load(open(args.dm_element_ids))
+                      if args.dm_element_ids else None)
+
+    dm = build_dm_spec(b, args, inode_map, ae_winners)
+    wb, report_keys, layout_xml, control_scope, warnings = \
+        build_workbook_spec(b, args, ae_winners, dm_element_ids)
+    json.dump(dm, open(args.out_dm, "w"), indent=1)
+    json.dump(wb, open(args.out_wb, "w"), indent=1)
+    json.dump(report_keys, open("parity_keys.json", "w"), indent=1)
+    open(args.out_layout, "w").write(layout_xml)
+    json.dump(control_scope, open(args.control_scope_out, "w"), indent=1)
+
+    print(f"fact table: {b.table_info[b.fact_tid]['name']}")
+    for j in b.derive_joins():
+        print(f"join: {b.table_info[b.fact_tid]['tableName']}.{j['fact_col']} = "
+              f"{b.table_info[j['lookup_tid']]['tableName']}.{j['lookup_col']}")
+    for el in dm["pages"][0]["elements"]:
+        for m in el.get("metrics", []):
+            print(f"metric: {m['name']} = {m['formula']}")
+    for c in control_scope["controls"]:
+        print(f"control: {c['controlId']} ({c['controlType']}) -> "
+              f"{[w['elementId'] for w in c['wired']]} scope={c['scope']}")
+    for u in control_scope["unbound"]:
+        print(f"control UNBOUND [{u['status']}]: {u['sourceName']} — {u['reason']}")
+    for w in warnings:
+        print(f"WARN: {w}")
+    print(f"signals: {control_scope['sourceFilterSignals']} filter signal(s), "
+          f"{len(control_scope['controls'])} control(s) emitted")
+    print(f"wrote {args.out_dm}, {args.out_wb}, {args.out_layout}, "
+          f"{args.control_scope_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/escalate-gap.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/escalate-gap.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""escalate-gap — opt-in GitHub-issue filer for gap-scout escalations.
+
+Shared across every migration skill (vendored identically into each plugin's
+scripts/). When the gap scout can't find a working Sigma translation for a
+source feature, the main agent offers the user the *option* to open a tracking
+issue in the appropriate repo. This script is what turns that "yes" into filed
+issues — with dedupe, repo routing, converter-repo mirroring, and a cross-linked
+bead.
+
+DESIGN: opt-in, never automatic.
+  - Default (no --yes): DRY RUN. Prints the drafted issue(s), the target repo(s),
+    and any existing open issues/beads that already cover this gap. Files NOTHING.
+    This is what the agent shows the user.
+  - With --yes: actually files. Skips any repo where dedupe already found a match
+    (unless --force).
+
+ROUTING (category -> repos):
+  converter  -> twells89/sigma-data-model-manager + twells89/sigma-data-model-mcp
+               (a source expression the *converter* failed to translate — the
+                browser tool and the MCP must stay in sync, so mirror to both)
+  builder    -> twells89/sigma-migration-skills   (workbook/DM spec builder gap)
+  skill      -> twells89/sigma-migration-skills   (skill-logic / discovery gap)
+
+Usage (dry-run draft the agent shows the user):
+  python3 scout/escalate-gap.py \
+    --skill tableau-to-sigma --category converter \
+    --feature WINDOW_AVG --description 'moving average over SUM' \
+    --source-pattern 'WINDOW_AVG(SUM([...]))' \
+    --template-attempted 'MovingAvg(Sum([Master/\\1]), -10, 10)' \
+    --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+    --sigma-response '<failing column type / error json>' \
+    --example-from 'Sales.twb line 412' \
+    --escalation-yaml ~/.tableau-to-sigma/escalations/window_avg.yaml
+
+Then, only if the user says yes, the agent re-runs the same command with --yes.
+
+Requires `gh` on PATH and authed for the target repos. `bd` (beads) optional.
+Exit codes: 0 = ok (drafted or filed), 3 = nothing fileable / gh missing on --yes.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+ROUTES = {
+    "converter": ["twells89/sigma-data-model-manager", "twells89/sigma-data-model-mcp"],
+    "builder":   ["twells89/sigma-migration-skills"],
+    "skill":     ["twells89/sigma-migration-skills"],
+}
+BEADS_DIR = os.path.expanduser("~/.beads-sigma")
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def run(args, **kw):
+    """Run a command, return (ok, stdout, stderr)."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, **kw)
+        return p.returncode == 0, p.stdout.strip(), p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return False, "", str(e)
+
+
+def build_issue(a):
+    title = f"{a.skill} gap: {a.feature}" + (f" ({a.description})" if a.description else "")
+    body = []
+    body.append(f"**Skill:** `{a.skill}`")
+    body.append(f"**Gap category:** `{a.category}`")
+    body.append(f"**Feature:** `{a.feature}`")
+    if a.description:
+        body.append(f"**Description:** {a.description}")
+    if a.source_pattern:
+        body.append(f"**Source pattern:** `{a.source_pattern}`")
+    if a.template_attempted:
+        body.append(f"**Sigma template attempted:** `{a.template_attempted}`")
+    if a.test_formula:
+        body.append(f"**Test formula POSTed:** `{a.test_formula}`")
+    if a.sigma_response:
+        body.append(f"**Sigma response:**\n```\n{a.sigma_response}\n```")
+    body.append(f"**Example source:** {a.example_from or '(not provided)'}")
+    if a.escalation_yaml:
+        body.append(f"**Local escalation record:** `{a.escalation_yaml}`")
+    body.append("\n_Filed via the gap-scout opt-in escalation flow (`escalate-gap.py`)._")
+    return title, "\n\n".join(body)
+
+
+def labels_for(a):
+    return ["gap-scout-escalation", a.skill, f"category:{a.category}"]
+
+
+def ensure_labels(repo, labels):
+    """Best-effort: create labels so `gh issue create --label` won't fail."""
+    for lab in labels:
+        run(["gh", "label", "create", lab, "--repo", repo, "--force"])
+
+
+def find_dupes(repo, feature, skill):
+    """Return list of {number,title,url} open issues that look like this gap."""
+    ok, out, _ = run([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--label", "gap-scout-escalation", "--search", feature,
+        "--json", "number,title,url",
+    ])
+    if not ok or not out:
+        return []
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return []
+    feat = feature.lower()
+    return [i for i in items if feat in (i.get("title", "").lower())]
+
+
+def find_bead_dupe(feature):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    ok, out, _ = run(["bd", "list", "--json"], cwd=BEADS_DIR)
+    if not ok or not out:
+        return None
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return None
+    rows = items if isinstance(items, list) else items.get("issues", items.get("beads", []))
+    feat = feature.lower()
+    for b in rows or []:
+        if feat in (str(b.get("title", "")) + str(b.get("summary", ""))).lower():
+            return b.get("id") or b.get("bead_id")
+    return None
+
+
+def create_bead(title, body, skill, category):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    labels = f"sigma-converter,{skill},gap-scout-escalation,category:{category}"
+    ok, out, _ = run([
+        "bd", "create", title, "--priority", "2", "--labels", labels,
+        "--description", body, "--silent",
+    ], cwd=BEADS_DIR)
+    return out.strip() if ok else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--feature", required=True)
+    ap.add_argument("--category", default="converter", choices=list(ROUTES))
+    ap.add_argument("--description", default="")
+    ap.add_argument("--source-pattern", default="")
+    ap.add_argument("--template-attempted", default="")
+    ap.add_argument("--test-formula", default="")
+    ap.add_argument("--sigma-response", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--escalation-yaml", default="")
+    ap.add_argument("--extra-repo", action="append", default=[],
+                    help="additional target repo(s), repeatable")
+    ap.add_argument("--yes", action="store_true",
+                    help="actually file. Without it: dry-run, prints the draft only.")
+    ap.add_argument("--force", action="store_true",
+                    help="file even if a matching open issue already exists")
+    ap.add_argument("--no-beads", action="store_true")
+    a = ap.parse_args()
+
+    repos = list(dict.fromkeys(ROUTES[a.category] + a.extra_repo))
+    title, body = build_issue(a)
+    labels = labels_for(a)
+
+    # Dedupe scan (read-only) up front so the agent can show it to the user.
+    gh_ok = have("gh")
+    dupes = {r: (find_dupes(r, a.feature, a.skill) if gh_ok else []) for r in repos}
+    bead_dupe = None if a.no_beads else find_bead_dupe(a.feature)
+
+    if not a.yes:
+        # DRY RUN — this is what the agent presents to the user.
+        out = {
+            "mode": "draft",
+            "would_file_in": repos,
+            "labels": labels,
+            "title": title,
+            "body": body,
+            "existing_issues": {r: d for r, d in dupes.items() if d},
+            "existing_bead": bead_dupe,
+            "gh_available": gh_ok,
+            "next_step": "re-run with --yes to file (skips repos already covered)",
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    # --yes: actually file.
+    if not gh_ok:
+        print(json.dumps({"status": "error", "error": "gh not on PATH; cannot file"}))
+        return 3
+
+    # Bead first (authoritative tracker), so its id can be embedded in issues.
+    bead_id = bead_dupe
+    if bead_id is None and not a.no_beads:
+        bead_id = create_bead(title, body, a.skill, a.category)
+    issue_body = body + (f"\n\n**Bead:** `{bead_id}`" if bead_id else "")
+
+    filed, skipped = [], []
+    for repo in repos:
+        if dupes.get(repo) and not a.force:
+            skipped.append({"repo": repo, "existing": dupes[repo]})
+            continue
+        ensure_labels(repo, labels)
+        ok, out, err = run([
+            "gh", "issue", "create", "--repo", repo,
+            "--title", title, "--body", issue_body,
+            "--label", ",".join(labels),
+        ])
+        if ok:
+            filed.append({"repo": repo, "url": out.strip()})
+        else:
+            # retry once without labels (in case label creation was denied)
+            ok2, out2, err2 = run([
+                "gh", "issue", "create", "--repo", repo,
+                "--title", title, "--body", issue_body,
+            ])
+            if ok2:
+                filed.append({"repo": repo, "url": out2.strip(), "note": "filed without labels"})
+            else:
+                filed.append({"repo": repo, "error": err or err2})
+
+    # Cross-link mirrored issues to each other.
+    urls = [f["url"] for f in filed if f.get("url")]
+    if len(urls) > 1:
+        for f in filed:
+            if not f.get("url"):
+                continue
+            others = [u for u in urls if u != f["url"]]
+            num = f["url"].rstrip("/").split("/")[-1]
+            link_body = issue_body + "\n\n**Mirrored to:** " + ", ".join(others)
+            run(["gh", "issue", "edit", num, "--repo", f["repo"], "--body", link_body])
+
+    # Cross-link the bead back to the filed issue urls.
+    if bead_id and urls and have("bd"):
+        run(["bd", "update", bead_id, "--description",
+             issue_body + "\n\nFiled issues: " + ", ".join(urls)], cwd=BEADS_DIR)
+
+    print(json.dumps({
+        "status": "filed",
+        "filed": filed,
+        "skipped_existing": skipped,
+        "bead_id": bead_id,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/extract.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/extract.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Extract a MicroStrategy dossier + its full semantic model into one JSON bundle.
+
+Usage: python3 extract.py <dossierId> [out.json]
+
+The bundle is the converter input: dossier definition (chapters/pages/vizzes),
+each dataset report's template, and the schema objects they reference —
+attributes (forms, expressions, lookup tables), facts, metrics (formula text),
+and logical tables (physical table + namespace + datasource).
+"""
+import json
+import sys
+import mstr
+
+
+def extract(s, dossier_id):
+    bundle = {'dossier': s.get(f'/v2/dossiers/{dossier_id}/definition')}
+
+    # datasets -> report definitions (template + data source)
+    reports = {}
+    for ds in bundle['dossier'].get('datasets', []):
+        rid = ds['id']
+        reports[rid] = s.get(
+            f'/model/reports/{rid}?showExpressionAs=tokens')
+    bundle['reports'] = reports
+
+    # collect referenced attribute/metric ids from report templates
+    attr_ids, metric_ids = set(), set()
+    for r in reports.values():
+        units = (r.get('dataSource', {}).get('dataTemplate', {})
+                 .get('units', []))
+        for u in units:
+            if u.get('type') == 'attribute':
+                attr_ids.add(u['id'])
+            elif u.get('type') == 'metrics':
+                for e in u.get('elements', []):
+                    metric_ids.add(e['id'])
+
+    bundle['attributes'] = {}
+    table_ids = set()
+    for aid in sorted(attr_ids):
+        a = s.get(f'/model/attributes/{aid}?showExpressionAs=tokens')
+        bundle['attributes'][aid] = a
+        for f in a.get('forms', []):
+            for ex in f.get('expressions', []):
+                for t in ex.get('tables', []):
+                    table_ids.add(t['objectId'])
+
+    bundle['metrics'] = {}
+    fact_ids = set()
+    for mid in sorted(metric_ids):
+        m = s.get(f'/model/metrics/{mid}?showExpressionAs=tokens')
+        bundle['metrics'][mid] = m
+        for tok in m.get('expression', {}).get('tokens', []):
+            tgt = tok.get('target')
+            if tgt and tgt.get('subType') == 'fact':
+                fact_ids.add(tgt['objectId'])
+            if tgt and tgt.get('subType') == 'metric':
+                metric_ids.add(tgt['objectId'])  # compound metric base
+
+    # second pass for compound-metric bases discovered above
+    for mid in sorted(metric_ids):
+        if mid not in bundle['metrics']:
+            m = s.get(f'/model/metrics/{mid}?showExpressionAs=tokens')
+            bundle['metrics'][mid] = m
+            for tok in m.get('expression', {}).get('tokens', []):
+                tgt = tok.get('target')
+                if tgt and tgt.get('subType') == 'fact':
+                    fact_ids.add(tgt['objectId'])
+
+    bundle['facts'] = {}
+    for fid in sorted(fact_ids):
+        f = s.get(f'/model/facts/{fid}?showExpressionAs=tokens')
+        bundle['facts'][fid] = f
+        for ex in f.get('expressions', []):
+            for t in ex.get('tables', []):
+                table_ids.add(t['objectId'])
+
+    bundle['tables'] = {}
+    for tid in sorted(table_ids):
+        bundle['tables'][tid] = s.get(f'/model/tables/{tid}')
+
+    # attribute relationships (hierarchy) for join/topology hints
+    bundle['relationships'] = {}
+    for aid in sorted(attr_ids):
+        try:
+            rel = s.get(f'/model/systemHierarchy/attributes/{aid}/relationships')
+            if rel.get('relationships'):
+                bundle['relationships'][aid] = rel['relationships']
+        except Exception:
+            pass
+
+    return bundle
+
+
+if __name__ == '__main__':
+    dossier_id = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else 'bundle.json'
+    s = mstr.Session()
+    b = extract(s, dossier_id)
+    json.dump(b, open(out, 'w'), indent=1)
+    print(f'wrote {out}: {len(b["reports"])} reports, '
+          f'{len(b["attributes"])} attributes, {len(b["metrics"])} metrics, '
+          f'{len(b["facts"])} facts, {len(b["tables"])} tables')

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/extract_datamodel.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/extract_datamodel.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Extract the complete 'Orders Data Model' definition -> datamodel_definition.json.
+
+Reads every dataModels sub-resource (model + tables + attributes + factMetrics
++ metrics + links + hierarchy) with token+tree expression forms where the API
+supports showExpressionAs. GETs work without a changeset (read from metadata).
+Output is the converter input for MicroStrategy DataModel -> Sigma.
+"""
+import json
+
+import mstr
+
+s = mstr.Session()
+state = json.load(open('datamodel_ids.json'))
+dm = state['dataModelId']
+
+
+def get(path, **kw):
+    try:
+        return s.get(path, **kw)
+    except RuntimeError as e:
+        return {'_error': str(e)[:500]}
+
+
+out = {
+    'dataModelId': dm,
+    'dataModel': get(f'/model/dataModels/{dm}'),
+    'tables': get(f'/model/dataModels/{dm}/tables'
+                  '?showExpressionAs=tokens&showDerivedColumns=true'
+                  '&showDerivedForms=true'),
+    'attributes': get(f'/model/dataModels/{dm}/attributes'
+                      '?showExpressionAs=tokens&showDerivedForms=true'),
+    'factMetrics': get(f'/model/dataModels/{dm}/factMetrics'
+                       '?showExpressionAs=tokens'),
+    'metrics': get(f'/model/dataModels/{dm}/metrics'
+                   '?showExpressionAs=tokens&showFilterTokens=true'),
+    'links': None,  # filled below — GET /links requires a changeset header
+    'hierarchy': get(f'/model/dataModels/{dm}/hierarchy'),
+    'attributeRelationships': {},
+}
+for name, aid in state['attributes'].items():
+    out['attributeRelationships'][name] = get(
+        f'/model/dataModels/{dm}/attributes/{aid}/relationships')
+
+# GET /links is changeset-scoped (unlike every other GET here); use a
+# throwaway non-schema changeset and abort it immediately.
+cs = s.changeset(schema_edit=False)
+try:
+    out['links'] = get(f'/model/dataModels/{dm}/links',
+                       headers={'X-MSTR-MS-Changeset': cs})
+finally:
+    s.abort(cs)
+
+json.dump(out, open('datamodel_definition.json', 'w'), indent=1)
+print('wrote datamodel_definition.json')
+for k, v in out.items():
+    if isinstance(v, dict):
+        err = v.get('_error')
+        n = v.get('total', '')
+        print(f'  {k}: {"ERR " + err if err else ("total=" + str(n) if n != "" else "ok")}')

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/find-or-pick-dm.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/find-or-pick-dm.rb
@@ -1,0 +1,372 @@
+#!/usr/bin/env ruby
+# Phase 1.5 — Reuse existing Sigma data models when one already covers the
+# Tableau workbook's needs. Goals:
+#   1. Avoid DM sprawl: don't add a 4th "Orders" DM when the customer already
+#      has three that all point at the same warehouse table.
+#   2. Performance: skip Phase 2 (warehouse column discovery) and Phase 3
+#      (DM build + POST + validate) when reusing — often 2-3 min savings.
+#
+# This script DOES NOT mutate any DM. It only scores existing DMs against the
+# Tableau workbook signature and recommends a candidate (with a warning about
+# inherited columns / RLS / metrics). The downstream phase decides whether to
+# reuse or create new.
+#
+# Usage:
+#   ruby scripts/find-or-pick-dm.rb \
+#     --workbook-signature /tmp/<name>/workbook-signature.json \
+#     --out /tmp/<name>/dm-match.json \
+#     [--limit 200]                    # max DMs to scan
+#     [--min-score 0.6]                # below: no recommendation, build new
+#     [--force-new]                    # always recommend new (skip scan)
+#
+# Input signature shape (produced by Phase 1 + 2.5 — adjust paths as needed):
+#   {
+#     "tableau_workbook":   "Monthly Revenue",
+#     "warehouse_tables":   ["CSA.ORDER_FACT"],          # FQN list
+#     "referenced_columns": ["ORDER_DATE","GROSS_REVENUE","REGION","STATE"],
+#     "measures":           [{"col":"GROSS_REVENUE","derivation":"Sum"}, ...]
+#   }
+#
+# Output: dm-match.json with shape documented in SKILL.md Phase 1.5.
+# Exit: 0 if any candidate ≥ --min-score, 1 if none (caller can choose to
+# build new). Never aborts on missing inputs — always emits a result file so
+# the agent can decide.
+
+require 'json'
+require 'yaml'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
+# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
+# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
+# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
+# picker run with no score regression. beads-sigma-3kw.
+opts = { limit: 25, min_score: 0.6 }
+OptionParser.new do |p|
+  p.on('--workbook-signature P') { |v| opts[:sig]      = v }
+  p.on('--out P')                { |v| opts[:out]      = v }
+  p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
+  p.on('--force-new')            { |_| opts[:force_new]= true }
+  p.on('--auto-pick',
+       'Auto-recommend without UX prompt when top score >= --auto-pick-threshold AND no other candidate within --auto-pick-tie-window of it. Sets `auto_picked: true` on the result so the caller can WARN about inherited columns.') { |_| opts[:auto_pick] = true }
+  p.on('--auto-pick-threshold F', Float, 'Min score for auto-pick (default 0.55).')                  { |v| opts[:auto_pick_threshold] = v }
+  p.on('--auto-pick-tie-window F', Float, 'Gap from top score within which other candidates count as a tie that disables auto-pick (default 0.05).') { |v| opts[:auto_pick_tie_window] = v }
+end.parse!
+%i[sig out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# DM-shortlisting scans many candidates and is called per-follower in cluster
+# orchestration — auto-refresh on 401 to survive long batch runs.
+def http_get(path)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{BASE}#{path}")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept'] = 'application/json'
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+sig = JSON.parse(File.read(opts[:sig]))
+warn "workbook: #{sig['tableau_workbook'] || '(unnamed)'}"
+warn "  warehouse_tables:   #{sig['warehouse_tables']&.size || 0}"
+warn "  referenced_columns: #{sig['referenced_columns']&.size || 0}"
+
+# Force-new short-circuit: emit a no-match result and exit 1.
+if opts[:force_new]
+  File.write(opts[:out], JSON.pretty_generate({
+    'recommended_dm_id' => nil,
+    'score' => 0.0,
+    'rationale' => '--force-new: bypassed DM-reuse scan',
+    'candidates' => []
+  }))
+  warn "force-new mode — wrote empty match"
+  exit 1
+end
+
+# 1. List ALL data models, then sort deterministically before applying --limit.
+# Sigma's /v2/dataModels list endpoint returns server page-order, not
+# relevance order. Without a stable client-side sort, the same workbook
+# picks different candidates on different runs (observed: 3 conversions of
+# the same Tableau workbook reached 3 different recommendations). Fix:
+# fetch all DMs (cheap — one list call per 100), sort by updatedAt desc
+# (recent DMs are usually more relevant), then take the first --limit for
+# parallel spec-fetch + scoring. Stable tiebreaker by name. beads-sigma-3kw.
+all_dms = []
+page = nil
+hard_cap = 500
+loop do
+  qs = "limit=100"
+  qs += "&page=#{page}" if page
+  r = http_get("/v2/dataModels?#{qs}")
+  break unless r.code.to_i == 200
+  data = JSON.parse(r.body)
+  rows = data['entries'] || data['dataModels'] || []
+  break if rows.empty?
+  all_dms.concat(rows)
+  break if all_dms.size >= hard_cap
+  page = data['nextPage']
+  break if page.nil? || page.empty?
+end
+
+# Deterministic ranking: updatedAt desc, then name asc.
+# NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
+# every timestamp rescues to 0, and the sort silently degrades to name-ascending
+# (recently-updated DMs past the --limit window are never scanned).
+require 'time'
+all_dms = all_dms.sort_by do |dm|
+  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+end
+
+warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+
+# 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
+def normalize_fqn(s)
+  return nil if s.nil? || s.empty?
+  parts = s.to_s.split('.').reject(&:empty?).map(&:upcase)
+  parts.join('.')
+end
+
+def normalize_col(s)
+  s.to_s.upcase.gsub(/[^A-Z0-9]/, '')
+end
+
+# Fetch all DM specs in parallel (10 threads). Some DMs return non-200
+# (archived, permission-restricted, broken refs) — log and continue. Single
+# transient 5xx errors are retried once.
+dm_specs = {}
+dm_failures = []
+require 'thread'
+mu = Mutex.new
+queue = Queue.new
+all_dms.take(opts[:limit]).each { |dm| queue << dm }
+threads = 5.times.map do
+  Thread.new do
+    until queue.empty?
+      dm = queue.pop(true) rescue nil
+      break unless dm
+      dm_id = dm['dataModelId'] || dm['id']
+      next unless dm_id
+      r = nil
+      # Retry on 429 (Cloudflare burst limit) with exponential backoff. The
+      # /v2/dataModels endpoint commonly 429s at >5 concurrent across
+      # tj-wells-1989 — see beads-sigma-cn5.
+      4.times do |attempt|
+        r = http_get("/v2/dataModels/#{dm_id}/spec")
+        code = r.code.to_i
+        break if code == 200 || (code != 429 && code < 500)
+        sleep (0.5 * (2 ** attempt))  # 0.5s, 1s, 2s, 4s
+      end
+      if r.code.to_i != 200
+        mu.synchronize { dm_failures << { name: dm['name'], id: dm_id, code: r.code, body_head: r.body[0..80] } }
+        next
+      end
+      spec = begin
+        JSON.parse(r.body)
+      rescue JSON::ParserError
+        YAML.safe_load(r.body, permitted_classes: [Date, Time])
+      end
+      mu.synchronize { dm_specs[dm_id] = spec }
+    end
+  end
+end
+threads.each(&:join)
+warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
+dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
+
+dm_signatures = []
+all_dms.take(opts[:limit]).each do |dm|
+  dm_id = dm['dataModelId'] || dm['id']
+  spec = dm_specs[dm_id]
+  next unless spec
+
+  tables = []
+  columns = []
+  metrics = []
+  column_captions = {}  # normalized → original, so output can be human-readable
+
+  # Walk every element. Sigma DM specs nest elements under pages[*].elements
+  # (NOT top-level `elements` — that's a workbook-only convention). Fall back
+  # to top-level for robustness in case schema changes.
+  all_elements = spec['elements'] || (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  all_elements.each do |el|
+    src = el['source'] || {}
+    case src['kind']
+    when 'warehouse-table', 'table'
+      # source like { kind: warehouse-table, connectionId, path: "DB.SCHEMA.TABLE" }.
+      # Live API specs return path as an ARRAY (["DB","SCHEMA","TABLE"]) — join it,
+      # else normalize_fqn sees the array's to_s and table-match never fires.
+      raw = src['path']
+      fqn = raw.is_a?(Array) ? raw.join('.') : (raw || [src['database'], src['schema'], src['name']].compact.join('.'))
+      tables << normalize_fqn(fqn) if fqn && !fqn.empty?
+    when 'sql'
+      # Custom SQL — surface a sentinel so the agent knows; not directly comparable
+      tables << 'CUSTOM_SQL'
+    end
+    (el['columns'] || []).each do |c|
+      colname = c['name'] || (c['formula'].to_s.match(/\[.*?([^\/\]]+)\]/) || [])[1]
+      if colname && !colname.empty?
+        norm = normalize_col(colname)
+        columns << norm
+        column_captions[norm] ||= colname
+      end
+    end
+    (el['metrics'] || []).each do |m|
+      metrics << "#{m['name']}/#{m['aggregation'] || m['derivation']}"
+    end
+  end
+
+  dm_signatures << {
+    dm_id: dm_id,
+    dm_name: dm['name'],
+    tables: tables.uniq.compact,
+    columns: columns.uniq.compact,
+    column_captions: column_captions,
+    metrics: metrics.uniq.compact,
+    raw_element_count: all_elements.size
+  }
+end
+
+# 3. Score each DM.
+tableau_tables  = (sig['warehouse_tables']   || []).map { |t| normalize_fqn(t) }.compact
+# Keep both forms: normalized for matching, original for human-readable output.
+tableau_columns_orig = (sig['referenced_columns'] || [])
+tableau_columns      = tableau_columns_orig.map { |c| normalize_col(c) }
+tableau_col_caption  = tableau_columns.zip(tableau_columns_orig).to_h
+tableau_measure_keys = (sig['measures'] || []).map { |m| "#{normalize_col(m['col'])}/#{m['derivation']}" }
+
+candidates = dm_signatures.map do |dm|
+  # Table match: 1.0 if Tableau tables ⊆ DM tables. 0.5 if partial. 0 if disjoint.
+  shared_tables = (tableau_tables & dm[:tables])
+  table_match =
+    if tableau_tables.empty?
+      0.0
+    elsif shared_tables.size == tableau_tables.size
+      1.0
+    elsif shared_tables.any?
+      0.5 + 0.5 * (shared_tables.size.to_f / tableau_tables.size)
+    else
+      0.0
+    end
+
+  # Column match: % of Tableau-referenced columns present in DM.
+  shared_cols = (tableau_columns & dm[:columns])
+  col_match =
+    tableau_columns.empty? ? 0.0 : shared_cols.size.to_f / tableau_columns.size
+
+  # Metric overlap (small weight).
+  shared_metrics = (tableau_measure_keys & dm[:metrics])
+  metric_match =
+    tableau_measure_keys.empty? ? 0.0 : shared_metrics.size.to_f / tableau_measure_keys.size
+
+  # Weighting rationale: column overlap is the most reliable signal —
+  # a DM's source table FQN can vary (raw warehouse table vs view vs joined
+  # element) but the column set must be a superset of what the workbook
+  # references for reuse to be safe. Table-match is a soft tiebreaker.
+  score = 0.2 * table_match + 0.7 * col_match + 0.1 * metric_match
+
+  # Extras the workbook would inherit. Surface original captions (not the
+  # normalized form) so the user-facing report is readable.
+  extra_cols_norm = dm[:columns] - tableau_columns
+  caption_of = ->(norm) { dm[:column_captions][norm] || norm }
+  {
+    'dm_id'             => dm[:dm_id],
+    'dm_name'           => dm[:dm_name],
+    'score'             => score.round(3),
+    'table_match'       => table_match.round(2),
+    'column_match'      => col_match.round(2),
+    'metric_match'      => metric_match.round(2),
+    'shared_tables'     => shared_tables,
+    'missing_tables'    => tableau_tables - dm[:tables],
+    'shared_columns'    => shared_cols.map(&caption_of),
+    'missing_columns'   => (tableau_columns - dm[:columns]).map { |c| tableau_col_caption[c] || c },
+    'extra_columns'     => extra_cols_norm.size,
+    'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
+    'raw_element_count' => dm[:raw_element_count]
+  }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
+
+best = candidates.first
+second = candidates[1]
+
+# Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
+# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
+# workbook's source tables (table_match 1.0). Table coverage is the safety
+# invariant: a DM that sources every table the workbook needs can satisfy every
+# column ref through its element set, so reusing it is safe; a DM missing a table
+# is never auto-picked (its denorm view can't resolve the missing columns).
+#
+# We deliberately DO NOT block on a score tie here. A tie among table-covering
+# candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
+# exactly what reuse-first exists to collapse — so we take the top (the
+# deterministic tie-break already prefers a name match, then the fewest extra
+# columns, over the most-recently-updated set). A column-SUPERSET (every
+# referenced column present, column_match 1.0) is the safest case and always
+# qualifies. Callers should reuse `recommended_dm_id` only when `auto_picked`.
+auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
+auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
+tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+best_covers_tables   = best && best['table_match'].to_f >= 1.0
+best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables)
+
+# Standard recommend path keeps the old semantics (printed for human opt-in).
+recommended_via_std  = best && best['score'] >= opts[:min_score]
+recommended_dm_id    = (auto_picked || recommended_via_std) ? best['dm_id'] : nil
+
+rationale =
+  if best.nil?
+    'no DMs in org'
+  elsif auto_picked
+    kind = best_is_superset ? 'column-superset' : 'covers all source tables'
+    tie  = tie_with_second ? " (collapsing a #{best['score']}-score tie — duplicate-DM sprawl)" : ''
+    "AUTO-PICKED at score #{best['score']} — #{kind}#{tie}. #{best['shared_columns'].size}/#{tableau_columns.size} cols, #{best['shared_tables'].size}/#{tableau_tables.size} tables matched. Caller must WARN about #{best['extra_columns']} inherited columns."
+  elsif opts[:auto_pick] && best['score'] >= auto_pick_threshold && !best_covers_tables
+    "score #{best['score']} clears the bar but the candidate is MISSING source table(s) #{best['missing_tables'].join(', ')} — not a safe reuse — build a new DM"
+  elsif best['score'] >= opts[:min_score]
+    'ambiguous match — ASK USER before reusing'
+  else
+    'no candidate above min-score; build a new DM'
+  end
+
+result = {
+  'workbook_signature_path' => opts[:sig],
+  'scanned_dm_count'        => candidates.size,
+  'recommended_dm_id'       => recommended_dm_id,
+  'auto_picked'             => auto_picked,
+  'score'                   => best ? best['score'] : 0.0,
+  'rationale'               => rationale,
+  'warning'                 => (best && best['extra_columns'] > 0) ? "Reusing inherits #{best['extra_columns']} extra columns (sample: #{best['extra_columns_sample'].join(', ')})" : nil,
+  'candidates'              => candidates.first(5)
+}.compact
+
+File.write(opts[:out], JSON.pretty_generate(result))
+warn ""
+warn "wrote #{opts[:out]}"
+warn "best score: #{result['score']}  →  #{result['rationale']}"
+exit result['recommended_dm_id'].nil? ? 1 : 0

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/gap-scout.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/gap-scout.md
@@ -1,0 +1,93 @@
+# gap-scout — guide for the main agent (MicroStrategy → Sigma)
+
+The MSTR converter (`convert.py` `metric_formula`) passes metric **function names**
+through optimistically — it maps an MSTR function token straight to a Sigma function
+name without checking that Sigma has an equivalent. So a metric using a function with
+no clean Sigma mapping does NOT warn at convert time; it surfaces as a **type=error
+column** when the workbook is read back after POST (Phase 4). The mechanical gate
+`scripts/scout-gate-readback.py` STOPS on any such column until a gap-scout has tried
+to translate it.
+
+The scout writes validated rules to `~/.microstrategy-to-sigma/learned-rules.yaml`
+(customer HOME, not the skill repo, so `git pull` never clobbers them).
+`scripts/learned-rules.py` loads them; future conversions apply them before falling
+back to the raw function name.
+
+## What the converter already handles
+Plain object refs (`[TABLE/Col]`), `Sum/Count/Avg/Min/Max`, `Count<Distinct=True>` →
+`CountDistinct`, arithmetic (`+ - * /`), nested-metric inlining (workbook context),
+metric→SQL for AE-emulation sql elements.
+
+## Candidates to scout (MSTR metric function → Sigma)
+| MSTR function | Why it errors | Candidate Sigma translation to validate |
+|---|---|---|
+| `RunningSum / RunningAvg / RunningMax` | window/running calc | `CumulativeSum([Master/Col])` in a date-grouped element |
+| `Rank / RankByValue` | window rank | `Rank([Master/Col])` (grouped-element context) |
+| `Lag / Lead / OffsetValue` | offset | `Lag([Master/Col], n)` in a sorted/date-grouped element |
+| `Median / Percentile / Mode` | distribution | `Median([Master/Col])` / `Percentile([Master/Col], p)` |
+| `StdDev / Variance` | stats | `Stdev([Master/Col])` / `Var([Master/Col])` |
+| `NTile / Quartile` | bucketing | derived bins or `Rank` + ratio; escalate if no 1:1 |
+| `FirstInRange / LastInRange` | windowed first/last | `First`/`Last` in a sorted grouped element |
+| MSTR-specific (`ApplySimple`, `BannerNumber`, …) | passthrough/raw SQL | translate via the warehouse SQL, else escalate |
+
+Spawn ONE scout per distinct error column; run them in parallel (independent).
+
+**Point the scout at the denormalized join element** (e.g. `Orders`), referencing
+columns as `[Master/<Display Name>]`.
+
+## How to spawn (Agent tool, subagent_type 'general-purpose')
+```
+You are a translation scout for a MicroStrategy→Sigma migration. Propose a Sigma
+formula that replaces an MSTR metric function, validate it against the live Sigma
+API, and persist the rule.
+
+INPUTS
+- Error column: <the type=error column's label + its formula from the gate output>
+- Sample MSTR metric expression(s): <2-5 real examples>
+- Sigma data-model id: <dm-id> ; denormalized element id: <denorm-elem-id> ; folder: <id>
+- Gate id + workdir: <errcol:... and --workdir from scout-gate-readback.py's GAP-SCOUT REQUIRED block>
+
+DO
+1. Propose a Sigma formula (see the candidate table above).
+2. Validate (eval get-token.sh first):
+   python3 scripts/scout-validate.py --formula '<sigma>' \
+     --data-model-id <dm> --element-id <denorm> --folder-id <folder> \
+     --feature '<fn>' --pattern '<regex>' --template '<sigma template>' \
+     --description '<fn> -> Sigma' --home ~/.microstrategy-to-sigma \
+     --gap-id '<errcol:... from the GAP-SCOUT REQUIRED list>' --workdir <migration workdir>
+3. If status=validated it's persisted; report the rule. If error, try another form
+   (≤4 attempts). After the last failed attempt the result carries an
+   `escalation.dry_run_cmd` / `escalation.file_cmd`; report it as genuine-(c)
+   needing redesign. Do NOT file anything yourself — see "Opt-in issue filing".
+```
+Validated rules auto-apply on the next migrate via `learned-rules.py`.
+
+## Run-each-time gate (bead beads-sigma-5l5e) — why `--gap-id` + `--workdir` matter
+
+`scout-gate-readback.py` reads the workbook back after POST, finds each type=error
+column, and **STOPS** (exit 11) with a `GAP-SCOUT REQUIRED` block listing each
+unscouted column's `--gap-id` (`errcol:<elementId>/<label>`) and the `--workdir`.
+
+`scout-validate.py` appends its result (`validated` or `escalated`) to
+`<workdir>/scout-ledger.jsonl` keyed by that exact `--gap-id` (via `lib/scout_gate.py`,
+the shared JSONL contract). You MUST pass the `--gap-id` and `--workdir` the STOP block
+printed — otherwise the ledger entry won't match the error column and re-running the
+gate will STOP again. The gate cannot be skipped with `--yes`: an unscouted error
+column always stops; once every error column is scouted (validated → translated and
+persisted, or escalated → genuinely-hard and flagged) the gate passes. Flow: POST →
+gate STOPS → scout each column → re-run the gate → proceed.
+
+## Opt-in issue filing (escalations)
+
+Filing a GitHub issue is **opt-in and confirm-before-file** — never automatic.
+When `scout-validate.py` returns `status=error`, its `escalation` block carries
+ready-to-run commands for the shared `escalate-gap.py` filer. The main agent:
+
+1. Runs `escalation.dry_run_cmd` — files NOTHING; prints the drafted issue, the
+   target repo(s), and any existing open issues/beads that already cover the gap.
+2. Shows the user that draft and asks whether to open the issue.
+3. Only if the user says yes, runs `escalation.file_cmd` (the same command + `--yes`).
+
+MSTR metric gaps are **converter** gaps, so they mirror to both converter repos
+(`sigma-data-model-manager` + `sigma-data-model-mcp`) with a cross-link and a bead as
+the authoritative tracker. See `scripts/escalate-gap.py`.

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/get-token.sh
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/get-token.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SIGMA_API_TOKEN=${TOKEN}"

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/learned-rules.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/learned-rules.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""learned-rules — load + apply gap-scout translation rules (MicroStrategy → Sigma).
+
+Rules live in the customer's HOME (`~/.microstrategy-to-sigma/learned-rules.yaml`), NOT
+the skill repo — so `git pull` of the skill never clobbers what a customer's scout has
+discovered, and wins persist across every dossier they migrate. Override the dir
+with the `MICROSTRATEGY_TO_SIGMA_HOME` env var. (Identical loader to the sibling
+Looker/Qlik/Power BI copies; only the default home + env var differ.)
+
+The conversion build step imports this and calls `apply()` on each MSTR metric
+expression before falling back to the converter / a WARN line.
+
+    from learned_rules import load, apply
+    rules = load(home="~/.microstrategy-to-sigma")
+    sigma_formula, hint = apply(rules, mstr_expr)   # (None, None) if no rule matches
+"""
+import os, re, yaml
+
+def home_dir(home=None, env=None):
+    if home: return os.path.expanduser(home)
+    if env and os.environ.get(env): return os.path.expanduser(os.environ[env])
+    return os.path.expanduser("~/.microstrategy-to-sigma")
+
+def load(home=None, env="MICROSTRATEGY_TO_SIGMA_HOME"):
+    path = os.path.join(home_dir(home, env), "learned-rules.yaml")
+    if not os.path.exists(path): return []
+    doc = yaml.safe_load(open(path)) or {}
+    return doc.get("rules", [])
+
+def apply(rules, expr):
+    """Return (translated_formula, hint) for the first matching rule, else (None, None)."""
+    for r in rules:
+        pat = r.get("source_pattern") or r.get("tableau_pattern") or r.get("dax_pattern")
+        tmpl = r.get("sigma_template")
+        if not pat or not tmpl: continue
+        m = re.search(pat, expr, re.IGNORECASE)
+        if m:
+            out = tmpl
+            for i, g in enumerate(m.groups(), start=1):
+                out = out.replace("\\%d" % i, g or "").replace("CAP%d" % i, g or "")
+            return out, r.get("hint", "")
+    return None, None
+
+if __name__ == "__main__":
+    import sys, json
+    rules = load(home=(sys.argv[2] if len(sys.argv) > 2 else None))
+    expr = sys.argv[1] if len(sys.argv) > 1 else ""
+    out, hint = apply(rules, expr)
+    print(json.dumps({"input": expr, "translated": out, "hint": hint, "rules_loaded": len(rules)}, indent=2))

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/control_lint.rb
@@ -1,0 +1,304 @@
+# frozen_string_literal: true
+#
+# control_lint.rb — mechanized control-wiring lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as layout_lint.rb / sigma_rest.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the layout lint
+#   - assert-phase6-ran.rb gate 7 (with a --skip-control-lint escape)
+#   - scripts/probe-controls.rb (reuses the reach computation to pick its
+#     in-closure / out-of-closure probe elements)
+#
+# It exists because a workbook can pass parity + layout gates and still ship
+# controls that DO NOTHING (the "Orders Overview (from Looker)" estate escape:
+# three list controls bound to no element at all) or controls that silently
+# skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
+# escape, and the Qlik class: source full of listboxes, spec with zero
+# controls). Three checks:
+#
+#   (a) dead control — every kind:control element must have >=1 `filters`
+#       target resolving to a REAL element id in the spec, OR be referenced
+#       as [controlId] in at least one non-control element (formula / spec
+#       reference). A control with neither is furniture: a user changes it
+#       and nothing on the page reacts.
+#   (b) reach — source-closure walk from the control's targets (filter
+#       targets + formula-referencing elements, expanded downstream through
+#       source.elementId chains). Any same-page QUERYABLE element outside
+#       the closure flags PARTIAL with the element names. Intentional
+#       single-chart switchers (grain / geo-level segmented controls) are
+#       allow-listed via the controlScope annotation (CONTRACT below).
+#   (c) source-scope coverage — when a control-scope sidecar is provided
+#       (emitted by the builder from the SOURCE BI artifact's filter
+#       signals), FAIL if the source had filter signals but the spec has
+#       zero controls, if an annotated control is missing from the spec,
+#       or if an annotated mustReach element is not in that control's
+#       closure.
+#
+# CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
+# to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
+# up from the workdir automatically, or take --control-scope PATH):
+#
+#   {
+#     "version": 1,
+#     "source": "qlik",               // provenance tag, free-form
+#     "sourceFilterSignals": 3,       // count of filter-like signals detected
+#                                     //   in the source artifact (listboxes,
+#                                     //   quick filters, actions, slicers,
+#                                     //   prompts, dashboard filters...).
+#                                     //   >0 with zero spec controls = FAIL.
+#     "controls": [
+#       {
+#         "controlId": "ctl-region",           // spec controlId (required)
+#         "sourceName": "Region quick filter", // optional, for messages
+#         "scope": "page",                     // "page" (default): the reach
+#                                              //   check applies to every
+#                                              //   same-page queryable element
+#                                              // OR an array of element ids /
+#                                              //   display names the control
+#                                              //   is INTENDED to affect — the
+#                                              //   single-chart-switcher
+#                                              //   allowlist (grain controls)
+#         "mustReach": ["Monthly Revenue Trend"] // optional hard assertions:
+#                                              //   each must be in the closure
+#       }
+#     ]
+#   }
+#
+# In-spec alternative (pre-POST local specs only): a control element may carry
+#   "controlScope": ["Element Name", ...]   // or "page"
+# with the same meaning as scope. NOTE: Sigma strips unknown keys on readback,
+# so the SIDECAR is the durable form — builders should emit both when the
+# allowlist must survive a live re-lint of the posted workbook.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query) evaluates a workbook
+# element WITH the workbook's saved control DEFAULTS applied and exposes NO
+# parameter mechanism to override them. The REST export API
+# (POST /v2/workbooks/{id}/export with `"parameters": {"<controlId>": "<value>"}`)
+# IS the only programmatic way to exercise a non-default control value — which
+# is why probe-controls.rb (the flip test) is built on export, not MCP.
+#
+# API:
+#   report     = ControlLint.controls_report(spec)   # per-control reach rows
+#   violations = ControlLint.lint(spec, scope: nil)  # scope = parsed sidecar
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/control_lint.rb <spec.json|spec.yaml> [control-scope.json]
+require 'json'
+require 'set'
+
+module ControlLint
+  QUERYABLE = %w[
+    table pivot-table input-table bar-chart line-chart pie-chart donut-chart
+    area-chart scatter-chart combo-chart kpi-chart box-chart funnel-chart
+    gauge-chart waterfall-chart sankey-chart region-map point-map viz chart
+    treemap-chart heatmap-chart word-cloud
+  ].to_set.freeze
+
+  module_function
+
+  # { element_id => {el:, page:, kind:, name:, srcel:} } for every element.
+  def elements(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        eid = el['id'] || el['elementId']
+        next unless eid
+        out[eid] = { el: el, page: pg['name'] || pg['id'],
+                     kind: (el['kind'] || el['type']).to_s,
+                     name: el['name'], srcel: source_element_id(el) }
+      end
+    end
+    out
+  end
+
+  # Unwraps {kind:"source", source:{elementId}} and direct {elementId} forms.
+  def source_element_id(el)
+    src = el['source']
+    return nil unless src.is_a?(Hash)
+    src = src['source'] if src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src.is_a?(Hash) ? src['elementId'] : nil
+  end
+
+  def control?(info)
+    info[:kind].include?('control')
+  end
+
+  # Transitive closure of elements sourcing (directly or via chains) from any
+  # element in `roots`. Returns roots + downstream ids.
+  def closure(elems, roots)
+    reach = roots.to_set
+    loop do
+      grew = false
+      elems.each do |eid, info|
+        next if reach.include?(eid)
+        next unless info[:srcel] && reach.include?(info[:srcel])
+        reach << eid
+        grew = true
+      end
+      break unless grew
+    end
+    reach
+  end
+
+  # Non-control elements whose serialized spec references [controlId] —
+  # catches formula refs (If([GeoLevel]="State",...)) and any other spec-level
+  # binding that names the control.
+  def formula_refs(elems, cid)
+    return [] if cid.nil? || cid.to_s.empty?
+    pat = /\[#{Regexp.escape(cid)}\]/
+    elems.select { |_eid, info| !control?(info) && JSON.generate(info[:el]).match?(pat) }
+         .keys
+  end
+
+  # Per-control reach report. Each row:
+  #   { control_element_id:, control_id:, name:, page:, control_type:,
+  #     filter_targets: [ids], ghost_targets: [ids], formula_refs: [ids],
+  #     reach: Set[ids], page_queryable: [ids], uncovered: [ids] }
+  def controls_report(spec)
+    elems = elements(spec)
+    rows = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      cid = el['controlId']
+      tgt_ids = (el['filters'] || []).map { |t| t.is_a?(Hash) ? t.dig('source', 'elementId') : nil }.compact
+      live    = tgt_ids.select { |t| elems.key?(t) }
+      frefs   = formula_refs(elems, cid)
+      roots   = (live + frefs).uniq
+      reach   = roots.empty? ? Set.new : closure(elems, roots)
+      page_q  = elems.select do |qid, i|
+        qid != eid && i[:page] == info[:page] && QUERYABLE.include?(i[:kind])
+      end.keys
+      rows << { control_element_id: eid, control_id: cid, name: info[:name],
+                page: info[:page], control_type: el['controlType'],
+                filter_targets: live, ghost_targets: tgt_ids - live,
+                formula_refs: frefs, reach: reach, page_queryable: page_q,
+                uncovered: page_q.reject { |q| reach.include?(q) } }
+    end
+    rows
+  end
+
+  # Resolve a sidecar element reference (id or display name) to element ids.
+  def resolve_ref(elems, ref)
+    return [ref] if elems.key?(ref)
+    elems.select { |_eid, i| i[:name] == ref }.keys
+  end
+
+  def label(elems, eid)
+    n = elems[eid] && elems[eid][:name]
+    n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
+  end
+
+  def lint(spec, scope: nil)
+    violations = []
+    elems = elements(spec)
+    rows  = controls_report(spec)
+
+    scope_by_cid = {}
+    if scope.is_a?(Hash)
+      Array(scope['controls']).each do |c|
+        scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
+      end
+      # (c) the Qlik class: source had filter signals, spec built zero controls.
+      signals = scope['sourceFilterSignals'].to_i
+      if signals.positive? && rows.empty?
+        violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
+                      '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
+                      'elements — the source dashboard is interactive and the migration shipped a ' \
+                      'static one; build the controls (or set sourceFilterSignals to 0 with a ' \
+                      'reason if the signals are genuinely non-portable)'
+      end
+    end
+
+    rows.each do |r|
+      ann = scope_by_cid.delete(r[:control_id]) || {}
+      ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
+      ctl_label = "control #{label(elems, r[:control_element_id])}#{r[:control_id] ? " [#{r[:control_id]}]" : ''} on page #{r[:page].inspect}"
+
+      r[:ghost_targets].each do |g|
+        violations << "ghost target: #{ctl_label} lists filter target #{g.inspect} which does not " \
+                      'resolve to any element in the spec — fix or drop the target'
+      end
+
+      # (a) dead control --------------------------------------------------------
+      if r[:reach].empty?
+        violations << "dead control: #{ctl_label} has no resolving `filters` target and no " \
+                      '[controlId] reference in any non-control element — a user changes it and ' \
+                      'nothing reacts; wire it (filters: [{source:{elementId}, columnId}]) or, if ' \
+                      'the bound column genuinely does not exist on any element, REMOVE the ' \
+                      'control (honest) instead of shipping furniture'
+        next
+      end
+
+      # (c) mustReach assertions -------------------------------------------------
+      Array(ann['mustReach']).each do |ref|
+        ids = resolve_ref(elems, ref)
+        if ids.empty?
+          violations << "scope mustReach: #{ctl_label} — annotated element #{ref.inspect} does not " \
+                        'exist in the spec'
+        elsif ids.none? { |i| r[:reach].include?(i) }
+          violations << "scope mustReach: #{ctl_label} does NOT reach annotated element " \
+                        "#{ref.inspect} — wire a filter target (or formula ref) so it does"
+        end
+      end
+
+      # (b) reach / PARTIAL --------------------------------------------------------
+      if ann_scope.is_a?(Array)
+        # Explicit allowlist (single-chart switcher): every listed element must
+        # be reached; same-page elements OUTSIDE the list are intentionally
+        # unaffected and not flagged.
+        ann_scope.each do |ref|
+          ids = resolve_ref(elems, ref)
+          if ids.empty?
+            violations << "controlScope: #{ctl_label} — scoped element #{ref.inspect} does not exist " \
+                          'in the spec'
+          elsif ids.none? { |i| r[:reach].include?(i) }
+            violations << "controlScope: #{ctl_label} does NOT reach its scoped element #{ref.inspect}"
+          end
+        end
+      elsif r[:uncovered].any?
+        names = r[:uncovered].map { |u| label(elems, u) }
+        violations << "partial control: #{ctl_label} affects #{r[:page_queryable].length - r[:uncovered].length} " \
+                      "of #{r[:page_queryable].length} same-page queryable element(s); NOT affected: " \
+                      "#{names.join(', ')} — wire those elements (add filter targets on their " \
+                      'sources, matching the source dashboard\'s filter scope) or declare the ' \
+                      'narrow scope intentional via controlScope (sidecar control-scope.json ' \
+                      'scope:[...] — see header CONTRACT)'
+      end
+    end
+
+    # (c) annotated controls that never made it into the spec ------------------
+    scope_by_cid.each do |cid, c|
+      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                    'has no control with that controlId — the source filter was not migrated'
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  abort 'usage: ruby control_lint.rb <workbook-spec.json|yaml> [control-scope.json]' unless ARGV[0] && File.exist?(ARGV[0])
+  body = File.read(ARGV[0])
+  spec =
+    begin
+      JSON.parse(body)
+    rescue JSON::ParserError
+      require 'yaml'
+      require 'date'
+      YAML.safe_load(body, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+  scope = ARGV[1] && File.exist?(ARGV[1]) ? JSON.parse(File.read(ARGV[1])) : nil
+  v = ControlLint.lint(spec, scope: scope)
+  if v.empty?
+    n = ControlLint.controls_report(spec).length
+    puts "control lint: clean (#{n} control(s) checked)"
+  else
+    warn "control lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/layout_lint.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
+        end
+        fill = covered.count(true).to_f / ncols
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/preflight_lint.rb
@@ -1,0 +1,110 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Preflight lint for a workbook spec — catches the two EDNA-class failure modes
+# BEFORE POST, with a precise message instead of the opaque "Invalid kind: control"
+# or a silently-detail-rendered table.
+#
+#   ruby preflight_lint.rb <workbook-spec.json>
+#     exit 0  = clean
+#     exit 1  = violations (printed, one per line)
+#
+# Checks:
+#   T1  a `table` with aggregate column(s) + dimension(s) but NO `groupings`
+#       → renders raw detail rows (the 9.6M-row / $0 / duplicate-dim EDNA bug).
+#   T2  a `groupings.calculations` column that is a PASSTHROUGH of an aggregate
+#       (re-aggregates to "multiple values"); calc cols must be Sum(...)/etc.
+#   C1  a `control` missing id / controlId / controlType.
+#   C2  any control nesting its value fields under a bogus `value` OBJECT
+#       (control fields are FLAT top-level) → the opaque `Invalid kind: control`.
+#       NOTE: a scalar `value:` is legitimate (slider handle position); only an
+#       OBJECT value is the trap. Also: a `source`, if present, must be double-nested.
+#   C3  a list/segmented/hierarchy control wired to NOTHING — neither a `source`
+#       (value-list) nor `filters` (target columns). A filters-only list control
+#       is VALID (live-verified), so source is NOT independently required.
+require 'json'
+
+AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
+PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
+LISTY = %w[list segmented hierarchy].freeze
+
+def lint(spec)
+  errs = []
+  cols_by_id = {}
+  pages = spec['pages'] || []
+  pages.each do |pg|
+    (pg['elements'] || []).each do |el|
+      (el['columns'] || []).each { |c| cols_by_id[c['id']] = c }
+    end
+  end
+  pages.each do |pg|
+    (pg['elements'] || []).each do |el|
+      kind = el['kind']
+      name = el['name'] || el['id'] || '(unnamed)'
+      cols = el['columns'] || []
+
+      if kind == 'table'
+        agg = cols.select { |c| c['formula'].to_s =~ AGG }
+        dim = cols.select { |c| c['formula'].to_s =~ PLAIN_REF }
+        grouped = el['groupings'].is_a?(Array) && !el['groupings'].empty?
+        if agg.any? && dim.any? && !grouped
+          errs << "T1 table '#{name}': has aggregate column(s) #{agg.map { |c| c['name'] }.inspect} + dimension(s) but NO `groupings` → will render raw detail rows, not an aggregated summary. Add groupings:[{groupBy:[<dim id>], calculations:[<agg id>...]}]."
+        end
+        # T2: a grouping calculation that points at a passthrough-of-aggregate column
+        (el['groupings'] || []).each do |g|
+          (g['calculations'] || []).each do |cid|
+            f = (cols_by_id[cid] || {})['formula'].to_s
+            # a calc that is a plain ref to another column whose own formula is an aggregate
+            if f =~ PLAIN_REF
+              # can't always resolve cross-element; flag bare passthroughs that look like measures
+              errs << "T2 table '#{name}': grouping calculation '#{cid}' is a passthrough (`#{f}`) — a grouped calculation must be an aggregate expression (Sum([...]) etc.), not a passthrough of an already-aggregated column (renders 'multiple values')." if cols_by_id[cid] && (cols_by_id[cid]['name'].to_s =~ /total|sum|count|avg|revenue|profit|tcv|amount/i)
+            end
+          end
+        end
+      end
+
+      if kind == 'control'
+        %w[id controlId controlType].each do |f|
+          errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
+        end
+        errs << "C1 control '#{name}': `id` and `controlId` must be DISTINCT." if !el['id'].to_s.empty? && el['id'] == el['controlId']
+
+        # C2: control value fields are FLAT top-level — never nested under a `value` OBJECT.
+        # (Live-verified: a nested value:{...} yields the opaque "Invalid kind: control" for
+        #  list / date-range / number-range / slider alike.) A SCALAR value: is legitimate
+        #  (the slider handle position), so only flag `value` when it is a Hash.
+        errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
+
+        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
+        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+          errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
+        end
+
+        # C3: a list-type control must be wired to SOMETHING — a `source` (value-list) and/or
+        # `filters` (target columns). A filters-only list control is VALID (live-verified), so we
+        # require source OR filters, never both, and never the bare mode/selectionMode/values.
+        if LISTY.include?(el['controlType'])
+          has_source  = el['source'].is_a?(Hash)
+          has_filters = el['filters'].is_a?(Array) && !el['filters'].empty?
+          unless has_source || has_filters
+            errs << "C3 control '#{name}': list-type control has neither `source` (value-list) nor `filters` (target columns) — it controls nothing. Add filters:[{source:{kind:table,elementId}, columnId}] and/or a double-nested source."
+          end
+        end
+      end
+    end
+  end
+  errs
+end
+
+if __FILE__ == $PROGRAM_NAME
+  path = ARGV[0] or abort('usage: preflight_lint.rb <workbook-spec.json>')
+  spec = JSON.parse(File.read(path))
+  errs = lint(spec)
+  if errs.empty?
+    puts 'preflight lint: clean'
+    exit 0
+  end
+  warn "preflight lint: #{errs.size} violation(s)"
+  errs.each { |e| warn "  ✗ #{e}" }
+  exit 1
+end

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/scout_gate.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/scout_gate.py
@@ -1,0 +1,64 @@
+"""Shared run-each-time gap-scout ledger (bead beads-sigma-5l5e) — Python side.
+
+Mirrors scout_gate.rb's contract exactly: a per-conversion JSONL ledger at
+<workdir>/scout-ledger.jsonl, one row per scouted gap:
+    {"gap_id": ..., "feature": ..., "status": "validated"|"escalated", "at": ...}
+
+Ruby orchestrators read it via scout_gate.rb#classify; Python scouts append to
+it via record() below. The JSONL format is the language-neutral contract.
+"""
+import json
+import os
+import datetime
+
+LEDGER = "scout-ledger.jsonl"
+
+
+def record(workdir, gap_id, feature, status):
+    """Append one scout result. Non-fatal on error (never crash a good scout)."""
+    if not workdir or not os.path.isdir(workdir):
+        return False
+    row = {
+        "gap_id": str(gap_id or feature),
+        "feature": str(feature),
+        "status": str(status),
+        "at": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    }
+    try:
+        with open(os.path.join(workdir, LEDGER), "a") as f:
+            f.write(json.dumps(row) + "\n")
+        return True
+    except OSError as e:
+        import sys
+        print("scout-ledger write failed (non-fatal): %s" % e, file=sys.stderr)
+        return False
+
+
+def read_ledger(workdir):
+    p = os.path.join(workdir or "", LEDGER)
+    if not os.path.exists(p):
+        return []
+    out = []
+    with open(p) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except ValueError:
+                pass
+    return out
+
+
+def classify(workdir, gap_ids):
+    """Split unhandled gap-ids into unscouted / escalated / validated buckets.
+    Mirrors scout_gate.rb#classify exactly (same JSONL ledger contract)."""
+    by = {}
+    for e in read_ledger(workdir):
+        by.setdefault(str(e.get("gap_id")), []).append(e)
+    unscouted = [g for g in gap_ids if str(g) not in by]
+    rest = [g for g in gap_ids if str(g) in by]
+    validated = [g for g in rest if any(x.get("status") == "validated" for x in by[str(g)])]
+    escalated = [g for g in rest if g not in validated]
+    return {"unscouted": unscouted, "escalated": escalated, "validated": validated}

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/lib/sigma_rest.rb
@@ -1,0 +1,130 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Sigma creds aren't in ENV yet, load
+# them from the neutral cred file written by setup.rb. Existing env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env) do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN'] || refresh_token!
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      @token_mutex.synchronize { @token_override = tok }
+      # Surface the refreshed token to child processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/mstr-dm-signature.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/mstr-dm-signature.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""mstr-dm-signature.py — build a DM-reuse signature from the MicroStrategy converter output.
+
+Feeds scripts/find-or-pick-dm.rb (Phase 2.6) so the migration REUSES an existing
+Sigma data model that already covers the same warehouse tables instead of
+creating a near-identical one. Structurally mirrors cognos-dm-signature.py /
+pbi-dm-signature.py (the Sigma DM JSON shape is the same across converters).
+Emits the signature shape find-or-pick-dm expects:
+
+  { "tableau_workbook": "<dossier/project name>",  # label only
+    "warehouse_tables":   ["DB.SCHEMA.TABLE", ...],
+    "referenced_columns": ["Col", ...],
+    "measures":           [{"col": "Col", "derivation": "Sum|CountDistinct|..."}] }
+
+Input = the Phase-2 converter output `sigma_dm_spec.json` (the Sigma data-model
+JSON, BEFORE it is POSTed). Walks every element: `source.path` (warehouse-table)
+-> tables, column `name`/formula tail -> columns, element `metrics` -> measures.
+Custom-SQL elements surface as a CUSTOM_SQL sentinel, same as the picker uses for
+candidate DMs. Pure (no network).
+
+Usage: python3 scripts/mstr-dm-signature.py --dm-spec sigma_dm_spec.json --out dm-signature.json
+"""
+import argparse, json, re, sys
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dm-spec", required=True, help="Phase-2 converter output (sigma_dm_spec.json)")
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+    spec = json.load(open(a.dm_spec))
+
+    elements = spec.get("elements") or [e for p in spec.get("pages", []) for e in p.get("elements", [])]
+    tables, cols, measures = [], [], []
+    for el in elements:
+        src = el.get("source") or {}
+        kind = src.get("kind")
+        if kind in ("warehouse-table", "table"):
+            path = src.get("path")
+            fqn = ".".join(path) if isinstance(path, list) else \
+                  (path or ".".join(p for p in [src.get("database"), src.get("schema"), src.get("name")] if p))
+            if fqn:
+                tables.append(str(fqn).upper())
+        elif kind == "sql":
+            tables.append("CUSTOM_SQL")
+        for c in el.get("columns", []):
+            name = c.get("name")
+            if not name:
+                m = re.search(r"\[.*?([^/\]]+)\]", str(c.get("formula", "")))
+                name = m.group(1) if m else None
+            if name:
+                cols.append(name)
+        for m in el.get("metrics", []):
+            measures.append({"col": m.get("name", ""),
+                             "derivation": m.get("aggregation") or m.get("derivation")})
+
+    sig = {"tableau_workbook": spec.get("name") or "MicroStrategy dossier",
+           "warehouse_tables": sorted(set(tables)),
+           "referenced_columns": sorted(set(cols)),
+           "measures": measures}
+    json.dump(sig, open(a.out, "w"), indent=2)
+    print(f"[mstr-dm-signature] {len(elements)} element(s): {len(sig['warehouse_tables'])} table(s), "
+          f"{len(sig['referenced_columns'])} col(s), {len(measures)} measure(s) -> {a.out}",
+          file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/mstr.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/mstr.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Minimal MicroStrategy (Strategy One) REST client. Zero dependencies.
+
+Usage: import mstr; s = mstr.Session(); s.get('/projects') ...
+
+Credentials (in priority order):
+  1. Environment: MSTR_BASE_URL, MSTR_USERNAME, MSTR_PASSWORD
+     (+ optional MSTR_PROJECT_ID, MSTR_LOGIN_MODE — default 1 = standard)
+  2. The agent-neutral cred file ~/.sigma-migration/env (lines of
+     `export KEY="value"`), same pattern as the sibling sigma-migration-skills.
+
+MSTR_BASE_URL is the Library root, e.g. https://<host>/MicroStrategyLibrary
+(the client appends /api). Auth = POST /api/auth/login -> X-MSTR-AuthToken
+header + session cookies; there is no API-key concept.
+"""
+import json
+import os
+import ssl
+import urllib.error
+import urllib.request
+
+# Some MicroStrategy cloud-trial CA certs lack the key-usage extension;
+# Python 3.13+ rejects them under VERIFY_X509_STRICT (on by default).
+# curl accepts them — relax only the strictness flag, keep verification on.
+_SSL_CTX = ssl.create_default_context()
+_SSL_CTX.verify_flags &= ~ssl.VERIFY_X509_STRICT
+
+CRED_FILE = os.path.expanduser('~/.sigma-migration/env')
+
+
+def _load_env():
+    env = {}
+    if os.path.exists(CRED_FILE):
+        for line in open(CRED_FILE):
+            line = line.strip()
+            if line.startswith('export '):
+                k, _, v = line[7:].partition('=')
+                env[k] = v.strip('"').strip("'")
+    env.update({k: v for k, v in os.environ.items() if k.startswith('MSTR_')})
+    missing = [k for k in ('MSTR_BASE_URL', 'MSTR_USERNAME', 'MSTR_PASSWORD')
+               if not env.get(k)]
+    if missing:
+        raise SystemExit(
+            f'missing {", ".join(missing)} — export them or add them to '
+            f'{CRED_FILE} (export KEY="value" lines)')
+    return env
+
+
+class Session:
+    def __init__(self, project_id=None):
+        e = _load_env()
+        self.base = e['MSTR_BASE_URL'].rstrip('/') + '/api'
+        self.project_id = project_id or e.get('MSTR_PROJECT_ID')
+        self.cookies = {}
+        self.token = None
+        self.last_headers = {}
+        self._login(e['MSTR_USERNAME'], e['MSTR_PASSWORD'],
+                    int(e.get('MSTR_LOGIN_MODE', '1')))
+
+    def _req(self, method, path, body=None, headers=None, raw=False):
+        url = self.base + path
+        h = {'Content-Type': 'application/json', 'Accept': 'application/json'}
+        if self.token:
+            h['X-MSTR-AuthToken'] = self.token
+        if self.project_id:
+            h['X-MSTR-ProjectID'] = self.project_id
+        if self.cookies:
+            h['Cookie'] = '; '.join(f'{k}={v}' for k, v in self.cookies.items())
+        if headers:
+            h.update(headers)
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, headers=h, method=method)
+        try:
+            resp = urllib.request.urlopen(req, context=_SSL_CTX)
+        except urllib.error.HTTPError as err:
+            detail = err.read().decode()[:2000]
+            raise RuntimeError(f'{method} {path} -> {err.code}: {detail}') from None
+        # Response headers, lowercased — instance-save flows need
+        # x-mstr-ms-instance from a *creation response* header.
+        self.last_headers = {k.lower(): v for k, v in resp.headers.items()}
+        for sc in resp.headers.get_all('Set-Cookie') or []:
+            kv = sc.split(';', 1)[0]
+            k, _, v = kv.partition('=')
+            self.cookies[k] = v
+        tok = resp.headers.get('X-MSTR-AuthToken')
+        if tok:
+            self.token = tok
+        text = resp.read().decode()
+        if raw:
+            return text
+        return json.loads(text) if text else None
+
+    def _login(self, user, pw, login_mode=1):
+        self._req('POST', '/auth/login',
+                  {'username': user, 'password': pw, 'loginMode': login_mode})
+
+    def get(self, path, **kw):
+        return self._req('GET', path, **kw)
+
+    def post(self, path, body=None, **kw):
+        return self._req('POST', path, body, **kw)
+
+    def put(self, path, body=None, **kw):
+        return self._req('PUT', path, body, **kw)
+
+    def patch(self, path, body=None, **kw):
+        return self._req('PATCH', path, body, **kw)
+
+    def delete(self, path, **kw):
+        return self._req('DELETE', path, **kw)
+
+    # -- changeset helpers (schema edits require one; reports do NOT) --
+    def changeset(self, schema_edit=True):
+        r = self.post(f'/model/changesets?schemaEdit={"true" if schema_edit else "false"}')
+        return r['id']
+
+    def commit(self, cs_id):
+        r = self.post(f'/model/changesets/{cs_id}/commit',
+                      headers={'X-MSTR-MS-Changeset': cs_id})
+        self.delete(f'/model/changesets/{cs_id}',
+                    headers={'X-MSTR-MS-Changeset': cs_id})
+        return r
+
+    def cs_post(self, path, body, cs_id):
+        return self.post(path, body, headers={'X-MSTR-MS-Changeset': cs_id})
+
+    def abort(self, cs_id):
+        """Delete a changeset (releases its schema lock)."""
+        try:
+            self.delete(f'/model/changesets/{cs_id}',
+                        headers={'X-MSTR-MS-Changeset': cs_id})
+        except Exception:
+            pass
+
+    def schema_edit(self, fn):
+        """Run fn(cs_id) inside a schema changeset; commit on success,
+        abort on failure so the schema lock is never left dangling.
+        (A failed call inside an undeleted changeset leaves 'Schema editing
+        is in use by another user' — clear via DELETE /api/model/schema/lock.)"""
+        cs = self.changeset()
+        try:
+            result = fn(cs)
+        except Exception:
+            self.abort(cs)
+            raise
+        self.commit(cs)
+        return result
+
+
+if __name__ == '__main__':
+    s = Session()
+    print('token ok; projects:', [p['name'] for p in s.get('/projects')])

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/pick_destination.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/pick_destination.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Shared destination picker for the *-to-sigma migration skills (Python port).
+Produces the folderId where a migrated data model + workbook should land.
+The SKILL drives the *asking*; this script lists candidates and creates folders.
+
+  python3 pick_destination.py list
+      -> {"workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+          "myDocuments": "<id>"|null}
+      Only EDIT-able folders are returned. folderId in a DM/workbook POST accepts
+      a workspace id (lands in the workspace root) or a folder id.
+
+  python3 pick_destination.py create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+      -> {"id","name","parentId"}
+
+Auth: SIGMA_API_TOKEN + SIGMA_BASE_URL if set (e.g. via get-token.sh); otherwise
+minted from SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (sourced from ~/.sigma-migration/env).
+"""
+import json, os, sys, urllib.request, urllib.parse, urllib.error
+
+def _load_neutral_env():
+    if os.environ.get("SIGMA_CLIENT_ID") or os.environ.get("SIGMA_API_TOKEN"):
+        return
+    p = os.path.expanduser("~/.sigma-migration/env")
+    if os.path.exists(p):
+        for line in open(p):
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, v = line.split("=", 1)
+            os.environ.setdefault(k.strip(), v.strip().strip('"').strip("'"))
+
+def _base():
+    return os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com").rstrip("/")
+
+def _token():
+    tok = os.environ.get("SIGMA_API_TOKEN")
+    if tok:
+        return tok
+    _load_neutral_env()
+    data = urllib.parse.urlencode({
+        "grant_type": "client_credentials",
+        "client_id": os.environ["SIGMA_CLIENT_ID"],
+        "client_secret": os.environ["SIGMA_CLIENT_SECRET"],
+    }).encode()
+    req = urllib.request.Request(_base() + "/v2/auth/token", data=data)
+    return json.load(urllib.request.urlopen(req))["access_token"]
+
+_TOK = None
+def call(method, path, body=None):
+    global _TOK
+    if _TOK is None:
+        _TOK = _token()
+    url = _base() + path
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(url, data=data, method=method,
+        headers={"Authorization": "Bearer " + _TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+            return json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"{method} {path} -> {e.code} {e.read().decode()[:300]}")
+
+def my_documents_id():
+    try:
+        uid = (call("GET", "/v2/whoami") or {}).get("userId")
+        if not uid:
+            return None
+        entries = (call("GET", f"/v2/members/{uid}/files?typeFilters=folder&limit=500") or {}).get("entries", [])
+        for e in entries:
+            if e.get("name") == "My Documents" or e.get("path") == "My Documents":
+                return e.get("id")
+    except Exception:
+        return None
+    return None
+
+def cmd_list():
+    ws = (call("GET", "/v2/workspaces?limit=500") or {}).get("entries", [])
+    workspaces = [{"id": w.get("workspaceId") or w.get("id"), "name": w.get("name")} for w in ws]
+    ws_name = {w["id"]: w["name"] for w in workspaces}
+    fl = (call("GET", "/v2/files?typeFilters=folder&limit=500") or {}).get("entries", [])
+    folders = [{"id": f["id"], "name": f["name"], "parentId": f.get("parentId"),
+                "parentName": ws_name.get(f.get("parentId"))}
+               for f in fl if f.get("permission") == "edit"]
+    print(json.dumps({"workspaces": workspaces, "folders": folders,
+                      "myDocuments": my_documents_id()}, indent=2))
+
+def cmd_create(argv):
+    name = parent = None
+    i = 0
+    while i < len(argv):
+        if argv[i] == "--name":
+            name = argv[i + 1]; i += 2
+        elif argv[i] == "--parent":
+            parent = argv[i + 1]; i += 2
+        else:
+            i += 1
+    if not name:
+        raise SystemExit("pick_destination create: --name is required")
+    if not parent:
+        parent = my_documents_id()
+    body = {"type": "folder", "name": name}
+    if parent:
+        body["parentId"] = parent
+    res = call("POST", "/v2/files", body)
+    print(json.dumps({"id": res.get("id"), "name": res.get("name"), "parentId": res.get("parentId")}, indent=2))
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "list"
+    if cmd == "list":
+        cmd_list()
+    elif cmd == "create":
+        cmd_create(sys.argv[2:])
+    else:
+        raise SystemExit("usage: pick_destination.py [list | create --name NAME [--parent ID]]")

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/probe-controls.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/probe-controls.rb
@@ -1,0 +1,236 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# probe-controls.rb — live flip test proving a workbook's controls actually
+# filter what they claim to. OPTIONAL Phase 6 step (not the mandatory inner
+# loop): run it after the control lint (gate 7) passes when you want runtime
+# evidence, after repairing control wiring on a live workbook, or whenever a
+# control's reach was wired by hand.
+#
+# SHARED script, vendored byte-identical into every covered plugin's scripts/
+# (md5 discipline — same as scripts/lib/control_lint.rb, which it reuses).
+#
+# What it does, per control:
+#   1. computes the control's reach (filter targets + [controlId] formula
+#      references, expanded through source.elementId chains —
+#      ControlLint.controls_report)
+#   2. exports one IN-closure queryable element as CSV twice via
+#      POST /v2/workbooks/{id}/export — once with no `parameters` (the saved
+#      control defaults) and once with parameters:{<controlId>: <flip value>}.
+#      The two CSVs MUST differ, or the control is wired but inert -> FAIL.
+#   3. with --check-out-of-closure: also exports one same-page queryable
+#      element OUTSIDE the closure with and without the parameter — those
+#      MUST be identical (the flip must not leak) -> FAIL if they differ
+#      (the closure walk missed an edge; fix control_lint, not the workbook).
+#
+# Flip-value selection ("first non-default value"):
+#   --value <controlId>=<value> beats everything (repeatable).
+#   Otherwise: the control's value-source column (source.columnId, falling
+#   back to the first filter target's columnId) is resolved to its display
+#   label via GET /v2/workbooks/{id}/columns, that element is exported once,
+#   and the first distinct value of that column NOT in the control's saved
+#   defaults (`values`) is used. switch controls flip true<->false. Controls
+#   whose value cannot be auto-picked (date ranges, numeric sliders, missing
+#   labels) are SKIPped with a NOTE — pass --value for those.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query / claude.ai Sigma MCP)
+# evaluates workbook elements WITH the saved control defaults applied and
+# exposes NO parameter mechanism to set a control value. The REST export API
+# (POST /v2/workbooks/{id}/export with "parameters": {"<controlId>": "<val>"})
+# is the ONLY programmatic way to exercise a non-default control value —
+# which is why this probe is built on export, not MCP. (MCP is still fine for
+# default-state parity checks — Phase 6 uses it for exactly that.)
+#
+# Usage:
+#   ruby scripts/probe-controls.rb --workbook-id <id> \
+#     [--control <controlId>]        # probe just one control (repeatable)
+#     [--value <controlId>=<value>]  # explicit flip value (repeatable)
+#     [--check-out-of-closure]       # also assert the flip does NOT leak
+#     [--out DIR]                    # CSV evidence dir (default /tmp/probe-controls-<id>)
+#     [--timeout SECS]               # export poll timeout per CSV (default 90)
+#
+# Exit codes: 0 = every probed control flips correctly (skips allowed);
+#             1 = at least one FAIL; 2 = no control could be probed at all.
+require 'json'
+require 'csv'
+require 'optparse'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+require 'control_lint'
+
+opts = { values: {}, controls: [], timeout: 90 }
+OptionParser.new do |p|
+  p.on('--workbook-id ID')        { |v| opts[:wb] = v }
+  p.on('--control CID')           { |v| opts[:controls] << v }
+  p.on('--value SPEC', '<controlId>=<value>') do |v|
+    cid, val = v.split('=', 2)
+    abort "bad --value #{v.inspect} (want <controlId>=<value>)" unless cid && val
+    opts[:values][cid] = val
+  end
+  p.on('--check-out-of-closure')  { opts[:check_out] = true }
+  p.on('--out DIR')               { |v| opts[:out] = v }
+  p.on('--timeout SECS', Integer) { |v| opts[:timeout] = v }
+end.parse!
+abort('--workbook-id required') unless opts[:wb]
+WB = opts[:wb]
+OUT = opts[:out] || "/tmp/probe-controls-#{WB}"
+FileUtils.mkdir_p(OUT)
+
+# --- Sigma plumbing ---------------------------------------------------------
+
+def fetch_spec(wb)
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'application/json')
+  return body if body.is_a?(Hash)
+  require 'yaml'
+  require 'date'
+  YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {}
+end
+
+# Export an element as CSV (optionally with control parameters), poll the
+# query download until ready, return the CSV text. Raises on timeout/error.
+def export_csv(wb, element_id, params, timeout)
+  body = { 'elementId' => element_id, 'format' => { 'type' => 'csv' } }
+  body['parameters'] = params if params && !params.empty?
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+  qid = res.is_a?(Hash) && res['queryId']
+  raise "export request failed: #{res.inspect}" unless qid
+  deadline = Time.now + timeout
+  loop do
+    uri = URI("#{Sigma.base_url}/v2/query/#{qid}/download")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    r = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 60) { |h| h.request(req) }
+    return r.body if r.code.to_i == 200
+    raise "export download failed: HTTP #{r.code} #{r.body.to_s[0, 300]}" if r.code.to_i >= 400 && r.code.to_i != 404
+    raise "export timed out after #{timeout}s (queryId=#{qid})" if Time.now > deadline
+    sleep 2
+  end
+end
+
+# Row-order-insensitive CSV signature (filters change row SETS; ordering noise
+# must not mask or fake a flip).
+def csv_sig(text)
+  text.to_s.lines.map(&:chomp).sort
+end
+
+# --- reach + element metadata ------------------------------------------------
+
+spec  = fetch_spec(WB)
+elems = ControlLint.elements(spec)
+rows  = ControlLint.controls_report(spec)
+rows.select! { |r| opts[:controls].include?(r[:control_id]) } if opts[:controls].any?
+abort "no controls found in workbook #{WB}#{opts[:controls].any? ? " matching #{opts[:controls].inspect}" : ''}" if rows.empty?
+
+cols = Sigma.request(:get, "/v2/workbooks/#{WB}/columns")
+col_label = {} # [elementId, columnId] -> display label
+(cols && cols['entries'] || []).each do |c|
+  col_label[[c['elementId'], c['columnId']]] = c['label'] if c['elementId'] && c['columnId']
+end
+
+baseline_cache = {}
+get_baseline = lambda do |eid|
+  baseline_cache[eid] ||= export_csv(WB, eid, nil, opts[:timeout])
+end
+
+# Pick the flip value for a control (returns [value, note] — value nil = skip).
+pick_value = lambda do |r|
+  el = elems[r[:control_element_id]][:el]
+  cid = r[:control_id]
+  return [opts[:values][cid], 'explicit --value'] if opts[:values].key?(cid)
+  defaults = Array(el['values']).map(&:to_s)
+  case el['controlType'].to_s
+  when 'switch'
+    return [(defaults.first.to_s.downcase == 'true' ? 'false' : 'true'), 'switch flip']
+  when 'list', 'segmented', 'text'
+    src = el['source']
+    src = src['source'].merge('columnId' => src['columnId']) if src.is_a?(Hash) && src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src = (el['filters'] || []).map { |f| f.is_a?(Hash) ? (f['source'] || {}).merge('columnId' => f['columnId']) : nil }.compact.first if !src.is_a?(Hash) || !src['columnId']
+    return [nil, 'no value-source column resolvable — pass --value'] unless src.is_a?(Hash) && src['elementId'] && src['columnId']
+    label = col_label[[src['elementId'], src['columnId']]]
+    return [nil, "no /columns label for #{src['elementId']}/#{src['columnId']} — pass --value"] unless label
+    csv = CSV.parse(get_baseline.call(src['elementId']), headers: true)
+    return [nil, "column #{label.inspect} not in export of #{src['elementId']} — pass --value"] unless csv.headers.include?(label)
+    distinct = csv.map { |row| row[label] }.compact.map(&:to_s).reject(&:empty?).uniq
+    val = distinct.find { |v| !defaults.include?(v) }
+    val ? [val, "auto-picked from #{label.inspect}"] : [nil, 'no non-default value found — pass --value']
+  else
+    [nil, "controlType=#{el['controlType'].inspect} has no auto flip value — pass --value"]
+  end
+end
+
+# --- probe loop ----------------------------------------------------------------
+
+failures = 0
+probed = 0
+results = []
+rows.each do |r|
+  cid = r[:control_id]
+  ctl = "#{r[:name].inspect} [#{cid}]"
+  if r[:reach].empty?
+    results << { control: cid, result: 'FAIL', note: 'dead control — empty reach (run the control lint)' }
+    failures += 1
+    next
+  end
+
+  in_el = (r[:reach] & r[:page_queryable]).first ||
+          r[:reach].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if in_el.nil?
+    results << { control: cid, result: 'SKIP', note: 'no queryable element in closure' }
+    next
+  end
+
+  val, note = pick_value.call(r)
+  if val.nil?
+    results << { control: cid, result: 'SKIP', note: note }
+    next
+  end
+
+  probed += 1
+  base = get_baseline.call(in_el)
+  flip = export_csv(WB, in_el, { cid => val }, opts[:timeout])
+  File.write(File.join(OUT, "#{cid}--#{in_el}--base.csv"), base)
+  File.write(File.join(OUT, "#{cid}--#{in_el}--flip.csv"), flip)
+  changed = csv_sig(base) != csv_sig(flip)
+  if changed
+    results << { control: cid, result: 'PASS', element: in_el, value: val,
+                 note: "#{note}; in-closure export differs (#{base.lines.count - 1} -> #{flip.lines.count - 1} rows)" }
+  else
+    failures += 1
+    results << { control: cid, result: 'FAIL', element: in_el, value: val,
+                 note: "#{note}; in-closure export IDENTICAL with #{cid}=#{val.inspect} — control is wired but inert" }
+  end
+
+  next unless opts[:check_out]
+  out_el = r[:uncovered].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if out_el.nil?
+    results << { control: cid, result: 'OK', note: 'out-of-closure: none on page (full reach) — nothing to check' }
+  else
+    obase = get_baseline.call(out_el)
+    oflip = export_csv(WB, out_el, { cid => val }, opts[:timeout])
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-base.csv"), obase)
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-flip.csv"), oflip)
+    if csv_sig(obase) == csv_sig(oflip)
+      results << { control: cid, result: 'OK', element: out_el, note: 'out-of-closure export unchanged (no leak)' }
+    else
+      failures += 1
+      results << { control: cid, result: 'FAIL', element: out_el,
+                   note: 'out-of-closure export CHANGED — the closure walk missed an edge (fix control_lint, not the workbook)' }
+    end
+  end
+end
+
+puts format('%-22s %-6s %-34s %s', 'CONTROL', 'RESULT', 'ELEMENT', 'NOTE')
+results.each do |x|
+  puts format('%-22s %-6s %-34s %s', x[:control], x[:result], x[:element] || '-', [x[:value] && "flip=#{x[:value].inspect}", x[:note]].compact.join('; '))
+end
+File.write(File.join(OUT, 'probe-results.json'), JSON.pretty_generate(results))
+puts "evidence: #{OUT}/ (CSVs + probe-results.json)"
+
+exit 1 if failures.positive?
+exit 2 if probed.zero?
+exit 0

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/put-layout.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/put-layout.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# GET a workbook spec, replace per-page layouts with a single top-level layout
+# XML (provided), strip read-only fields, PUT back.
+#
+# Container layouts: a <GridContainer> in the layout XML must be paired with a
+# `kind: container` placeholder element in the spec (else it is silently
+# dropped — layout-playbook.md). Layout builders that emit GridContainers
+# write a sidecar `<layout>.elements.json` ({pageId: [element, ...]}) next to
+# the layout XML; this script injects those elements (containers + header
+# text) into the matching pages before the PUT. Pass --elements to override
+# the sidecar path. Injection is idempotent (existing element ids are kept).
+#
+# Usage:
+#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml> \
+#     [--elements <elements.json>]
+
+require 'json'
+require 'yaml'
+require 'date'
+require 'optparse'
+# sigma_rest self-exchanges SIGMA_CLIENT_ID/SECRET (auto-loading
+# ~/.sigma-migration/env) exactly like the phase 1-4 scripts — SIGMA_API_TOKEN
+# is optional, not a hard requirement (bead eqom).
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook ID') { |v| opts[:wb] = v }
+  p.on('--layout PATH') { |v| opts[:layout] = v }
+  p.on('--elements PATH', 'spec elements to inject (default: <layout>.elements.json if present)') { |v| opts[:elements] = v }
+end.parse!
+%i[wb layout].each { |k| abort("missing --#{k}") unless opts[k] }
+
+def http(method, path, body = nil)
+  Sigma.request(method, path, body: body, binary: true)
+end
+
+xml = File.read(opts[:layout])
+abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
+
+spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec"))
+spec['pages'].each { |p| p.delete('layout') }
+spec['layout'] = xml
+
+# Inject container/header-text spec elements (see header comment).
+elements_path = opts[:elements] || "#{opts[:layout]}.elements.json"
+if File.exist?(elements_path)
+  inject = JSON.parse(File.read(elements_path))
+  injected = 0
+  inject.each do |page_id, els|
+    page = spec['pages'].find { |p| p['id'] == page_id }
+    unless page
+      warn "WARN: elements sidecar references unknown page #{page_id.inspect} — skipped"
+      next
+    end
+    page['elements'] ||= []
+    existing = page['elements'].map { |e| e['id'] }
+    els.each do |el|
+      next if existing.include?(el['id'])
+      page['elements'] << el
+      injected += 1
+    end
+  end
+  puts "injected #{injected} container/header element(s) from #{elements_path}"
+end
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
+
+begin
+  resp_body = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))
+rescue Sigma::Error => e
+  puts "ERROR: #{e.message}"
+  exit 1
+end
+parsed = YAML.safe_load(resp_body, permitted_classes: [Date, Time])
+puts parsed['workbookId'] ? "PUT ok: workbookId=#{parsed['workbookId']}" : "ERROR: #{parsed.inspect}"
+exit(parsed['workbookId'] ? 0 : 1)

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/resolve_ae_winners.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/resolve_ae_winners.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+resolve_ae_winners.py — pin MicroStrategy Analytical-Engine representative rows.
+
+Why: when an attribute's key form is non-unique in its lookup table (here:
+Month.key = MONTH_NUMBER while DATE_DIM carries multiple MONTH_NAME spellings
+and repeats month numbers across years), MicroStrategy's Analytical Engine
+collapses the per-(parent, key) SQL result to ONE arbitrary-but-stable
+representative row per key and cross-tabs it across the parent attribute.
+The representative is a hash artifact of the engine — it cannot be derived
+from the model bundle. This script pins it empirically:
+
+  1. Re-execute each affected report via the MicroStrategy REST API.
+  2. Compute the clean per-(parents, key) aggregates from the warehouse
+     (same SQL MicroStrategy generated) via a temporary Sigma workbook.
+  3. Match each key's MSTR-reported label+values to the unique clean row.
+  4. Emit ae_winners.json for convert.py.
+
+A report is affected when one of its attribute units has a DESC form
+(label column distinct from the grouping key). Reports without such
+attributes are skipped (their grids are clean).
+
+Usage: python3 resolve_ae_winners.py --connection-id <uuid> --database CSA \
+          [--bundle bundle.json] [--folder-id <uuid>] [--out ae_winners.json]
+"""
+import argparse
+import csv
+import io
+import json
+import time
+
+import mstr
+from convert import Bundle, friendly
+from verify_parity import api, export_element
+
+
+def run_mstr_grid(s, report_id):
+    """Execute a report, return list of (keys_tuple, values_list)."""
+    inst = s.post(f"/v2/reports/{report_id}/instances?limit=500", {})
+    d, data = inst["definition"], inst["data"]
+    rowsets = d["grid"]["rows"]
+    attr_elems = []
+    for unit in rowsets:
+        attr_elems.append([
+            e.get("formValues", [None])[0] if e.get("formValues") else e.get("name")
+            for e in unit["elements"]])
+    out = []
+    for i, h in enumerate(data["headers"]["rows"]):
+        keys = tuple(attr_elems[j][idx] for j, idx in enumerate(h))
+        out.append((keys, data["metricValues"]["raw"][i]))
+    return out
+
+
+def clean_groups_via_sigma(b, args, report, quirk_aid, parent_aids):
+    """Run the clean per-(parents, key) aggregation on the warehouse through a
+    temporary Sigma workbook (sql element) and return the rows."""
+    sql = b.build_clean_group_sql(args.database, report)
+    spec = {
+        "name": "zz-ae-resolver-probe",
+        "folderId": args.folder_id,
+        "schemaVersion": 1,
+        "pages": [{"id": "p1", "name": "P", "elements": [{
+            "id": "t1", "kind": "table", "name": "Probe",
+            "source": {"kind": "sql", "connectionId": args.connection_id,
+                       "statement": sql},
+            "columns": [
+                {"id": f"c{i}", "name": alias,
+                 "formula": f"[Custom SQL/{alias}]"}
+                for i, alias in enumerate(b.clean_group_aliases(report))
+            ],
+        }]}],
+    }
+    st, out = api("POST", "/v2/workbooks/spec", spec)
+    if st >= 300:
+        raise SystemExit(f"probe workbook POST failed {st}: {out[:500]}")
+    wb_id = json.loads(out)["workbookId"]
+    try:
+        # element id may be remapped — read back
+        import yaml
+        st, out = api("GET", f"/v2/workbooks/{wb_id}/spec")
+        eid = yaml.safe_load(out)["pages"][0]["elements"][0]["id"]
+        csv_text = export_element(wb_id, eid)
+    finally:
+        api("DELETE", f"/v2/files/{wb_id}")
+    return list(csv.DictReader(io.StringIO(csv_text)))
+
+
+def close(a, b_, tol=1e-6):
+    try:
+        fa, fb = float(a), float(b_)
+    except (TypeError, ValueError):
+        return str(a) == str(b_)
+    return abs(fa - fb) <= tol * max(abs(fb), 1.0)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bundle", default="bundle.json")
+    ap.add_argument("--connection-id", required=True)
+    ap.add_argument("--database", default="CSA")
+    ap.add_argument("--folder-id", required=True)
+    ap.add_argument("--out", default="ae_winners.json")
+    args = ap.parse_args()
+
+    b = Bundle(json.load(open(args.bundle)))
+    s = mstr.Session()
+    result = {}
+
+    for rid, report in b.reports.items():
+        rname = report["information"]["name"]
+        units = report["dataSource"]["dataTemplate"]["units"]
+        attr_units = [u for u in units if u.get("type") == "attribute"]
+        quirk = None
+        for u in attr_units:
+            key_col, desc_col = b.attribute_unit_cols(u["id"])
+            if desc_col:
+                quirk = (u["id"], key_col, desc_col)
+        if not quirk:
+            continue  # clean report — no DESC-form attribute
+        quirk_aid, qkey, qdesc = quirk
+        parent_units = [u for u in attr_units if u["id"] != quirk_aid]
+        parent_cols = [b.attribute_unit_cols(u["id"])[0] for u in parent_units]
+
+        print(f"resolving AE representatives for {rname!r} "
+              f"(quirk attr key={qkey} desc={qdesc})")
+        grid = run_mstr_grid(s, rid)
+        clean = clean_groups_via_sigma(b, args, report,
+                                       quirk_aid, [u["id"] for u in parent_units])
+
+        qkey_f, qdesc_f = friendly(qkey), friendly(qdesc)
+        parent_f = [friendly(c) for c in parent_cols]
+        metric_names = [el["name"] for u in units if u.get("type") == "metrics"
+                        for el in u["elements"]]
+
+        # MSTR grid: label + values per quirk element (identical across parents)
+        per_label = {}
+        for keys, vals in grid:
+            label = keys[-1]  # quirk attr is rendered by its DESC form
+            per_label.setdefault(label, vals)
+
+        winners = []
+        for label, vals in per_label.items():
+            cands = [r for r in clean
+                     if r[qdesc_f] == label
+                     and all(close(r[m], v) for m, v in zip(metric_names, vals))]
+            keys_seen = {tuple(r[p] for p in parent_f) +
+                         (r[qkey_f],) for r in cands}
+            if len(keys_seen) != 1:
+                raise SystemExit(
+                    f"{rname}: could not uniquely match label {label!r} "
+                    f"{vals} -> {len(keys_seen)} candidates")
+            r = cands[0]
+            w = {qkey_f: r[qkey_f]}
+            for p in parent_f:
+                w[p] = r[p]
+            winners.append(w)
+            print(f"  {label!r:14} -> {w}")
+
+        result[rname] = {
+            "quirkKeyCol": qkey, "quirkDescCol": qdesc,
+            "parentKeyCols": parent_cols,
+            "winners": winners,
+        }
+
+    json.dump(result, open(args.out, "w"), indent=1)
+    print(f"wrote {args.out} ({len(result)} report(s))")
+
+
+if __name__ == "__main__":
+    main()

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/scout-gate-readback.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/scout-gate-readback.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""scout-gate-readback — the run-each-time gap-scout gate for MicroStrategy → Sigma
+(bead beads-sigma-5l5e).
+
+MSTR's converter (convert.py metric_formula) passes metric function names through
+optimistically — a function with no Sigma equivalent does NOT surface as a
+convert-time warning; it surfaces as a type=error column when the freshly-POSTed
+workbook is read back. There is no Python orchestrator that POSTs (Phase 4 of
+SKILL.md POSTs the workbook via curl), so this standalone script IS the mechanical
+gate: SKILL.md mandates running it immediately after the workbook POST, replacing
+the prose "check for type:error columns" instruction with a hard, scripted STOP.
+
+Run it after the workbook POST (Phase 4):
+    eval "$(scripts/get-token.sh)"
+    python3 scripts/scout-gate-readback.py --workbook-id <id> --workdir <dir>
+
+Behavior (mirrors the looker / thoughtspot readback gate):
+  - GET /v2/workbooks/{id}/columns, find type=error columns.
+  - gap-id = errcol:<elementId>/<label>; classify against <workdir>/scout-ledger.jsonl.
+  - any UNSCOUTED error column  -> exit 11 (GAP-SCOUT REQUIRED; scout each, re-run).
+    --yes does NOT skip this gate; it only accepts columns the scout already tried.
+  - every error column scouted (validated or escalated) -> exit 0 (proceed).
+  - no error columns -> exit 0.
+
+Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (eval get-token.sh first).
+"""
+import argparse
+import json
+import os
+import sys
+import urllib.request
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import scout_gate
+
+BASE = os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com")
+TOKEN = os.environ.get("SIGMA_API_TOKEN") or sys.exit(
+    'SIGMA_API_TOKEN not set — run: eval "$(scripts/get-token.sh)"')
+
+
+def api(method, path):
+    req = urllib.request.Request(BASE + path, method=method)
+    req.add_header("Authorization", "Bearer " + TOKEN)
+    req.add_header("Accept", "application/json")
+    try:
+        with urllib.request.urlopen(req) as r:
+            return r.status, r.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook-id", required=True)
+    ap.add_argument("--workdir", required=True,
+                    help="conversion working dir holding scout-ledger.jsonl")
+    ap.add_argument("--yes", action="store_true",
+                    help="(does NOT skip the gate; present for parity — an unscouted "
+                         "error column always stops)")
+    a = ap.parse_args()
+
+    st, body = api("GET", f"/v2/workbooks/{a.workbook_id}/columns")
+    if st >= 300:
+        sys.exit(f"FATAL: columns GET failed {st}: {body[:300]}")
+    cols = json.loads(body)
+    entries = cols.get("entries") if isinstance(cols, dict) else cols
+    entries = entries or []
+    errs = [c for c in entries if (c.get("type") or {}).get("type") == "error"]
+    n = len(entries)
+    print(f"workbook {a.workbook_id}: {n - len(errs)}/{n} columns resolve"
+          + (f" — {len(errs)} ERROR-typed" if errs else ""))
+    if not errs:
+        return
+    for c in errs[:6]:
+        print(f"  [{c.get('elementId')}] {c.get('label')}: {c.get('formula')}")
+
+    gid = lambda c: "errcol:%s/%s" % (c.get("elementId"), c.get("label"))
+    gap_ids = list(dict.fromkeys(gid(c) for c in errs))
+    bk = scout_gate.classify(a.workdir, gap_ids)
+    if bk["unscouted"]:
+        print("\n==================== GAP-SCOUT REQUIRED ====================")
+        print("%d of %d ERROR-typed column(s) have NOT been scouted — the gap-scout must"
+              % (len(bk["unscouted"]), len(gap_ids)))
+        print("attempt a Sigma translation before a broken column ships:")
+        for i in bk["unscouted"]:
+            print("  --gap-id '%s'" % i)
+        print("\nSpawn one gap-scout per column (scripts/gap-scout.md) with the exact --gap-id")
+        print("above plus --workdir %s, then re-run this gate. --yes does NOT skip it." % a.workdir)
+        print("===========================================================")
+        sys.exit(11)
+    print("gap-scout: all %d error column(s) accounted for (validated or escalated)" % len(gap_ids))
+
+
+if __name__ == "__main__":
+    main()

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/scout-validate.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/scout-validate.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""scout-validate — gap-scout validation primitive (MicroStrategy → Sigma).
+
+Validates a candidate Sigma formula against a real data-model element by building a
+throwaway test workbook, checking the column resolves (type != "error"), and — on
+success — persisting the rule to the customer-local learned-rules.yaml. Generic across
+skills via --home.
+
+The MSTR converter (convert.py metric_formula) passes metric function names through
+optimistically — a function with no Sigma equivalent surfaces as a type=error column
+when the workbook is read back. Use this to confirm a candidate replacement resolves.
+
+    python3 scout-validate.py \
+      --formula 'CumulativeSum([Master/Net Revenue])' \
+      --data-model-id <dm> --element-id <denorm-elem-id> --folder-id <folder> \
+      --feature 'RunningSum' --pattern '\\bRunningSum\\s*\\(' \
+      --template 'CumulativeSum([Master/\\1])' --hint 'date-grouped element' \
+      --description 'MSTR RunningSum -> Sigma CumulativeSum' --home ~/.microstrategy-to-sigma
+
+To feed the run-each-time gap-scout gate (bead beads-sigma-5l5e), also pass the
+error column's gate id and the conversion working dir — the result is appended to
+<workdir>/scout-ledger.jsonl so scout-gate-readback.py sees the gap as scouted
+(validated → ok; error → escalated):
+
+      --gap-id 'errcol:<elementId>/<label>' --workdir <wd>
+
+Env: SIGMA_BASE_URL, SIGMA_API_TOKEN (eval get-token.sh first).
+Prints JSON: {status: validated|error, workbook_id, error, ...}. Cleans up the test workbook.
+"""
+import json, os, sys, urllib.request, argparse, datetime, re
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "lib"))
+import scout_gate
+
+BASE = os.environ["SIGMA_BASE_URL"]; TOK = os.environ["SIGMA_API_TOKEN"]
+def api(method, path, body=None, accept_json=True):
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(BASE+path, data=data, method=method,
+        headers={"Authorization":"Bearer "+TOK, "Content-Type":"application/json",
+                 **({"Accept":"application/json"} if accept_json else {})})
+    try:
+        r = urllib.request.urlopen(req); return r.status, r.read().decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+
+def dm_element_master_columns(dm_id, el_id):
+    """Read the DM spec, find the element, return (elementName, [displayName,...])."""
+    st, body = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    spec = json.loads(body)
+    for pg in spec.get("pages", []):
+        for el in pg.get("elements", []):
+            if el.get("id") == el_id:
+                src = el.get("source", {})
+                name = el.get("name") or ("Custom SQL" if src.get("kind")=="sql"
+                       else (src.get("path",["Element"])[-1] if src.get("kind")=="warehouse-table" else "Element"))
+                cols = []
+                for c in el.get("columns", []):
+                    dn = c.get("name") or re.sub(r'.*/', '', c.get("formula","").strip("[]"))
+                    cols.append(dn)
+                return name, cols
+    raise SystemExit("element not found in DM spec")
+
+def build_escalation(a, err):
+    """Record the gap locally and return opt-in escalate-gap.py commands.
+
+    Filing a tracking issue is NOT automatic: the main agent runs dry_run_cmd
+    (drafts the issue + dedupes against open issues/beads), shows the user, and
+    runs file_cmd only if they accept. Source-formula gaps are converter gaps."""
+    import shlex
+    skill = (a.skill or os.path.basename(os.path.normpath(a.home)).lstrip("."))
+    esc_dir = os.path.join(a.home, "escalations"); os.makedirs(esc_dir, exist_ok=True)
+    slug = re.sub(r"[^a-z0-9]+", "-", a.feature.lower()).strip("-") or "gap"
+    ts = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    esc_path = os.path.join(esc_dir, f"{ts}-{slug}.yaml")
+    payload = {"feature": a.feature, "description": a.description,
+               "source_pattern": a.pattern, "sigma_template_attempted": a.template,
+               "test_formula": a.formula, "example_from": a.example_from,
+               "error_column": err, "escalated_at": ts}
+    try:
+        import yaml; yaml.safe_dump(payload, open(esc_path, "w"), sort_keys=False)
+    except Exception:
+        json.dump(payload, open(esc_path, "w"), indent=2)
+    filer = os.path.join(os.path.dirname(os.path.abspath(__file__)), "escalate-gap.py")
+    cmd = ["python3", filer, "--skill", skill, "--category", "converter",
+           "--feature", a.feature, "--description", a.description or "",
+           "--source-pattern", a.pattern or "", "--template-attempted", a.template or "",
+           "--test-formula", a.formula, "--sigma-response", json.dumps(err)[:1500],
+           "--example-from", a.example_from or "", "--escalation-yaml", esc_path]
+    dry = " ".join(shlex.quote(c) for c in cmd)
+    return {"note": "Gap recorded locally. Filing a tracking issue is opt-in — run "
+                    "dry_run_cmd, show the user, then file_cmd only if they accept.",
+            "escalation_yaml": esc_path, "dry_run_cmd": dry, "file_cmd": dry + " --yes"}
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    for f in ["formula","data-model-id","element-id","feature"]:
+        ap.add_argument("--"+f, required=True)
+    ap.add_argument("--folder-id", required=True)
+    ap.add_argument("--pattern"); ap.add_argument("--template")
+    ap.add_argument("--hint", default=""); ap.add_argument("--description", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--kind", default="kpi-chart", choices=["kpi-chart","table"])
+    ap.add_argument("--home", default=os.path.expanduser("~/.microstrategy-to-sigma"))
+    ap.add_argument("--skill", default="", help="skill name for issue routing (default: derived from --home)")
+    ap.add_argument("--gap-id", default="", help="error column this scout addressed (gate ledger; e.g. errcol:<elementId>/<label>)")
+    ap.add_argument("--workdir", default="", help="conversion working dir; ledger written here")
+    a = ap.parse_args()
+
+    elem_name, cols = dm_element_master_columns(a.data_model_id, a.element_id)
+    master = {"id":"m","name":"Master","kind":"table",
+              "source":{"dataModelId":a.data_model_id,"elementId":a.element_id,"kind":"data-model"},
+              "columns":[{"id":f"mc{i}","name":c,"formula":f"[{elem_name}/{c}]"} for i,c in enumerate(cols)]}
+    if a.kind == "kpi-chart":
+        test = {"id":"scout","kind":"kpi-chart","name":"scout","source":{"elementId":"m","kind":"table"},
+                "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}],"value":{"columnId":"sc"}}
+    else:
+        test = {"id":"scout","kind":"table","name":"scout","source":{"elementId":"m","kind":"table"},
+                "columns":[{"id":"sc","formula":a.formula,"name":"scout_test"}]}
+    spec = {"name":f"SCOUT TEST {a.feature}","folderId":a.folder_id,"schemaVersion":1,
+            "pages":[{"id":"d","name":"Data","elements":[master]},{"id":"t","name":"Test","elements":[test]}]}
+    st, body = api("POST","/v2/workbooks/spec",spec)
+    wb = None
+    try: wb = json.loads(body).get("workbookId")
+    except Exception: pass
+    if not wb:
+        m = re.search(r'workbookId:\s*(\S+)', body)
+        if m: wb = m.group(1)
+    result = {"feature":a.feature,"formula":a.formula,"workbook_id":wb}
+    if not wb:
+        print(json.dumps({**result,"status":"error","error":"POST failed: "+body[:200]})); return
+    # check the test column's type
+    st2, cbody = api("GET", f"/v2/workbooks/{wb}/elements/scout/columns")
+    err = None
+    try:
+        colsout = json.loads(cbody)
+        entries = colsout.get("entries", colsout) if isinstance(colsout, dict) else colsout
+        for c in (entries or []):
+            t = (c.get("type") or {})
+            if (t.get("type") or t) == "error" or "error" in str(t).lower():
+                err = c
+    except Exception as e:
+        err = {"parse": str(e), "raw": cbody[:200]}
+    status = "error" if err else "validated"
+    # persist on success
+    if status == "validated":
+        if a.pattern and a.template:
+            os.makedirs(a.home, exist_ok=True)
+            import yaml
+            rp = os.path.join(a.home, "learned-rules.yaml")
+            doc = yaml.safe_load(open(rp)) if os.path.exists(rp) else None
+            doc = doc or {"rules":[]}
+            doc["rules"].append({"feature":a.feature,"description":a.description,
+                "source_pattern":a.pattern,"sigma_template":a.template,"hint":a.hint,
+                "validated_at":datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                "validated_workbook":wb,"example_from":a.example_from,"confidence":"validated"})
+            yaml.safe_dump(doc, open(rp,"w"), sort_keys=False)
+            result["persisted_to"] = rp
+    else:
+        # opt-in escalation: record the gap locally + hand back ready-to-run filer cmds
+        result["error_column"] = err
+        result["escalation"] = build_escalation(a, err)
+    # cleanup test workbook
+    api("DELETE", f"/v2/files/{wb}")
+    # record to the run-each-time gap-scout ledger (bead beads-sigma-5l5e) so the
+    # scout-gate-readback.py type=error gate sees this gap as scouted.
+    scout_gate.record(a.workdir, a.gap_id, a.feature, "validated" if status == "validated" else "escalated")
+    print(json.dumps({**result,"status":status}, indent=2))
+
+if __name__ == "__main__":
+    main()

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/setup-microstrategy.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/setup-microstrategy.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+# Store MicroStrategy credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent uses
+# MicroStrategy uses session-based auth (POST /api/auth/login, loginMode 1) — there
+# is no API-key concept; scripts/mstr.py reads these env vars to authenticate.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Sigma creds from setup.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "MicroStrategy credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Library URL (e.g. https://<host>/MicroStrategyLibrary): "
+base = $stdin.gets.chomp
+base = base.sub(%r{/+$}, '')
+
+print "Username: "
+username = $stdin.gets.chomp
+
+print "Password (will be hidden): "
+password = $stdin.noecho(&:gets).chomp
+puts
+
+print "Project ID (optional — Enter to default to the first project): "
+project_id = $stdin.gets.chomp
+
+if [base, username, password].any?(&:empty?)
+  abort "Library URL, Username, and Password are all required. Aborting without writing settings."
+end
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["MSTR_BASE_URL"] = base
+settings["env"]["MSTR_USERNAME"] = username
+settings["env"]["MSTR_PASSWORD"] = password
+settings["env"]["MSTR_PROJECT_ID"] = project_id unless project_id.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "MSTR_BASE_URL" => base,
+  "MSTR_USERNAME" => username,
+  "MSTR_PASSWORD" => password,
+}
+pairs["MSTR_PROJECT_ID"] = project_id unless project_id.empty?
+upsert_neutral_env(pairs)
+
+puts "Wrote MicroStrategy credentials to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: `source ~/.sigma-migration/env`, then run"
+puts "`python3 scripts/mstr.py` to verify the login probe."

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/setup.rb
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/sigma-export-png.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/sigma-export-png.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""sigma-export-png.py — render a Sigma workbook page or element to PNG via the
+REST export API, for VISUAL QA of a migrated workbook (Phase 4: side-by-side
+against the source Looker dashboard).
+
+A PNG is more reliable than an MCP SQL query for catching LAYOUT/render problems —
+hidden KPI titles, orphaned filters, overlapping tiles, wrong chart kinds — that a
+numeric parity check can't see.
+
+POST /v2/workbooks/{id}/export {pageId|elementId, format:{type:"png",pixelWidth,pixelHeight}}
+  -> {queryId, jobComplete}; then GET /v2/query/{queryId}/download until the PNG is ready.
+
+Env: SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
+Usage:
+  python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png
+  python3 sigma-export-png.py --workbook <id> --element <elId> --out /tmp/x.png [--w 1600 --h 900]
+"""
+import argparse, os, sys, time, requests
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook", required=True)
+    ap.add_argument("--page"); ap.add_argument("--element")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--w", type=int, default=1600); ap.add_argument("--h", type=int, default=900)
+    a = ap.parse_args()
+    base = os.environ["SIGMA_BASE_URL"]; tok = os.environ["SIGMA_API_TOKEN"]
+    h = {"Authorization": f"Bearer {tok}", "Content-Type": "application/json"}
+    fmt = {"type": "png", "pixelWidth": a.w, "pixelHeight": a.h}
+    body = {"format": fmt}
+    if a.element: body["elementId"] = a.element
+    elif a.page:  body["pageId"] = a.page
+    else: sys.exit("need --page or --element")
+    r = requests.post(f"{base}/v2/workbooks/{a.workbook}/export", headers=h, json=body)
+    if r.status_code != 200: sys.exit(f"export POST {r.status_code}: {r.text[:300]}")
+    qid = r.json()["queryId"]
+    dl = f"{base}/v2/query/{qid}/download"
+    for i in range(60):
+        g = requests.get(dl, headers={"Authorization": f"Bearer {tok}"})
+        ct = g.headers.get("Content-Type", "")
+        if g.status_code == 200 and ("image" in ct or g.content[:8] == b"\x89PNG\r\n\x1a\n"):
+            open(a.out, "wb").write(g.content)
+            print(f"[png] {len(g.content)} bytes -> {a.out}"); return
+        time.sleep(3)
+    sys.exit("timed out waiting for PNG")
+
+if __name__ == "__main__":
+    main()

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/verify_parity.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/verify_parity.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+verify_parity.py — export each workbook table element from Sigma via the REST
+export API and compare against expected_parity.json (MicroStrategy ground truth).
+
+Money / counts: exact. Profit Margin Pct: relative tolerance 1e-6.
+
+Also writes the cross-plugin gate sentinels next to --report:
+  parity-final.json  {status, mode, charts_total, charts_pass, fail_names}
+  wb-ids.json        {workbookId}
+so scripts/assert-phase6-ran.rb (gates 1-7, shared) can prove this phase ran.
+
+Usage: python3 verify_parity.py --workbook-id <id> [--report parity_report.md]
+Requires SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
+"""
+import argparse
+import csv
+import io
+import json
+import os
+import sys
+import time
+import urllib.request
+
+BASE = os.environ.get("SIGMA_BASE_URL", "https://aws-api.sigmacomputing.com")
+TOKEN = os.environ.get("SIGMA_API_TOKEN") or sys.exit(
+    'SIGMA_API_TOKEN not set — run: eval "$(scripts/get-token.sh)"')
+
+# report name -> (element name, key column names, tolerance map)
+TOLERANT = {"Profit Margin Pct": 1e-6}
+
+
+def api(method, path, body=None, raw=False):
+    req = urllib.request.Request(BASE + path, method=method)
+    req.add_header("Authorization", "Bearer " + TOKEN)
+    if not path.endswith("/spec") or body is not None:
+        req.add_header("Accept", "application/json")
+    data = None
+    if body is not None:
+        req.add_header("Content-Type", "application/json")
+        data = json.dumps(body).encode()
+    try:
+        with urllib.request.urlopen(req, data) as r:
+            payload = r.read()
+            return r.status, payload if raw else payload.decode()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode()
+
+
+def export_element(workbook_id, element_id):
+    st, out = api("POST", f"/v2/workbooks/{workbook_id}/export", {
+        "elementId": element_id,
+        "format": {"type": "csv"},
+    })
+    if st >= 300:
+        raise SystemExit(f"export start failed {st}: {out[:500]}")
+    query_id = json.loads(out)["queryId"]
+    for _ in range(60):
+        st, out = api("GET", f"/v2/query/{query_id}/download", raw=True)
+        if st == 200:
+            return out.decode("utf-8-sig")
+        time.sleep(2)
+    raise SystemExit(f"export {query_id} never became ready")
+
+
+def parse_number(s):
+    s = s.strip()
+    pct = s.endswith("%")
+    s = s.replace(",", "").replace("$", "").replace("%", "")
+    if s in ("", "null", "None"):
+        return None
+    v = float(s)
+    return v / 100.0 if pct else v
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook-id", required=True)
+    ap.add_argument("--expected", default="expected_parity.json")
+    ap.add_argument("--keys", default="parity_keys.json",
+                    help="optional report-name -> ordered key column names")
+    ap.add_argument("--report", default="parity_report.md")
+    ap.add_argument("--save-csv-dir", default="exports")
+    args = ap.parse_args()
+
+    expected = json.load(open(args.expected))
+    key_cols_by_report = {}
+    if os.path.exists(args.keys):
+        key_cols_by_report = json.load(open(args.keys))
+
+    # map report name -> element id from the workbook spec readback
+    st, out = api("GET", f"/v2/workbooks/{args.workbook_id}/spec")
+    if st >= 300:
+        raise SystemExit(f"spec GET failed {st}: {out[:300]}")
+    try:
+        spec = json.loads(out)
+    except json.JSONDecodeError:
+        import yaml
+        spec = yaml.safe_load(out)
+    el_by_name = {}
+    for pg in spec["pages"]:
+        for el in pg["elements"]:
+            # skip layout containers / header text / controls (no name or
+            # not a queryable element)
+            if el.get("name") and el.get("kind") not in ("container", "text",
+                                                         "control"):
+                el_by_name[el["name"]] = el["id"]
+
+    os.makedirs(args.save_csv_dir, exist_ok=True)
+    lines = ["# MicroStrategy -> Sigma Parity Report", "",
+             f"Workbook: `{args.workbook_id}`", ""]
+    all_green = True
+    summary = []
+
+    for report_name, rows in expected.items():
+        eid = el_by_name.get(report_name)
+        if not eid:
+            raise SystemExit(f"no workbook element named {report_name!r}; "
+                             f"have {list(el_by_name)}")
+        csv_text = export_element(args.workbook_id, eid)
+        open(os.path.join(args.save_csv_dir,
+                          report_name.replace(" ", "_") + ".csv"), "w").write(csv_text)
+
+        rdr = csv.DictReader(io.StringIO(csv_text))
+        n_keys = len(rows[0]["keys"])
+        key_cols = key_cols_by_report.get(report_name) or rdr.fieldnames[:n_keys]
+        missing_keys = [k for k in key_cols if k not in rdr.fieldnames]
+        if missing_keys:
+            raise SystemExit(f"{report_name}: key columns {missing_keys} not in "
+                             f"export ({rdr.fieldnames})")
+        metric_names = list(rows[0]["values"].keys())
+
+        # Sigma rows keyed by the tuple of key-column values (as strings)
+        sigma = {}
+        for r in rdr:
+            key = tuple(str(r[k]).strip() for k in key_cols)
+            # normalize numeric-looking keys like "2024.0" or 2024 -> "2024"
+            key = tuple(k[:-2] if k.endswith(".0") else k for k in key)
+            sigma[key] = r
+
+        matched, mismatches = 0, []
+        for row in rows:
+            key = tuple(str(k) for k in row["keys"])
+            srow = sigma.get(key)
+            if srow is None:
+                mismatches.append(f"MISSING row {key}")
+                continue
+            ok = True
+            for m, exp in row["values"].items():
+                col = next((c for c in rdr.fieldnames if c == m), None)
+                if col is None:
+                    mismatches.append(f"{key}: metric column {m!r} not in export "
+                                      f"({rdr.fieldnames})")
+                    ok = False
+                    continue
+                got = parse_number(srow[col])
+                if got is None:
+                    mismatches.append(f"{key}: {m} is null (expected {exp})")
+                    ok = False
+                    continue
+                tol = TOLERANT.get(m)
+                if tol is not None:
+                    if abs(got - exp) > tol * max(abs(exp), 1e-12):
+                        mismatches.append(f"{key}: {m} got {got!r} expected {exp!r} "
+                                          f"(rel diff {abs(got-exp)/abs(exp):.2e})")
+                        ok = False
+                else:
+                    if abs(got - exp) > 1e-9:
+                        mismatches.append(f"{key}: {m} got {got!r} expected {exp!r}")
+                        ok = False
+            if ok:
+                matched += 1
+
+        extra = len(sigma) - len(rows)
+        status = "PASS" if (matched == len(rows) and not mismatches) else "FAIL"
+        if status == "FAIL":
+            all_green = False
+        summary.append((report_name, matched, len(rows), extra, status))
+        lines.append(f"## {report_name} — {status}")
+        lines.append("")
+        lines.append(f"- Rows matched: **{matched} / {len(rows)}**")
+        lines.append(f"- Sigma rows: {len(sigma)}"
+                     + (f" ({extra:+d} vs expected)" if extra else ""))
+        lines.append(f"- Metrics compared: {', '.join(metric_names)}")
+        if mismatches:
+            lines.append("- Mismatches:")
+            for mm in mismatches[:50]:
+                lines.append(f"  - {mm}")
+        lines.append("")
+
+    lines.append("## Summary")
+    lines.append("")
+    lines.append("| Report | Matched / Total | Status |")
+    lines.append("|---|---|---|")
+    for name, m, t, _x, st_ in summary:
+        lines.append(f"| {name} | {m} / {t} | {st_} |")
+    lines.append("")
+    lines.append("Tolerances: money and counts exact; Profit Margin Pct relative 1e-6.")
+
+    open(args.report, "w").write("\n".join(lines) + "\n")
+
+    # gate sentinels (contract: scripts/assert-phase6-ran.rb gate 1 reads
+    # parity-final.json; gates 3/4/6/7 resolve the workbook via wb-ids.json)
+    outdir = os.path.dirname(os.path.abspath(args.report))
+    n_pass = sum(1 for _n, m, t, _x, st_ in summary
+                 if st_ == "PASS" and m == t)
+    json.dump({
+        "status": "PASS" if all_green else "FAIL",
+        "mode": "live",
+        "charts_total": len(summary),
+        "charts_pass": n_pass,
+        "fail_names": [n for n, _m, _t, _x, st_ in summary if st_ != "PASS"],
+        "generated_by": "verify_parity.py",
+    }, open(os.path.join(outdir, "parity-final.json"), "w"), indent=1)
+    json.dump({"workbookId": args.workbook_id},
+              open(os.path.join(outdir, "wb-ids.json"), "w"), indent=1)
+
+    for name, m, t, _x, st_ in summary:
+        print(f"{st_}: {name} {m}/{t}")
+    print(f"report -> {args.report} (+ parity-final.json, wb-ids.json)")
+    sys.exit(0 if all_green else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `microstrategy-migration-skills/microstrategy-to-sigma/` and `microstrategy-migration-skills/microstrategy-assessment/`, vendored from `twells89/sigma-migration-skills` upstream.
- Adds a new `setup-microstrategy.rb` that mirrors the per-source `setup-tableau.rb` pattern — interactive prompts for `MSTR_BASE_URL`, `MSTR_USERNAME`, `MSTR_PASSWORD`, and optional `MSTR_PROJECT_ID`. Writes to both `~/.claude/settings.json` and `~/.sigma-migration/env` (same shape as Tableau's per-source setup).
- Includes the Sigma-side `setup.rb` already shipped by every other vendored migration mirror — credential capture is interactive end-to-end now.

These files back the upcoming "Migrating From MicroStrategy Made Easy" QuickStart. The QS Install section references `~/.claude/skills/microstrategy-to-sigma/scripts/setup.rb` and `setup-microstrategy.rb` — both resolve once this PR lands and the user follows the QS's sparse-checkout + symlink steps.

## Test plan
- [ ] `git sparse-checkout set microstrategy-migration-skills` resolves the folder cleanly.
- [ ] Symlinking `~/.claude/skills/microstrategy-to-sigma` to the vendored folder allows `ruby ~/.claude/skills/microstrategy-to-sigma/scripts/setup.rb` and `setup-microstrategy.rb` to run.
- [ ] Both setup scripts write the expected env vars to `~/.claude/settings.json` and `~/.sigma-migration/env`.
- [ ] `python3 ~/.claude/skills/microstrategy-to-sigma/scripts/mstr.py` returns a successful login probe against a Strategy One tenant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)