### PR TITLE
Re-vendor microstrategy-migration-skills from twells89 upstream

### DIFF
--- a/microstrategy-migration-skills/microstrategy-to-sigma/SKILL.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/SKILL.md
@@ -64,7 +64,12 @@ logic.
   API-key concept; `scripts/mstr.py` handles it.
 - **Sigma API token** — `eval "$(scripts/get-token.sh)"` (uses
   `SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET`, same neutral-cred pattern as the
-  sibling skills).
+  sibling skills). If those Sigma creds aren't set yet (fresh machine, no prior
+  migration), run `ruby scripts/setup.rb` once — it prompts for the Sigma
+  base URL / client id / secret (+ optional connection id) and writes them to
+  both `~/.claude/settings.json` and `~/.sigma-migration/env`, so `get-token.sh`
+  and every sibling skill pick them up. (Source-side MSTR creds are separate —
+  see the MicroStrategy bullet above.)
 - **The same warehouse on both sides.** Sigma reads the warehouse live; parity
   only means something when the Sigma connection reaches the database
   MicroStrategy queries.
@@ -85,6 +90,21 @@ python3 scripts/mstr.py                          # login probe + project list
 # dossiers: see assessment, or GET /api/searches/results?type=55 via mstr.py
 ```
 
+### Phase 0.5 — Source type: classic schema vs Quick Cube (branch here)
+
+Check what backs the dossier's dataset before extracting. `GET /objects/{datasetId}?type=3` →
+`subtype`:
+
+- **Classic schema / Mosaic Data Model** (live warehouse-backed) → the normal path. Continue to Phase 1; `extract.py` reads the semantic model.
+- **Quick Cube / super-cube** (`subtype 779`, or a dataset whose source is a file import — `Row Count - <name>.xlsx` metric, no live warehouse connection) → **there is no warehouse semantic model to convert.** The model lives inside the in-memory cube. This is a **data rehost + rebuild**, not a semantic auto-conversion — set expectations accordingly and don't claim `convert.py` drove it.
+
+  **Decide first (ask the customer):** if the cube has a real upstream system of record, prefer pointing Sigma at that live warehouse source. **Rehosting the cube copies a point-in-time snapshot** into the customer's warehouse — it does not stay fresh unless something re-feeds it. Only rehost when there's no live source (demo/prototype cubes, locked-down trials, managed metrics without formulas).
+
+  **If rehosting**, the cube's *data* still extracts cleanly even though its model doesn't:
+  1. Pull all rows via the cube instance API — `POST /v2/cubes/{id}/instances?offset&limit` for page 1 (returns `instanceId` + `definition.grid` + `data`), then `GET /v2/cubes/{id}/instances/{iid}?offset` to page. Element lists in each response are page-scoped. Flatten attributes-on-rows + metrics-on-columns into one table.
+  2. `COPY` it into the warehouse the Sigma connection reaches (quote identifiers to preserve display names; `DATE_FORMAT`/`FIELD_OPTIONALLY_ENCLOSED_BY` for messy CSV; `GRANT SELECT` to the connection role + schema sync — see `sigma-data-models`).
+  3. **Rejoin the normal flow at Phase 3** with a `warehouse-table` source. Skip Phase 1/2 (no bundle to extract) — build the DM + workbook directly, and lean hard on Phase 1.1's source-PDF capture + execute-instance value truth (a cube's KPIs are often a latest-period stat, and a chapter date filter drives the row subsets). Verify with parity + the source-fidelity Visual QA gate exactly as usual.
+
 ## Phase 1 — Extract the bundle
 
 ```bash
@@ -95,6 +115,51 @@ Walks dossier definition → dataset reports (`showExpressionAs=tokens`) →
 referenced attributes / metrics (compound bases included via a second pass) /
 facts / logical tables / hierarchy relationships. The bundle is the converter
 contract — `fixtures/bundle.json` is a real, validated example.
+
+### Phase 1.1 — Capture the SOURCE visual + the values it actually shows (mandatory)
+
+The bundle gives you the data model and *which* vizzes exist; it does **not**
+tell you what the dossier *looks like* or what each viz actually *displays*.
+Both are required for a faithful migration — skip this and you will rebuild the
+right numbers in the wrong dashboard (and sometimes the wrong numbers). Two
+captures:
+
+```bash
+# (a) Pixel-faithful PDF of the live dossier — the layout/branding/arrangement reference.
+python3 scripts/export-dossier-pdf.py <dossierId> source_dossier.pdf
+```
+
+**READ `source_dossier.pdf`** before composing anything. Note, per page: the
+element arrangement (columns/rows, what sits next to what), each viz's real
+chart KIND (a "microcharts" or "kpi" type is not a bar table), branding/header
+bands, and any controls/selector panels.
+
+```bash
+# (b) Execute the dossier instance and pull each visualization's grid + DISPLAYED values.
+#     The static definition's panelStacks carry NO grid metrics — you must execute:
+#       POST /dossiers/{id}/instances            (v1; v2 404s) -> mid
+#       GET  /v2/dossiers/{id}/instances/{mid}/chapters/{chapKey}/visualizations/{vizKey}
+#     Per-viz response gives definition.grid (rows/columns/metrics) + data.metricValues.
+```
+
+Capture each viz's **actual displayed values** as the parity baseline. Two
+traps this surfaces that the bundle hides:
+
+- **KPI / stat cards are frequently a *latest-period* value, not a windowed
+  aggregate.** A "Total Sales" KPI may show the most recent day's value with a
+  prior-period delta + sparkline — NOT `Sum` over the filter window. Match the
+  number the card shows; don't assume the aggregation.
+- **Chapter-level filters drive every viz.** A chapter filter (e.g. `Date
+  Between …`) found via `…/instances/{mid}/definition` → `chapters[].filters`
+  (NOT in the static `/definition`) is the reason row counts and totals look
+  "filtered." Apply the equivalent as a page/base filter so all elements inherit
+  it (a hidden base table with the filter, sourced by every element, is the
+  cleanest propagation).
+
+Sparklines and KPI comparison/delta badges are **UI-only in the Sigma spec API**
+(see `sigma-workbooks` `kpis.md`) — reproduce the big-number value via formula,
+and flag the sparkline/badge as a one-click editor follow-up rather than
+claiming spec parity.
 
 ## Phase 2 — Convert → Sigma specs
 
@@ -246,13 +311,28 @@ It also writes the gate sentinels `parity-final.json` + `wb-ids.json` next to
 the report — the contract Phase 6 reads.
 
 ## Visual QA (mandatory gate — never skip)
-A workbook that POSTs 200 and passes parity can still be visually broken — **overlapping tiles, clipped KPI titles, dead zones, filters over charts.** Sigma's grid has no z-order; the shared layout lib de-overlaps bands, but this visual gate is the safety net (without a top-level layout the workbook renders as a single-column stack — see the existing layout gate).
+A workbook that POSTs 200 and passes row parity can still be **the wrong
+dashboard** — right numbers, wrong look. This gate has TWO parts: source
+**fidelity** (does it resemble the original?) and intrinsic **quality** (is it
+cleanly laid out?). Both must pass. Sigma's grid has no z-order; the shared
+layout lib de-overlaps bands, but this gate is the safety net (without a
+top-level layout the workbook renders as a single-column stack).
 
 1. Render every page to PNG (token first: `eval "$(scripts/get-token.sh)"`):
    `python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/<page>.png --w 1600`
-2. **Read each PNG** and check it against `refs/layout-visual-qa.md` (no overlaps/stacking, no dead zones, controls in-band, no clipped titles, even heights, right chart kind/format).
-3. Fix any failure in the spec — for multi-page workbooks use `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit → push) — then **re-render and re-read**.
-4. Declare the migration done on a **clean render**, not on HTTP 200.
+2. **Source-fidelity check — put the Sigma PNG side-by-side with the Phase 1.1
+   `source_dossier.pdf`** and compare page-for-page against the
+   `refs/layout-visual-qa.md` "Source-fidelity parity" checklist: same element
+   set, same relative arrangement (3-column stays 3-column), matching chart
+   KINDS (KPI vs bar vs table), KPI showing the same VALUE as the source card,
+   selector/control panels present, branding bands present (or explicitly
+   descoped with the user). A render that looks nothing like the PDF FAILS even
+   if parity is green.
+3. **Quality check** — also verify each PNG against the intrinsic checklist (no
+   overlaps/stacking, no dead zones, controls in-band, no clipped titles, even
+   heights, right format).
+4. Fix any failure in the spec — for multi-page workbooks use `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit → push) — then **re-render and re-compare**.
+5. Declare the migration done on a render that **matches the source PDF**, not on HTTP 200 and not on row-parity alone. If the user explicitly scoped styling down (e.g. "layout + metrics, skip branding"), record exactly what was descoped — don't silently drop it.
 
 ## Phase 6 — Finalize (hard gate before declaring GREEN)
 

--- a/microstrategy-migration-skills/microstrategy-to-sigma/refs/layout-visual-qa.md
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/refs/layout-visual-qa.md
@@ -28,6 +28,28 @@ declaring the migration done.
 4. **Loop until the render passes inspection.** Declare the migration done on a *clean render*,
    never on an HTTP 200.
 
+## Source-fidelity parity (run BEFORE the quality rubric)
+
+Clean ≠ faithful. A workbook can be perfectly laid out and still look nothing like the
+dashboard it migrated. This check compares the render against the **source's own
+appearance**, captured in Phase 1.1 as `source_dossier.pdf` (MSTR: `export-dossier-pdf.py`;
+other plugins have an equivalent source export). Put the Sigma page PNG and the source page
+side-by-side and verify, page-for-page:
+
+- [ ] **Same element set** — every viz on the source page exists on the Sigma page (none dropped, none invented).
+- [ ] **Same arrangement** — relative position holds (a 3-column source stays 3-column; KPIs that sit under a chart stay under it). Pixel-exact isn't required; the *grouping and reading order* are.
+- [ ] **Matching chart KIND** — source KPI → Sigma `kpi-chart` (not a 1-row table); source horizontal bar → horizontal bar; microchart/indicator → the closest Sigma equivalent (conditional-formatted table / data bars), not a generic bar. The dossier's `visualizationType` (`kpi`, `microcharts`, `combo_chart`, `grid`, …) is the spec to match.
+- [ ] **KPI shows the source's VALUE** — confirm the big number equals what the source card shows (often a latest-period stat, not a windowed Sum — see SKILL.md Phase 1.1). A KPI that's structurally a KPI but shows the wrong metric FAILS.
+- [ ] **Controls / selector panels present** — source filter panels, attribute/metric selectors, and chapter filters have Sigma equivalents (controls or an inherited base filter). An interactive source page rebuilt as a static grid FAILS.
+- [ ] **Branding bands** — header strips, logos, greeting/title bands present, OR explicitly descoped *with the user* and recorded.
+
+A render that diverges on any unchecked box is a FAIL even when row parity is green — fix the
+spec and re-compare. **Known spec ceilings** (don't loop on them — note them as editor
+follow-ups): KPI sparklines and comparison/delta badges are UI-only (`sigma-workbooks`
+`kpis.md`); source-tool chrome (theme toggles, native nav) has no spec equivalent. When the
+user scopes styling down ("layout + metrics, skip branding"), record exactly what was
+descoped in the final summary — never drop it silently.
+
 ## Pass/fail rubric (read the PNG against every item)
 
 - [ ] **No overlaps / no stacking.** No two elements occupy the same cell; no filter, legend, or

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/export-dossier-pdf.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/export-dossier-pdf.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Export the SOURCE MicroStrategy dossier to PDF — the visual-parity reference.
+
+Why this exists: the dossier *definition* (panelStacks/visualizations) does NOT
+carry the rendered layout, styling, branding, or the actual metric VALUES each
+viz displays. A converter that builds only from the definition produces a
+workbook with the right data but the wrong *look*. To match the source you must
+SEE it. This pulls a pixel-faithful PDF of the live dossier so the Visual QA
+gate can put the Sigma render side-by-side with the original and check fidelity
+(arrangement, chart kinds, KPI semantics, branding), not just generic quality.
+
+Pairs with execute-instance value capture (see SKILL.md Phase 1): the PDF tells
+you the layout; executing each visualization tells you the exact displayed
+values (KPIs are often a LATEST-DATE stat, not a windowed Sum — never assume).
+
+Usage:
+  python3 scripts/export-dossier-pdf.py <dossierId> [out.pdf]
+
+Env: ~/microstrategy-migration/.mstr_env (or wherever mstr.py reads), same auth
+as the rest of the pipeline. Requires mstr.py alongside this script.
+"""
+import base64
+import sys
+import mstr
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("usage: export-dossier-pdf.py <dossierId> [out.pdf]", file=sys.stderr)
+        sys.exit(2)
+    dossier_id = sys.argv[1]
+    out = sys.argv[2] if len(sys.argv) > 2 else "source_dossier.pdf"
+
+    s = mstr.Session()
+    # Instance must be created and exported within ONE auth session (session-bound).
+    iid = s.post(f"/dossiers/{dossier_id}/instances", {})["mid"]
+    # NOTE: the v1 path works; /v2/dossiers/.../pdf 404s on this build.
+    resp = s.post(f"/documents/{dossier_id}/instances/{iid}/pdf", {})
+    if not resp or "data" not in resp:
+        print(f"error: no PDF data returned: {str(resp)[:200]}", file=sys.stderr)
+        sys.exit(1)
+    pdf = base64.b64decode(resp["data"])
+    with open(out, "wb") as f:
+        f.write(pdf)
+    print(f"wrote {out} ({len(pdf)} bytes) — READ it, then match the Sigma build to it")
+
+
+if __name__ == "__main__":
+    main()

--- a/microstrategy-migration-skills/microstrategy-to-sigma/scripts/scout-gate-readback.py
+++ b/microstrategy-migration-skills/microstrategy-to-sigma/scripts/scout-gate-readback.py
@@ -55,8 +55,8 @@ def main():
     ap.add_argument("--workdir", required=True,
                     help="conversion working dir holding scout-ledger.jsonl")
     ap.add_argument("--yes", action="store_true",
-                    help="(does NOT skip the gate; present for parity — an unscouted "
-                         "error column always stops)")
+                    help="unattended: accept unscouted ERROR-typed columns (they ship "
+                         "FLAGGED in Sigma) and proceed instead of stopping")
     a = ap.parse_args()
 
     st, body = api("GET", f"/v2/workbooks/{a.workbook_id}/columns")
@@ -77,6 +77,17 @@ def main():
     gid = lambda c: "errcol:%s/%s" % (c.get("elementId"), c.get("label"))
     gap_ids = list(dict.fromkeys(gid(c) for c in errs))
     bk = scout_gate.classify(a.workdir, gap_ids)
+    if bk["unscouted"] and a.yes:
+        # Regression fix (gap-scout PR #153 made --yes a no-op here, hard-stopping the
+        # unattended/demo path). Under --yes the gate is ADVISORY: ERROR-typed columns
+        # ship FLAGGED in Sigma (as before the gate existed) and the run proceeds.
+        # Record them so re-runs don't re-surface; recommend the gap-scout.
+        print("\ngap-scout: %d ERROR-typed column(s) NOT scouted — proceeding (--yes); they ship FLAGGED/broken in Sigma."
+              % len(bk["unscouted"]))
+        print("(optional: run scripts/gap-scout.md on these to persist a faithful Sigma translation)")
+        for i in bk["unscouted"]:
+            scout_gate.record(a.workdir, i, "errcol", "accepted")
+        return
     if bk["unscouted"]:
         print("\n==================== GAP-SCOUT REQUIRED ====================")
         print("%d of %d ERROR-typed column(s) have NOT been scouted — the gap-scout must"
@@ -85,7 +96,7 @@ def main():
         for i in bk["unscouted"]:
             print("  --gap-id '%s'" % i)
         print("\nSpawn one gap-scout per column (scripts/gap-scout.md) with the exact --gap-id")
-        print("above plus --workdir %s, then re-run this gate. --yes does NOT skip it." % a.workdir)
+        print("above plus --workdir %s, then re-run this gate, OR re-run with --yes to ship them FLAGGED." % a.workdir)
         print("===========================================================")
         sys.exit(11)
     print("gap-scout: all %d error column(s) accounted for (validated or escalated)" % len(gap_ids))


### PR DESCRIPTION
## Summary
Picks up TJ's recent MSTR converter updates:
- **Quick Cube branch documented** (`SKILL.md` Phase 0.5) — recognizes subtype-779 file-imported cubes that have no warehouse binding and no semantic model to extract, and documents the warehouse-rehost + rebuild path. Required to convert the `Retail Insights` dossier in the in-progress MSTR QS, which is built on exactly this source type (Quick Cube created from a CSV upload).
- **`export-dossier-pdf.py`** — exports the source dossier to PDF for visual-parity reference (Phase 1.1).
- **`scout-gate-readback.py`** + **`refs/layout-visual-qa.md`** refinements.

Keeps the Looker-aligned `setup.rb` already vendored (visible Client ID, no Connection ID prompt) instead of regressing to upstream's Tableau-shaped variant. Keeps `setup-microstrategy.rb` (per-source interactive MSTR cred capture authored alongside the QS).

## Test plan
- [ ] After merge, pull both `~/GitHub/quickstarts-public` and `~/quickstarts-public` clones.
- [ ] Re-run `/microstrategy-to-sigma` against the `Retail Insights` dossier — the Quick Cube branch should now be recognized and Phase 0.5 should fork into the warehouse-rehost path.
- [ ] Confirm `setup.rb` still shows the visible Client ID prompt and skips the Connection ID prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)