### PR TITLE
Vendor quicksight-migration-skills from twells89 upstream

### DIFF
--- a/quicksight-migration-skills/quicksight-assessment/PRIVACY.md
+++ b/quicksight-migration-skills/quicksight-assessment/PRIVACY.md
@@ -1,0 +1,89 @@
+# Privacy & data handling — `quicksight-assessment`
+
+Read this before running the skill, and share it with your privacy / security /
+legal team if your organization needs to review tools that send analysis and
+dataset metadata through a third-party LLM API.
+
+## What this skill reads and writes
+
+**READ-ONLY.** Every call is a `list-*` or `describe-*` (GET-equivalent). The
+skill **never** writes to QuickSight and **never** posts to Sigma. It connects to
+**two systems** on your behalf:
+
+1. **Your Amazon QuickSight account**, via the **AWS CLI** (`aws quicksight ...`,
+   shelled out as a subprocess — no boto3), authenticated as **you** through
+   whatever AWS profile you've already configured (`aws sso login`,
+   `gimme-aws-creds`, or static creds). QuickSight reads from the **identity
+   region** — almost always `us-east-1` even when data lives elsewhere. The skill
+   reads:
+   - Analysis / dashboard / dataset / data-source listings (counts)
+   - Per-analysis **AnalysisDefinition** — visual configuration + **calc-field
+     expressions** + parameters + FilterGroups + layout shape
+   - Per-dataset **describe-data-set** — physical source kinds, import mode
+     (SPICE / DIRECT_QUERY), custom-SQL presence, joins, transform count, RLS/CLS
+2. **The Anthropic API**, via Claude Code, to drive the agent.
+
+Everything the skill reads passes through Claude (and therefore the Anthropic
+API) on its way to producing the readout. Anthropic's API data handling:
+<https://www.anthropic.com/legal/privacy>.
+
+## What crosses the Anthropic API
+
+| Crosses API | Stays in your environment |
+|---|---|
+| **Aggregate counts** (analysis / dashboard / dataset / data-source counts) | Warehouse rows (this skill **never** queries the underlying database) |
+| **Names**: analysis names, dashboard names, dataset names, data-source names | **SPICE in-memory rows** (never read) |
+| **AnalysisDefinition** — visual config, **calc-field expressions**, parameter defaults, FilterGroup definitions, layout shape | AWS credentials (held by the AWS CLI, not surfaced to the agent) |
+| **Dataset metadata** — physical source kinds, import mode, custom-SQL presence, join/transform counts, **RLS/CLS flags** | The actual cell values your visuals display |
+| Data-source connection **types** (Snowflake, Redshift, Athena, …) — not credentials | The warehouse credentials QuickSight uses to connect |
+
+> **Calc-field expressions are the broadest data category that crosses the API.**
+> A QuickSight calculated field can encode business-sensitive logic (margin
+> formulas, eligibility rules, custom KPIs). When the skill reads an
+> AnalysisDefinition, that expression text crosses the Anthropic API. RLS rule
+> *configuration flags* cross (whether RLS is on), but the row-level predicate
+> values themselves are not pulled at definition time. Tell stakeholders this
+> before running.
+
+The AnalysisDefinition and dataset describes do **NOT** contain row-level data
+from your warehouse or SPICE. The data your visuals display is fetched live (or
+from the SPICE cache) at view time, which this skill never triggers.
+
+## What stays local
+
+All outputs are written to a directory of your choice (default
+`/tmp/qs-assessment-<acct>/`) and are **not uploaded anywhere**. The decoded
+definitions live under `raw-defs/` (analyses) and `raw-datasets/` (datasets). To
+share the readout with a Sigma rep, that's a deliberate action you take (zip and
+send).
+
+You can delete the decoded definitions after review with no impact on the
+already-rendered `readout.html` / `readout.md`:
+
+```bash
+rm -rf /tmp/qs-assessment-<acct>/raw-defs /tmp/qs-assessment-<acct>/raw-datasets
+```
+
+## How to limit exposure
+
+1. **Run counts-only.** A **Standard-edition** account rejects the
+   `describe-*-definition` / `describe-data-set` APIs, so the skill degrades to
+   environment counts only — no calc-field text crosses the API. (This is
+   automatic on Standard; on Enterprise the definition scan is the whole point.)
+2. **Delete the raw definitions immediately after rendering** (command above).
+3. **Review the JSON outputs before sharing** — `inventory.json` and the
+   `raw-defs/` decode contain calc-field text; `shortlist.json` and
+   `migration-plan.json` contain names and scores but no calc-field bodies.
+4. **Scope the AWS profile.** Run under an IAM principal scoped to
+   `quicksight:List*` / `quicksight:Describe*` on the account you intend to
+   assess — nothing more.
+
+## Where to direct privacy questions
+
+- Anthropic API privacy: <https://www.anthropic.com/legal/privacy>
+- Amazon QuickSight API reference:
+  <https://docs.aws.amazon.com/quicksight/latest/APIReference/Welcome.html>
+- This skill's source: every script under `scripts/` runs on your behalf and is
+  readable — `quicksight-inventory.py` is the only one that touches AWS, and
+  every call it makes is a read-only `list-*` / `describe-*`.
+- Sigma privacy policy: <https://www.sigmacomputing.com/privacy-policy>

--- a/quicksight-migration-skills/quicksight-assessment/README.md
+++ b/quicksight-migration-skills/quicksight-assessment/README.md
@@ -1,0 +1,134 @@
+# Amazon QuickSight Assessment
+
+A Claude Code skill that inventories an Amazon QuickSight account and produces a
+migration-readiness readout. Designed to be run by a customer (or a Sigma rep
+with the customer present) before deciding which QuickSight analyses to migrate
+to Sigma.
+
+**READ-ONLY.** Every call is a `list-*` / `describe-*` (GET-equivalent). The
+skill never writes to QuickSight and never posts to Sigma.
+
+This is the QuickSight sibling of [`tableau-assessment`](../../../tableau-to-sigma/skills/tableau-assessment/)
+and [`powerbi-assessment`](../../../powerbi-to-sigma/skills/powerbi-assessment/) —
+same file layout, same readout sections, same privacy discipline, same
+value/cost shortlist scoring — adapted to QuickSight's two-artifact world
+(analysis + datasets).
+
+## What it produces
+
+A directory (`/tmp/qs-assessment-<acct>/`) with:
+
+- `readout.html` — a Sigma-branded, share-friendly HTML report (the customer
+  deliverable): environment KPIs, analysis/dashboard priority, dataset reuse &
+  concentration, data-source patterns (SPICE / DIRECT_QUERY, warehouse vs
+  file/S3), ingestion & refresh activity, a value/cost-ranked **migration
+  shortlist** + per-analysis conversion profile, data handling, hand-off package,
+  and next steps. Render it with `scripts/render-readout-html.rb`.
+- `readout.md` — the same report as markdown (template at `refs/readout-template.md`).
+- `inventory.json` — raw environment + per-analysis + per-dataset metadata.
+- `complexity.json` — per-analysis convertibility scoring
+  (`n_auto` / `n_hint` / `n_manual` / `n_unhandled`).
+- `shortlist.json` — the value/cost-ranked migration shortlist as JSON.
+- `migration-plan.json` — per-analysis `recommended_path` + DM clusters (keyed on
+  shared dataset), directly consumable by the `quicksight-to-sigma` skill.
+- `raw-defs/`, `raw-datasets/` — decoded analysis + dataset definitions (delete
+  after review).
+
+Nothing in this directory is uploaded anywhere.
+
+## Prerequisites
+
+- Claude Code installed
+- **AWS CLI v2**, authenticated to the account you want to assess (`aws sso login
+  --profile <p>`, or `gimme-aws-creds` for Okta-fronted orgs). Confirm with
+  `aws sts get-caller-identity --profile <p>`. No Python packages — the inventory
+  script shells out to the CLI (see `scripts/requirements.txt`).
+- **Enterprise edition** for the complexity layer. The
+  `describe-analysis-definition` / `describe-data-set` APIs are Enterprise-only; a
+  Standard account is detected and degraded to a counts-only readout (it never
+  crashes).
+- QuickSight reads from the **identity region** — pass `--region us-east-1` unless
+  you know the account is regionalized differently.
+
+## How to run
+
+In Claude Code:
+
+```
+/quicksight-assessment
+```
+
+The skill will:
+
+1. Probe access + edition (`get-caller-identity`, `list-analyses`).
+2. Inventory analyses, dashboards, datasets, data sources; per-analysis
+   AnalysisDefinition (visual mix, calc-field a/b/c buckets, params, FilterGroups,
+   layout shape); per-dataset source / prep / RLS.
+   (`quicksight-inventory.py` → `inventory.json`, `raw-defs/`, `raw-datasets/`)
+3. Score per-analysis convertibility.
+   (`score-quicksight-complexity.rb` → `complexity.json`)
+4. Cross-tabulate into a value/cost-ranked migration shortlist.
+   (`build-shortlist.rb` → `shortlist.json`)
+5. Render the report.
+   (`render-readout.rb` → `readout.md`; `render-readout-html.rb` → `readout.html`)
+6. Compose the hand-off contract.
+   (`migration-plan.rb` → `migration-plan.json`)
+7. Offer to hand off to `quicksight-to-sigma`.
+
+## Modes
+
+| Mode | Setup | Coverage |
+|---|---|---|
+| **Complexity-only** *(default)* | AWS CLI + Enterprise | Environment + per-analysis visual/calc complexity + per-dataset sources + complexity-only shortlist |
+| **Usage-weighted** | Supply a CloudTrail/CloudWatch-derived `usage.json` | Adds view/user weighting → usage-weighted shortlist + cold-analysis detection |
+
+QuickSight has no per-analysis view-count API on the standard surface, so the
+default is complexity-only; the readout says so.
+
+## Convertibility taxonomy (what drives the scoring)
+
+- **auto** (easy): built visuals (KPI / bar / line / pie), mechanical calc fields,
+  warehouse-backed datasets (RelationalTable / CustomSql).
+- **manual** (medium): mid-catalog visuals (table / pivot / combo / scatter /
+  gauge / …), restructuring calc fields, dataset joins + data-prep transforms,
+  parameters, RLS/CLS.
+- **unhandled** (hard): window / table-calc functions (no Sigma equivalent →
+  `/* TODO */`), exotic visuals (maps, sankey, insight ML, custom content,
+  plugin), free-form / section-based layout, analysis-level FilterGroups, S3 /
+  uploaded-file sources.
+
+Per-analysis `cost = 10·unhandled + 3·manual + 1·hint`; `score = value / (1 + cost)`.
+
+## What this is NOT
+
+- **Not** a write tool. It cannot and will not modify QuickSight or Sigma.
+- **Not** a complete account audit. It covers the signals that matter for Sigma
+  migration scoping, scoped to **what the configured AWS credentials can reach**.
+- **Not** the converter. It scopes; `quicksight-to-sigma` converts. The
+  `migration-plan.json` is the hand-off between them.
+
+## Privacy
+
+This skill sends analysis/dataset metadata (not warehouse rows) through the
+Anthropic API — including **calc-field expressions** from each AnalysisDefinition.
+See [`PRIVACY.md`](./PRIVACY.md) for the full disclosure to review with your
+privacy/legal team before running.
+
+## Reusing this for migration
+
+The `migration-plan.json` output is directly consumable by `quicksight-to-sigma`:
+
+```
+/quicksight-to-sigma migrate the top analyses from this plan: /tmp/qs-assessment-<acct>/migration-plan.json
+```
+
+Analyses are pre-grouped into DM clusters (analyses that reference the same
+QuickSight dataset share one Sigma data model by construction), and the decoded
+`raw-defs/` + `raw-datasets/` overlap the converter's Phase-2 discovery output —
+the converter reuses them rather than re-calling the AWS CLI.
+
+## Sibling skills
+
+- [`quicksight-to-sigma`](../../) — the conversion skill this feeds into.
+- [`tableau-assessment`](../../../tableau-to-sigma/skills/tableau-assessment/) — the Tableau analog.
+- [`powerbi-assessment`](../../../powerbi-to-sigma/skills/powerbi-assessment/) — the Power BI analog.

--- a/quicksight-migration-skills/quicksight-assessment/SKILL.md
+++ b/quicksight-migration-skills/quicksight-assessment/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: quicksight-assessment
+description: Take inventory of an Amazon QuickSight account and produce a migration-readiness readout — environment counts, per-analysis visual-type mix, calc-field complexity (mechanical / restructuring / window-table-calc buckets), parameter + FilterGroup + layout-shape signals, per-dataset source types / custom-sql / joins / RLS, and a value/cost-ranked migration shortlist. Use when a user wants to scope a QuickSight→Sigma migration, audit BI sprawl, or pick which analyses to convert first. READ-ONLY — never writes to QuickSight or posts to Sigma. AWS-CLI auth (no boto3). Enterprise edition required for full complexity. Feeds the quicksight-to-sigma conversion skill.
+user-invocable: true
+---
+
+# Amazon QuickSight Assessment
+
+Surveys an Amazon QuickSight account — **what the configured AWS credentials can
+reach** — via the AWS CLI (`aws quicksight ...`, shelled out via subprocess; no
+boto3). Emits a markdown readout + JSON inventory + a value/cost-ranked migration
+shortlist the user can hand to a Sigma rep or directly to the
+`quicksight-to-sigma` conversion skill.
+
+This is the QuickSight sibling of `powerbi-assessment` and `tableau-assessment` —
+same file layout, same readout sections, same privacy discipline, same
+value/cost shortlist scoring — adapted to QuickSight's two-artifact world
+(analysis + datasets).
+
+> **READ-ONLY.** Every call is a `list-*` or `describe-*` GET-equivalent. The
+> skill **never** writes to QuickSight and **never** posts to Sigma. It does not
+> edit anything outside its output directory.
+
+> **Enterprise edition required for complexity.** The `describe-analysis-definition`,
+> `describe-dashboard-definition`, and `describe-data-set` APIs are
+> **Enterprise-only** — a Standard-edition account rejects them. The skill
+> detects that, flags the account as Standard, and degrades to a counts-only
+> readout (it never crashes on a Standard account, but it also can't score
+> complexity there).
+
+> **Warehouse-agnostic.** QuickSight datasets source from many places
+> (Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres, S3, SaaS). The
+> skill reports each dataset's physical source kind; the downstream
+> `quicksight-to-sigma` converter re-points Sigma at the same tables (S3/SaaS
+> are a known gap). Worked examples use Snowflake because that's where the dev
+> fixtures live.
+
+---
+
+## Privacy posture (READ FIRST, surface to the customer)
+
+**This skill reads analysis / dataset metadata, not warehouse data.** What
+crosses Anthropic's API on its way through Claude:
+
+| Crosses Anthropic API | Stays local |
+|---|---|
+| Aggregate counts (analysis / dataset / data-source counts) | Warehouse / SPICE rows (never queried) |
+| Analysis, dataset, data-source names | AWS credentials |
+| **Analysis definitions** — visual config + **calc-field expressions** | Actual visual cell values |
+| Dataset metadata — physical source kinds, custom-sql, RLS/CLS flags | |
+
+> If calc-field expressions encode business-sensitive logic, that text crosses
+> the API. Tell the customer before running.
+
+---
+
+## When to use this skill
+
+- A QuickSight customer wants a fast scoping view before a deeper migration engagement
+- A Sigma SE preparing for a discovery call wants a pre-built migration shortlist
+- A customer is deciding which QuickSight analyses to retire vs. migrate
+- A `quicksight-to-sigma` invocation needs a Phase 0 inventory of the source account
+
+---
+
+## Setup (one-time)
+
+No Python packages required — the inventory script shells out to the **AWS CLI
+v2** (which you install + authenticate separately). See `scripts/requirements.txt`.
+
+```bash
+# SSO orgs:
+aws sso login --profile <profile>
+# Okta-fronted orgs: gimme-aws-creds writes a usable profile
+gimme-aws-creds --profile <profile>
+# confirm + grab the account id:
+aws sts get-caller-identity --profile <profile>
+```
+
+QuickSight's **identity region is often `us-east-1`** even when data lives
+elsewhere — analyses/datasets/data-sources are read from the identity region.
+Pass `--region us-east-1` unless you know the account is regionalized
+differently.
+
+---
+
+## Scripts overview
+
+| Script | Lang | Purpose | Reused from powerbi-assessment? |
+|---|---|---|---|
+| `scripts/quicksight-inventory.py` | Python | Phase 1-3: analyses + dashboards + datasets + data sources, per-analysis definition complexity (visual mix, calc-field buckets, params, FilterGroups, layout shape) + per-dataset source/prep/RLS → `inventory.json`, `raw-defs/`, `raw-datasets/` | **New** (AWS CLI + AnalysisDefinition parsing has no PBI analog) |
+| `scripts/score-quicksight-complexity.rb` | Ruby | Derive per-analysis convertibility (easy/medium/hard → auto/manual/unhandled) → `complexity.json` | **New** (calc/visual-bucket logic), but emits the shared `n_auto/n_hint/n_manual/n_unhandled` shape |
+| `scripts/build-shortlist.rb` | Ruby | Cross-tab usage × complexity; `score = value/(1+cost)` → `shortlist.json` | **Adapted** — same scoring formula & tag rules; QS value-source + complexity-only fallback |
+| `scripts/render-readout.rb` | Ruby | Compose `readout.md` from the JSON files | **Adapted** — `md_table`/`section_block`/`md_cell` helpers reused verbatim; gather-body is QS-specific |
+| `scripts/migration-plan.rb` | Ruby | Per-analysis `recommended_path` + DM clusters (by shared dataset) → `migration-plan.json` | **Adapted** — same contract shape; clustering keyed on shared dataset instead of shared semantic model |
+
+> **What was reused vs rewritten:** the renderer's templating helpers and the
+> shortlist's value/cost scoring + tag vocabulary are lifted from
+> `powerbi-assessment` (which lifted them from `tableau-assessment`). The auth
+> layer (AWS CLI), AnalysisDefinition parsing, calc-field classification, and the
+> dataset-centric clustering are new because QuickSight's data shape has no
+> direct PBI/Tableau equivalent.
+
+---
+
+## Modes
+
+| Mode | Setup | Coverage | Use when |
+|---|---|---|---|
+| **Complexity-only** *(default)* | AWS CLI + Enterprise | Environment + per-analysis visual/calc complexity + per-dataset sources + **complexity-only** shortlist | Any user; the common case |
+| **Usage-weighted** | Supply `usage.json` (CloudTrail/CloudWatch-derived views) | Adds view/user weighting → usage-weighted shortlist + cold-analysis detection | When you have audit-trail usage data |
+
+QuickSight has no per-analysis view-count API on the standard surface, so the
+default is complexity-only; the readout says so.
+
+---
+
+## Phase 0 — Probe access + edition
+
+```bash
+aws sts get-caller-identity --profile <profile>            # account id + creds OK?
+aws quicksight list-analyses --aws-account-id <ID> --region us-east-1 --profile <profile> | head
+```
+
+If `list-analyses` works but `describe-analysis-definition` later 4xx's with a
+Standard/Enterprise/AccessDenied message, the inventory flags the account
+`enterprise: false` and degrades to counts-only.
+
+---
+
+## Phase 1-3 — Inventory + complexity (always runs)
+
+```bash
+python3 scripts/quicksight-inventory.py \
+  --account-id <ID> --region us-east-1 --profile <profile> \
+  --out /tmp/qs-assessment-<acct>
+ruby scripts/score-quicksight-complexity.rb --out /tmp/qs-assessment-<acct>
+```
+
+`quicksight-inventory.py` does:
+- `list-analyses` / `list-data-sets` / `list-data-sources` (+ `list-dashboards`
+  with `--dashboards-too`) → environment counts.
+- Per analysis: `describe-analysis-definition` → sheet/visual counts, visual-kind
+  histogram (bucketed built / mid-catalog / unhandled per `refs/migration-test-slate.md`),
+  calc-field a/b/c classification (window/table-calc funcs → `c`), parameter +
+  FilterGroup counts, free-form / section-based layout detection. Decoded def
+  saved to `raw-defs/<id>.json`.
+- Per referenced dataset (once): `describe-data-set` → physical source kind(s),
+  import mode, custom-sql, joins, transform count, RLS/CLS. Saved to
+  `raw-datasets/<id>.json`.
+
+`score-quicksight-complexity.rb` maps easy/medium/hard onto the shared
+`auto/manual/unhandled` tiers and folds in dataset joins, transforms, RLS, and
+layout/visual gaps.
+
+### Convertibility scoring
+
+Grounded in `refs/migration-test-slate.md`:
+- **easy → auto**: built visuals (KPI/bar/line/pie) + mechanical calc fields +
+  RelationalTable/CustomSql sources.
+- **medium → manual**: mid-catalog visuals (table/pivot/combo/scatter/gauge/…),
+  restructuring calc fields, dataset joins + data-prep transforms, parameters, RLS/CLS.
+- **hard → unhandled**: window / table-calc functions (no Sigma equivalent →
+  `/* TODO */`), exotic visuals (maps, sankey, insight ML, custom content,
+  plugin), free-form / section-based layout, analysis-level FilterGroups, S3/SaaS sources.
+
+Per-analysis `cost = 10·unhandled + 3·manual` in the shortlist.
+
+---
+
+## Phase 4 — Shortlist
+
+```bash
+ruby scripts/build-shortlist.rb --out /tmp/qs-assessment-<acct>
+```
+
+Scores each analysis:
+- `value = views × √(distinct_users)` *(if `usage.json` supplied)* — or
+  `10 × (sheets + visuals/4)` *(complexity-only fallback)*
+- `cost  = 10·unhandled + 3·manual + 1·hint`
+- `score = value / (1 + cost)`
+
+Same tag vocabulary as the other assessment skills: `migrate-first` / `easy-win`
+/ `moderate` / `needs-gap-scout` / `retire`.
+
+---
+
+## Phase 5 — Render the readout
+
+```bash
+ruby scripts/render-readout.rb --out /tmp/qs-assessment-<acct>
+```
+
+Composes the markdown report (template at `refs/readout-template.md`). Sections:
+environment, visual-type mix, analysis complexity, datasets/sources, priority,
+shortlist, per-analysis complexity, found-vs-not, privacy, hand-off, next steps.
+Carries a Standard-edition banner when the definition APIs were rejected and a
+limited-mode banner when usage data is absent.
+
+---
+
+## Phase 6 — Migration plan (always run)
+
+```bash
+ruby scripts/migration-plan.rb --out /tmp/qs-assessment-<acct>
+```
+
+Composes `migration-plan.json` — the hand-off contract for `quicksight-to-sigma`.
+Each analysis gets a `recommended_path`:
+
+| `recommended_path` | Means |
+|---|---|
+| `quicksight-to-sigma` | Ready for conversion. ≤5 manual/unhandled features. |
+| `quicksight-to-sigma-with-scout` | Has window calcs / exotic visuals / free-form layout — needs a design decision first. |
+| `retire` | Zero views (usage-supplied mode only); recommend not migrating. |
+| `blocked` | >5 manual/unhandled features; needs human rework first. |
+
+**DM clusters** are keyed on the **shared dataset** — analyses that reference the
+same QuickSight dataset (or transitively overlap) share a Sigma data model by
+construction. Cleaner than Tableau's `.twb`-table Jaccard; like Power BI's
+shared-model clustering.
+
+---
+
+## Phase 7 — Hand off to `quicksight-to-sigma`
+
+Present the migration-plan summary and let the user pick the next step (single
+analysis, top-N batch, or just keep the readout). Invoke the converter in the
+same conversation:
+
+```
+Skill(
+  skill: "quicksight-to-sigma",
+  args:  "Convert analysis <id> (<name>) from the just-finished assessment at
+          /tmp/qs-assessment-<acct>. Read migration-plan.json for the
+          recommended_path, blockers, dataset_source_types, and the cluster's
+          shared datasets. The decoded analysis definition is in raw-defs/ and
+          the dataset describes in raw-datasets/ — reuse them instead of
+          re-extracting."
+)
+```
+
+The decoded `raw-defs/` and `raw-datasets/` overlap the converter's Phase-2
+discovery output; the converter can reuse them rather than re-calling the AWS
+CLI.
+
+---
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `list-analyses FAILED` | AWS creds not configured / wrong region | `aws sso login` (or `gimme-aws-creds`); confirm `aws sts get-caller-identity`; try `--region us-east-1` |
+| All analyses show `def_error` + `enterprise: false` | Standard-edition account | Expected — definition APIs are Enterprise-only; readout degrades to counts-only |
+| `def_error: AccessDenied` on an Enterprise account | IAM/QuickSight permissions missing the `quicksight:DescribeAnalysisDefinition` action | Grant the describe-definition + describe-data-set permissions |
+| Empty visual histogram on an analysis you know is rich | Visual union node name not in the built/mid/unhandled sets | Check `VISUAL_*` sets in `quicksight-inventory.py`; unknown nodes default to mid |
+| Datasets section empty | Datasets describe failed or analysis uses dataset-of-datasets | Check `raw-datasets/`; dataset-of-datasets is out of scope (a known converter gap) |
+| `region` wrong / resources missing | Identity region ≠ data region | QuickSight reads from the identity region — almost always `us-east-1` |
+
+See `refs/migration-test-slate.md` (in the `quicksight-to-sigma` skill) for the
+complexity taxonomy + 20-dashboard test slate the buckets are grounded in.

--- a/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/README.md
+++ b/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/README.md
@@ -1,0 +1,39 @@
+# Sample readout — synthetic QuickSight account fixture
+
+A committed end-to-end run of `quicksight-assessment` against a **synthetic**
+`inventory.json` (account `153722385948`), so the skill's output shape is
+reviewable without an AWS account. The `inventory.json` here is hand-authored to
+exercise the three complexity profiles; the four downstream artifacts
+(`complexity.json`, `shortlist.json`, `migration-plan.json`, `readout.md`) are
+the **real** output of the Ruby pipeline run over it.
+
+Regenerate with:
+
+```bash
+ruby scripts/score-quicksight-complexity.rb --out fixtures/sample-readout
+ruby scripts/build-shortlist.rb            --out fixtures/sample-readout
+ruby scripts/migration-plan.rb             --out fixtures/sample-readout
+ruby scripts/render-readout.rb             --out fixtures/sample-readout
+```
+
+## What this run shows
+
+- **3 analyses, 2 datasets, 1 Snowflake data source.** Enterprise edition (the
+  definition APIs succeeded), so complexity is fully scored.
+- **`Orders Overview`** — the happy path: 5 built visuals (KPI/bar/line/pie), 3
+  mechanical calc fields, no window funcs → ranks highest, `recommended_path:
+  quicksight-to-sigma`.
+- **`Sales Deep Dive`** — mid-catalog visuals (table, pivot, combo), a join +
+  transforms, 1 window calc, RLS dataset → `needs-gap-scout`.
+- **`Exec ML Board`** — the hard case: InsightVisual (ML) + geospatial map +
+  sankey + 3 window calcs + free-form layout → mostly unhandled,
+  `needs-gap-scout`.
+- **Complexity-only mode** (no `usage.json`), so the readout carries the
+  limited-mode banner and the value basis is the `sheets + visuals/4` proxy.
+- **DM clustering** unions all three analyses into one cluster: they transitively
+  share `ds-orders-enriched` (Orders Overview + Exec ML Board reference it
+  directly; Sales Deep Dive references it alongside Customers), so they belong on
+  one Sigma data model.
+
+This validates the shared scoring + tag vocabulary, the Standard-edition /
+limited-mode banner logic, and the shared-dataset clustering.

--- a/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/complexity.json
+++ b/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/complexity.json
@@ -1,0 +1,213 @@
+{
+  "orders-overview": {
+    "name": "Orders Overview",
+    "sheets": 1,
+    "visuals": 5,
+    "visual_kinds": {
+      "KPIVisual": 2,
+      "BarChartVisual": 1,
+      "LineChartVisual": 1,
+      "PieChartVisual": 1
+    },
+    "calc_field_count": 3,
+    "window_calc_count": 0,
+    "parameter_count": 1,
+    "filter_group_count": 0,
+    "dataset_count": 1,
+    "dataset_source_types": [
+      "CustomSql"
+    ],
+    "has_custom_sql": true,
+    "has_joins": false,
+    "rls_role_count": 0,
+    "cls_count": 0,
+    "calc_buckets": {
+      "a": 3,
+      "b": 0,
+      "c": 0
+    },
+    "twb_size_kb": 0,
+    "n_features": 10,
+    "n_auto": 8,
+    "n_hint": 0,
+    "n_manual": 2,
+    "n_unhandled": 0,
+    "features": [
+      {
+        "name": "calc_mechanical",
+        "status": "auto",
+        "count": 3
+      },
+      {
+        "name": "visuals_built",
+        "status": "auto",
+        "count": 5
+      },
+      {
+        "name": "dataset_transforms",
+        "status": "manual",
+        "count": 2
+      },
+      {
+        "name": "parameters",
+        "status": "manual",
+        "count": 1
+      }
+    ]
+  },
+  "sales-deep-dive": {
+    "name": "Sales Deep Dive",
+    "sheets": 2,
+    "visuals": 8,
+    "visual_kinds": {
+      "KPIVisual": 1,
+      "BarChartVisual": 2,
+      "TableVisual": 1,
+      "PivotTableVisual": 1,
+      "ComboChartVisual": 1,
+      "LineChartVisual": 2
+    },
+    "calc_field_count": 6,
+    "window_calc_count": 1,
+    "parameter_count": 2,
+    "filter_group_count": 1,
+    "dataset_count": 2,
+    "dataset_source_types": [
+      "CustomSql",
+      "RelationalTable"
+    ],
+    "has_custom_sql": true,
+    "has_joins": true,
+    "rls_role_count": 1,
+    "cls_count": 0,
+    "calc_buckets": {
+      "a": 4,
+      "b": 1,
+      "c": 1
+    },
+    "twb_size_kb": 0,
+    "n_features": 19,
+    "n_auto": 9,
+    "n_hint": 0,
+    "n_manual": 8,
+    "n_unhandled": 2,
+    "features": [
+      {
+        "name": "calc_mechanical",
+        "status": "auto",
+        "count": 4
+      },
+      {
+        "name": "calc_restructure",
+        "status": "manual",
+        "count": 1
+      },
+      {
+        "name": "calc_window",
+        "status": "unhandled",
+        "count": 1
+      },
+      {
+        "name": "visuals_built",
+        "status": "auto",
+        "count": 5
+      },
+      {
+        "name": "visuals_rebuild",
+        "status": "manual",
+        "count": 3
+      },
+      {
+        "name": "dataset_joins",
+        "status": "manual",
+        "count": 1
+      },
+      {
+        "name": "dataset_transforms",
+        "status": "manual",
+        "count": 3
+      },
+      {
+        "name": "parameters",
+        "status": "manual",
+        "count": 2
+      },
+      {
+        "name": "filter_groups",
+        "status": "unhandled",
+        "count": 1
+      },
+      {
+        "name": "rls_cls",
+        "status": "manual",
+        "count": 1
+      }
+    ]
+  },
+  "exec-ml-board": {
+    "name": "Exec ML Board",
+    "sheets": 1,
+    "visuals": 4,
+    "visual_kinds": {
+      "InsightVisual": 1,
+      "GeospatialMapVisual": 1,
+      "SankeyDiagramVisual": 1,
+      "KPIVisual": 1
+    },
+    "calc_field_count": 4,
+    "window_calc_count": 3,
+    "parameter_count": 0,
+    "filter_group_count": 0,
+    "dataset_count": 1,
+    "dataset_source_types": [
+      "CustomSql"
+    ],
+    "has_custom_sql": true,
+    "has_joins": false,
+    "rls_role_count": 0,
+    "cls_count": 0,
+    "calc_buckets": {
+      "a": 1,
+      "b": 0,
+      "c": 3
+    },
+    "twb_size_kb": 0,
+    "n_features": 10,
+    "n_auto": 2,
+    "n_hint": 0,
+    "n_manual": 1,
+    "n_unhandled": 7,
+    "features": [
+      {
+        "name": "calc_mechanical",
+        "status": "auto",
+        "count": 1
+      },
+      {
+        "name": "calc_window",
+        "status": "unhandled",
+        "count": 3
+      },
+      {
+        "name": "visuals_built",
+        "status": "auto",
+        "count": 1
+      },
+      {
+        "name": "visuals_exotic",
+        "status": "unhandled",
+        "count": 3
+      },
+      {
+        "name": "dataset_transforms",
+        "status": "manual",
+        "count": 2
+      },
+      {
+        "name": "free_form_layout",
+        "status": "unhandled",
+        "count": 1
+      }
+    ]
+  }
+}

--- a/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/inventory.json
+++ b/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/inventory.json
@@ -1,0 +1,83 @@
+{
+  "account": {
+    "account_id": "153722385948",
+    "region": "us-east-1",
+    "generated_at": "2026-06-06",
+    "edition": "Enterprise",
+    "enterprise": true
+  },
+  "analyses": [
+    {
+      "id": "orders-overview",
+      "name": "Orders Overview",
+      "last_updated": "2026-05-20T00:00:00Z",
+      "sheet_count": 1,
+      "visual_count": 5,
+      "visual_kinds": { "KPIVisual": 2, "BarChartVisual": 1, "LineChartVisual": 1, "PieChartVisual": 1 },
+      "visuals_built": 5, "visuals_mid": 0, "visuals_unhandled": 0,
+      "calc_field_count": 3,
+      "calc_buckets": { "a": 3, "b": 0, "c": 0 },
+      "window_calc_count": 0,
+      "parameter_count": 1, "filter_group_count": 0,
+      "free_form_sheets": 0, "section_based_sheets": 0,
+      "dataset_identifiers": ["orders"],
+      "dataset_ids": ["ds-orders-enriched"]
+    },
+    {
+      "id": "sales-deep-dive",
+      "name": "Sales Deep Dive",
+      "last_updated": "2026-05-18T00:00:00Z",
+      "sheet_count": 2,
+      "visual_count": 8,
+      "visual_kinds": { "KPIVisual": 1, "BarChartVisual": 2, "TableVisual": 1, "PivotTableVisual": 1, "ComboChartVisual": 1, "LineChartVisual": 2 },
+      "visuals_built": 5, "visuals_mid": 3, "visuals_unhandled": 0,
+      "calc_field_count": 6,
+      "calc_buckets": { "a": 4, "b": 1, "c": 1 },
+      "window_calc_count": 1,
+      "parameter_count": 2, "filter_group_count": 1,
+      "free_form_sheets": 0, "section_based_sheets": 0,
+      "dataset_identifiers": ["orders", "customers"],
+      "dataset_ids": ["ds-orders-enriched", "ds-customers"]
+    },
+    {
+      "id": "exec-ml-board",
+      "name": "Exec ML Board",
+      "last_updated": "2026-05-10T00:00:00Z",
+      "sheet_count": 1,
+      "visual_count": 4,
+      "visual_kinds": { "InsightVisual": 1, "GeospatialMapVisual": 1, "SankeyDiagramVisual": 1, "KPIVisual": 1 },
+      "visuals_built": 1, "visuals_mid": 0, "visuals_unhandled": 3,
+      "calc_field_count": 4,
+      "calc_buckets": { "a": 1, "b": 0, "c": 3 },
+      "window_calc_count": 3,
+      "parameter_count": 0, "filter_group_count": 0,
+      "free_form_sheets": 1, "section_based_sheets": 0,
+      "dataset_identifiers": ["orders"],
+      "dataset_ids": ["ds-orders-enriched"]
+    }
+  ],
+  "datasets": [
+    {
+      "id": "ds-orders-enriched",
+      "name": "Orders Enriched",
+      "import_mode": "DIRECT_QUERY",
+      "physical_kinds": ["CustomSql"],
+      "has_custom_sql": true, "has_joins": false, "transform_count": 2,
+      "rls_enabled": false, "cls_enabled": false, "column_count": 14
+    },
+    {
+      "id": "ds-customers",
+      "name": "Customers",
+      "import_mode": "SPICE",
+      "physical_kinds": ["RelationalTable"],
+      "has_custom_sql": false, "has_joins": true, "transform_count": 1,
+      "rls_enabled": true, "cls_enabled": false, "column_count": 9
+    }
+  ],
+  "data_sources": [
+    { "id": "src-snow", "name": "Snowflake Prod", "type": "SNOWFLAKE" }
+  ],
+  "environment_overview": {
+    "analyses": 3, "dashboards": 2, "datasets": 2, "data_sources": 1
+  }
+}

--- a/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/migration-plan.json
+++ b/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/migration-plan.json
@@ -1,0 +1,121 @@
+{
+  "analyses": [
+    {
+      "analysisId": "orders-overview",
+      "name": "Orders Overview",
+      "dataset_ids": [
+        "ds-orders-enriched"
+      ],
+      "dataset_source_types": [
+        "CustomSql"
+      ],
+      "recommended_path": "quicksight-to-sigma",
+      "priority_tier": "moderate",
+      "score": 3.21,
+      "views": null,
+      "calc_buckets": {
+        "a": 3,
+        "b": 0,
+        "c": 0
+      },
+      "blockers": [
+        "2 restructuring/join/transform/RLS/param feature(s)"
+      ],
+      "cluster_id": "cluster-01-customers"
+    },
+    {
+      "analysisId": "sales-deep-dive",
+      "name": "Sales Deep Dive",
+      "dataset_ids": [
+        "ds-orders-enriched",
+        "ds-customers"
+      ],
+      "dataset_source_types": [
+        "CustomSql",
+        "RelationalTable"
+      ],
+      "recommended_path": "quicksight-to-sigma-with-scout",
+      "priority_tier": "needs-gap-scout",
+      "score": 0.89,
+      "views": null,
+      "calc_buckets": {
+        "a": 4,
+        "b": 1,
+        "c": 1
+      },
+      "blockers": [
+        "2 unhandled feature(s) (window calc / exotic visual / free-form layout / FilterGroups)",
+        "8 restructuring/join/transform/RLS/param feature(s)"
+      ],
+      "cluster_id": "cluster-01-customers"
+    },
+    {
+      "analysisId": "exec-ml-board",
+      "name": "Exec ML Board",
+      "dataset_ids": [
+        "ds-orders-enriched"
+      ],
+      "dataset_source_types": [
+        "CustomSql"
+      ],
+      "recommended_path": "quicksight-to-sigma-with-scout",
+      "priority_tier": "needs-gap-scout",
+      "score": 0.27,
+      "views": null,
+      "calc_buckets": {
+        "a": 1,
+        "b": 0,
+        "c": 3
+      },
+      "blockers": [
+        "7 unhandled feature(s) (window calc / exotic visual / free-form layout / FilterGroups)",
+        "1 restructuring/join/transform/RLS/param feature(s)"
+      ],
+      "cluster_id": "cluster-01-customers"
+    }
+  ],
+  "dm_clusters": [
+    {
+      "id": "cluster-01-customers",
+      "dataset_ids": [
+        "ds-customers",
+        "ds-orders-enriched"
+      ],
+      "dataset_names": [
+        "Customers",
+        "Orders Enriched"
+      ],
+      "analysisIds": [
+        "orders-overview",
+        "sales-deep-dive",
+        "exec-ml-board"
+      ],
+      "analysis_names": [
+        "Orders Overview",
+        "Sales Deep Dive",
+        "Exec ML Board"
+      ],
+      "shared_source_types": [
+        "CustomSql",
+        "RelationalTable"
+      ],
+      "cluster_size": 3
+    }
+  ],
+  "summary": {
+    "analyses_total": 3,
+    "analyses_ready": 1,
+    "analyses_need_scout": 2,
+    "analyses_blocked": 0,
+    "analyses_retire": 0,
+    "cluster_count": 1,
+    "usage_available": false,
+    "suggested_batch": [
+      {
+        "analysisId": "orders-overview",
+        "name": "Orders Overview",
+        "cluster_id": "cluster-01-customers"
+      }
+    ]
+  }
+}

--- a/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/readout.md
+++ b/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/readout.md
@@ -1,0 +1,216 @@
+# Amazon QuickSight Assessment — 153722385948
+
+**Account:** `153722385948` | **Region:** us-east-1 | **Edition:** Enterprise | **Mode:** Complexity-only | **Generated:** 2026-06-06
+
+> Lightweight pre-scoping readout produced by the `quicksight-assessment` skill.
+> READ-ONLY — nothing was written to QuickSight or posted to Sigma. The migration
+> shortlist below feeds directly into the `quicksight-to-sigma` conversion skill.
+
+
+
+---
+
+## 1. Environment overview
+
+| | |
+|---|---|
+| Analyses | **3** |
+| Dashboards | 2 |
+| Datasets | **2** |
+| Data sources | 1 |
+
+
+> ⚠️ Running WITHOUT per-analysis usage data. QuickSight has no per-analysis
+> view-count API on the standard surface, so the shortlist below is
+> **complexity-only**: it ranks analyses by size/richness, not by who actually
+> uses them. Supply a `usage.json` (CloudTrail/CloudWatch-derived) to add the
+> usage axis. Everything else (visual mix, calc-field buckets, dataset sources)
+> is accurate.
+
+
+---
+
+## 2. Visual-type mix (account-wide)
+
+QuickSight visuals the workbook builder reproduces directly: KPI, bar, line,
+pie/donut. Everything else is a manual rebuild (mid catalog: table, pivot,
+combo, scatter, gauge, funnel, treemap, …) or has no Sigma equivalent (maps,
+sankey, insight ML, custom content, plugin).
+
+| Visual type | Count |
+|---|---|
+| KPIVisual | 4 |
+| BarChartVisual | 3 |
+| LineChartVisual | 3 |
+| PivotTableVisual | 1 |
+| ComboChartVisual | 1 |
+| InsightVisual | 1 |
+| GeospatialMapVisual | 1 |
+| SankeyDiagramVisual | 1 |
+| PieChartVisual | 1 |
+| TableVisual | 1 |
+
+
+---
+
+## 3. Analysis complexity
+
+Each analysis's conversion burden = its visual mix + calc fields + parameters,
+plus its datasets' source/prep/RLS burden (inherited via dataset references).
+
+| Analysis | Sheets | Visuals | CalcFields | Window | Params | Calc a/b/c |
+|---|---|---|---|---|---|---|
+| Exec ML Board | 1 | 4 | 4 | 3 | 0 | 1/0/3 |
+| Sales Deep Dive | 2 | 8 | 6 | 1 | 2 | 4/1/1 |
+| Orders Overview | 1 | 5 | 3 | 0 | 1 | 3/0/0 |
+
+
+Calc-field convertibility buckets (from `refs/migration-test-slate.md`):
+- **a — mechanical** (~most calc fields): direct Sigma-formula rewrite
+  (`ifelse`→`If`, `switch`→nested `If`, arithmetic, string, date funcs).
+- **b — restructuring**: needs a grouped element or pre-aggregation.
+- **c — no Sigma equivalent**: window / table-calc functions (`sumOver`,
+  `runningSum`, `rank`, `percentOfTotal`, `periodOverPeriod*`, …) — the converter
+  degrades these to a `/* TODO */` placeholder.
+
+Across all scanned analyses: **8 mechanical / 1
+restructuring / 4 no-equivalent** calc fields.
+
+---
+
+## 4. Datasets & sources
+
+Physical source kinds parsed from each dataset's `PhysicalTableMap`:
+
+| Physical source kind | Datasets |
+|---|---|
+| CustomSql | 1 |
+| RelationalTable | 1 |
+
+
+- **1** dataset(s) use **CustomSql** (converted via the
+  `[Custom SQL/<ALIAS>]` fixup — see `quicksight-to-sigma`).
+- **1** dataset(s) have **row-level security** enabled.
+
+Migration signal: datasets on a cloud warehouse Sigma already supports
+(Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres) are **drop-in** —
+Sigma reads the same tables directly. **S3 / SaaS** physical sources are a
+converter gap (placeholder) and surface as unhandled.
+
+---
+
+## 5. Analysis priority — by complexity proxy
+
+| Analysis | Sheets | Visuals | Views | Users |
+|---|---|---|---|---|
+| Orders Overview | 1 | 5 | — | — |
+| Sales Deep Dive | 2 | 8 | — | — |
+| Exec ML Board | 1 | 4 | — | — |
+
+
+
+
+> Usage data unavailable. Analyses above are ranked by a complexity proxy
+> (sheet + visual count), not real view counts.
+
+
+---
+
+## 6. Migration shortlist (complexity-only proxy (sheets + visuals/4))
+
+`cost = 10·unhandled + 3·manual + 1·hint`, ranked by `value / (1 + cost)`.
+Higher score = better first-migration candidate. For QuickSight, `manual` =
+restructuring calc + mid-catalog visuals + dataset joins/transforms + parameters
++ RLS/CLS; `unhandled` = window/table-calc + exotic visuals + free-form/section
+layout + FilterGroups + S3/SaaS source.
+
+| Analysis | Views | Calc a/b/c | Auto/Hint/Man/Unh | Value | Score | Tag |
+|---|---|---|---|---|---|---|
+| Orders Overview | — | 3/0/0 | 8/0/2/0 | 22.5 | 3.21 | moderate |
+| Sales Deep Dive | — | 4/1/1 | 9/0/8/2 | 40.0 | 0.89 | ⚠️ needs-gap-scout |
+| Exec ML Board | — | 1/0/3 | 2/0/1/7 | 20.0 | 0.27 | ⚠️ needs-gap-scout |
+
+
+The top 3 analyses have **9
+unhandled features between them**.
+
+---
+
+## 7. Per-analysis complexity
+
+| Analysis | Sheets | Visuals | CalcFields | Window | RLS | Manual | Unhandled |
+|---|---|---|---|---|---|---|---|
+| Exec ML Board | 1 | 4 | 4 | 3 | 0 | 1 | **7** |
+| Sales Deep Dive | 2 | 8 | 6 | 1 | 1 | 8 | **2** |
+| Orders Overview | 1 | 5 | 3 | 0 | 0 | 2 | 0 |
+
+
+**Total unhandled features across the account: 9** spanning
+2 analyses. Each gets a `gap-scout`-style triage at conversion
+time.
+
+---
+
+## 8. What this skill found vs. what it didn't
+
+**Found (read-only, AWS-CLI delegated):**
+- Environment counts (analyses, dashboards, datasets, data sources)
+- Per-analysis: sheet count, visual count, visual-kind histogram
+- Per-analysis: calc-field count + a/b/c convertibility buckets, window-function detection
+- Per-analysis: parameter count, FilterGroup count, layout shape (free-form / section-based)
+- Per-dataset: source type(s), import mode (SPICE/DirectQuery), custom-sql, joins, transform count, RLS/CLS
+
+
+
+**Not gathered (out of scope):**
+- Per-visual field-level bindings (the converter re-derives these from the analysis definition at conversion time)
+
+- Usage / adoption — QuickSight has no per-analysis view-count API on the
+  standard surface; supply a CloudTrail/CloudWatch-derived `usage.json` to add it.
+
+
+---
+
+## 9. Privacy
+
+What crossed Anthropic's API on its way through Claude during this assessment:
+
+- Aggregate counts (analysis / dataset / data-source counts)
+- Analysis, dataset, and data-source names
+- **Analysis definitions** — visual configuration + **calc-field expressions**
+- Dataset metadata — physical source kinds, custom-sql presence, RLS/CLS flags
+
+What did NOT cross:
+- Warehouse / SPICE rows (this skill never queries the underlying data)
+- AWS credentials (handled by the AWS CLI, not surfaced)
+- Actual visual cell values
+
+---
+
+## 10. Hand-off package
+
+This directory contains:
+
+- `readout.md` — this report
+- `inventory.json` — raw environment + per-analysis + per-dataset metadata
+- `complexity.json` — per-analysis convertibility scoring
+- `shortlist.json` — value/cost-ranked migration shortlist
+- `migration-plan.json` — per-analysis `recommended_path` + DM clusters (by shared dataset)
+- `raw-defs/` — decoded analysis definitions (delete after review if you'd rather not retain calc-field text)
+- `raw-datasets/` — decoded dataset describes
+
+Nothing is uploaded automatically. To share, zip and send deliberately.
+
+---
+
+## 11. Next steps
+
+1. **Pilot the top 3 analyses** with the
+   `quicksight-to-sigma` skill — the migration-plan groups them into DM clusters
+   that share a Sigma data model (by shared dataset).
+2. **Triage the `needs-gap-scout` queue** (2 analyses):
+   window/table-calc functions, exotic visuals, or free-form layout that need a
+   design decision first.
+
+4. **Supply usage data** (CloudTrail/CloudWatch) to get a usage-weighted (not
+   complexity-only) shortlist.

--- a/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/shortlist.json
+++ b/quicksight-migration-skills/quicksight-assessment/fixtures/sample-readout/shortlist.json
@@ -1,0 +1,79 @@
+{
+  "usage_available": false,
+  "value_basis": "complexity-only proxy (sheets + visuals/4)",
+  "analyses": [
+    {
+      "name": "Orders Overview",
+      "id": "orders-overview",
+      "sheets": 1,
+      "visuals": 5,
+      "views": null,
+      "users": null,
+      "auto": 8,
+      "hint": 0,
+      "manual": 2,
+      "unhandled": 0,
+      "calc_buckets": {
+        "a": 3,
+        "b": 0,
+        "c": 0
+      },
+      "dataset_source_types": [
+        "CustomSql"
+      ],
+      "value": 22.5,
+      "cost": 6,
+      "score": 3.21,
+      "tag": "moderate"
+    },
+    {
+      "name": "Sales Deep Dive",
+      "id": "sales-deep-dive",
+      "sheets": 2,
+      "visuals": 8,
+      "views": null,
+      "users": null,
+      "auto": 9,
+      "hint": 0,
+      "manual": 8,
+      "unhandled": 2,
+      "calc_buckets": {
+        "a": 4,
+        "b": 1,
+        "c": 1
+      },
+      "dataset_source_types": [
+        "CustomSql",
+        "RelationalTable"
+      ],
+      "value": 40.0,
+      "cost": 44,
+      "score": 0.89,
+      "tag": "needs-gap-scout"
+    },
+    {
+      "name": "Exec ML Board",
+      "id": "exec-ml-board",
+      "sheets": 1,
+      "visuals": 4,
+      "views": null,
+      "users": null,
+      "auto": 2,
+      "hint": 0,
+      "manual": 1,
+      "unhandled": 7,
+      "calc_buckets": {
+        "a": 1,
+        "b": 0,
+        "c": 3
+      },
+      "dataset_source_types": [
+        "CustomSql"
+      ],
+      "value": 20.0,
+      "cost": 73,
+      "score": 0.27,
+      "tag": "needs-gap-scout"
+    }
+  ]
+}

--- a/quicksight-migration-skills/quicksight-assessment/refs/output-shapes.md
+++ b/quicksight-migration-skills/quicksight-assessment/refs/output-shapes.md
@@ -1,0 +1,137 @@
+# Output shapes
+
+Three JSON files + one markdown emitted to `<out>/`, plus decoded `raw-defs/`
+and `raw-datasets/`. `render-readout.rb` reads the JSON to produce `readout.md`;
+`quicksight-to-sigma` reads `migration-plan.json`.
+
+Parallel to `powerbi-assessment/refs/output-shapes.md` — the renderer and
+shortlist scoring share that skill's vocabulary so the markdown sections line
+up. The key difference: QuickSight splits complexity across the **analysis**
+(visuals, calc fields, parameters, layout) and its **datasets** (source type,
+custom-sql, joins, data-prep, RLS/CLS).
+
+## `inventory.json` (written by `quicksight-inventory.py`)
+
+```json
+{
+  "account": {
+    "account_id": "...", "region": "us-east-1",
+    "generated_at": "YYYY-MM-DD",
+    "edition": "Enterprise" | "Standard? (definition API rejected)" | null,
+    "enterprise": true | false | null
+  },
+  "analyses": [
+    {
+      "id": "...", "name": "...", "last_updated": "...",
+      "sheet_count": <int>, "visual_count": <int>,
+      "visual_kinds": { "BarChartVisual": N, "KPIVisual": N, ... },
+      "visuals_built": <int>, "visuals_mid": <int>, "visuals_unhandled": <int>,
+      "calc_field_count": <int>,
+      "calc_buckets": { "a": <int>, "b": <int>, "c": <int> },
+      "window_calc_count": <int>,
+      "parameter_count": <int>, "filter_group_count": <int>,
+      "free_form_sheets": <int>, "section_based_sheets": <int>,
+      "dataset_identifiers": [...], "dataset_ids": ["<dataSetId>", ...]
+      // OR, on a Standard account / no perms:  "def_error": "..."
+    }
+  ],
+  "datasets": [
+    {
+      "id": "...", "name": "...",
+      "import_mode": "SPICE" | "DIRECT_QUERY",
+      "physical_kinds": ["RelationalTable" | "CustomSql" | "S3Source", ...],
+      "has_custom_sql": <bool>, "has_joins": <bool>, "transform_count": <int>,
+      "rls_enabled": <bool>, "cls_enabled": <bool>, "column_count": <int>
+    }
+  ],
+  "data_sources": [ { "id": "...", "name": "...", "type": "SNOWFLAKE" | "REDSHIFT" | "ATHENA" | "S3" | ... } ],
+  "environment_overview": {
+    "analyses": <int>, "dashboards": <int>, "datasets": <int>, "data_sources": <int>
+  }
+}
+```
+
+`calc_buckets` semantics (from `refs/migration-test-slate.md`): `a` = mechanical
+rewrite, `b` = needs restructuring, `c` = window / table-calc function with no
+clean Sigma equivalent (converter degrades to a `/* TODO */` placeholder).
+
+## `complexity.json` (written by `score-quicksight-complexity.rb`)
+
+Keyed by **analysis id**. The analysis inherits its datasets' burden via
+`dataset_ids`. The four `n_*` tiers map onto the shared vocabulary: easy → auto,
+medium → manual, hard → unhandled, no `hint` tier.
+
+```json
+{
+  "<analysis-id>": {
+    "name": "...", "sheets": <int>, "visuals": <int>, "visual_kinds": {...},
+    "calc_field_count": <int>, "window_calc_count": <int>,
+    "parameter_count": <int>, "filter_group_count": <int>,
+    "dataset_count": <int>, "dataset_source_types": [...],
+    "has_custom_sql": <bool>, "has_joins": <bool>,
+    "rls_role_count": <int>, "cls_count": <int>,
+    "calc_buckets": { "a": <int>, "b": <int>, "c": <int> },
+    "twb_size_kb": 0,                       // n/a; renderer-compat
+    "n_features": <int>, "n_auto": <int>, "n_hint": 0,
+    "n_manual": <int>,                      // restructure calc + mid visuals + joins + transforms + params + RLS/CLS
+    "n_unhandled": <int>,                   // window calc + exotic visuals + free-form/section layout + FilterGroups + S3 source
+    "features": [{ "name": "...", "status": "auto|manual|unhandled", "count": <int> }]
+  }
+}
+```
+
+## `usage.json` (optional — only if the agent supplies it)
+
+QuickSight has no per-analysis view-count API on the standard surface. If the
+agent derives views from CloudTrail / CloudWatch (optional, out of scope for the
+default run) it can drop a file in this shape and `build-shortlist.rb` will use
+the usage-weighted value formula:
+
+```json
+{
+  "available": true,
+  "by_analysis": { "<analysis-id>": { "views": <int>, "users": <int> } }
+}
+```
+
+If absent, `build-shortlist.rb` falls back to the complexity-only proxy.
+
+## `shortlist.json` (written by `build-shortlist.rb`)
+
+```json
+{
+  "usage_available": <bool>,
+  "value_basis": "usage (views × √users)" | "complexity-only proxy (sheets + visuals/4)",
+  "analyses": [
+    {
+      "name": "...", "id": "...", "sheets": <int>, "visuals": <int>,
+      "views": <int>|null, "users": <int>|null,
+      "auto": <int>, "hint": <int>, "manual": <int>, "unhandled": <int>,
+      "calc_buckets": {...}, "dataset_source_types": [...],
+      "value": <float>, "cost": <int>, "score": <float>,
+      "tag": "migrate-first"|"easy-win"|"moderate"|"needs-gap-scout"|"retire"
+    }
+  ]
+}
+```
+
+Tag rules (mirror powerbi/tableau-assessment):
+- usage available AND `views == 0`               → `retire`
+- `unhandled >= 1`                               → `needs-gap-scout`
+- `score >= 20 and (manual + unhandled) == 0`    → `migrate-first`
+- `score >= 10`                                  → `easy-win`
+- else                                           → `moderate`
+
+## `migration-plan.json` (written by `migration-plan.rb`)
+
+The hand-off contract for `quicksight-to-sigma`. Per-analysis `recommended_path`
+(`quicksight-to-sigma` / `quicksight-to-sigma-with-scout` / `retire` /
+`blocked`) plus DM clusters. Clustering key is the **shared dataset** — analyses
+that reference the same QuickSight dataset (or transitively overlap) share a
+Sigma data model by construction. See `migration-plan.rb` header for the full
+shape.
+
+## `readout.md`
+
+Markdown readout. See `refs/readout-template.md` for section ordering and
+placeholders. Deterministic composition from the JSON files above.

--- a/quicksight-migration-skills/quicksight-assessment/refs/readout-template.md
+++ b/quicksight-migration-skills/quicksight-assessment/refs/readout-template.md
@@ -1,0 +1,195 @@
+# Amazon QuickSight Assessment — {{account_name}}
+
+**Account:** `{{account_name}}` | **Region:** {{region}} | **Edition:** {{edition}} | **Mode:** {{mode}} | **Generated:** {{generated_at}}
+
+> Lightweight pre-scoping readout produced by the `quicksight-assessment` skill.
+> READ-ONLY — nothing was written to QuickSight or posted to Sigma. The migration
+> shortlist below feeds directly into the `quicksight-to-sigma` conversion skill.
+
+{{#standard_edition_banner}}
+> ⛔ The `describe-*-definition` / `describe-data-set` APIs were rejected — this
+> looks like a **Standard-edition** account. Those APIs are **Enterprise-only**,
+> so per-analysis visual / calc-field complexity is **unavailable**: the readout
+> below is counts-only. Upgrade to Enterprise (or run against an Enterprise
+> account) to get the full complexity scoring and a real migration shortlist.
+{{/standard_edition_banner}}
+
+---
+
+## 1. Environment overview
+
+| | |
+|---|---|
+| Analyses | **{{analyses}}** |
+| Dashboards | {{dashboards}} |
+| Datasets | **{{datasets}}** |
+| Data sources | {{data_sources}} |
+
+{{#limited_mode_banner}}
+> ⚠️ Running WITHOUT per-analysis usage data. QuickSight has no per-analysis
+> view-count API on the standard surface, so the shortlist below is
+> **complexity-only**: it ranks analyses by size/richness, not by who actually
+> uses them. Supply a `usage.json` (CloudTrail/CloudWatch-derived) to add the
+> usage axis. Everything else (visual mix, calc-field buckets, dataset sources)
+> is accurate.
+{{/limited_mode_banner}}
+
+---
+
+## 2. Visual-type mix (account-wide)
+
+QuickSight visuals the workbook builder reproduces directly: KPI, bar, line,
+pie/donut. Everything else is a manual rebuild (mid catalog: table, pivot,
+combo, scatter, gauge, funnel, treemap, …) or has no Sigma equivalent (maps,
+sankey, insight ML, custom content, plugin).
+
+{{visuals_table}}
+
+---
+
+## 3. Analysis complexity
+
+Each analysis's conversion burden = its visual mix + calc fields + parameters,
+plus its datasets' source/prep/RLS burden (inherited via dataset references).
+
+{{analyses_table}}
+
+Calc-field convertibility buckets (from `refs/migration-test-slate.md`):
+- **a — mechanical** (~most calc fields): direct Sigma-formula rewrite
+  (`ifelse`→`If`, `switch`→nested `If`, arithmetic, string, date funcs).
+- **b — restructuring**: needs a grouped element or pre-aggregation.
+- **c — no Sigma equivalent**: window / table-calc functions (`sumOver`,
+  `runningSum`, `rank`, `percentOfTotal`, `periodOverPeriod*`, …) — the converter
+  degrades these to a `/* TODO */` placeholder.
+
+Across all scanned analyses: **{{total_calc_a}} mechanical / {{total_calc_b}}
+restructuring / {{total_calc_c}} no-equivalent** calc fields.
+
+---
+
+## 4. Datasets & sources
+
+Physical source kinds parsed from each dataset's `PhysicalTableMap`:
+
+{{source_table}}
+
+- **{{n_custom_sql}}** dataset(s) use **CustomSql** (converted via the
+  `[Custom SQL/<ALIAS>]` fixup — see `quicksight-to-sigma`).
+- **{{n_rls}}** dataset(s) have **row-level security** enabled.
+
+Migration signal: datasets on a cloud warehouse Sigma already supports
+(Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres) are **drop-in** —
+Sigma reads the same tables directly. **S3 / SaaS** physical sources are a
+converter gap (placeholder) and surface as unhandled.
+
+---
+
+## 5. Analysis priority — {{usage_basis}}
+
+{{usage_table}}
+
+{{#has_usage}}
+**Cold (zero-view) analyses:** {{n_cold}} — retire-don't-migrate candidates.
+{{/has_usage}}
+{{^has_usage}}
+> Usage data unavailable. Analyses above are ranked by a complexity proxy
+> (sheet + visual count), not real view counts.
+{{/has_usage}}
+
+---
+
+## 6. Migration shortlist ({{value_basis}})
+
+`cost = 10·unhandled + 3·manual + 1·hint`, ranked by `value / (1 + cost)`.
+Higher score = better first-migration candidate. For QuickSight, `manual` =
+restructuring calc + mid-catalog visuals + dataset joins/transforms + parameters
++ RLS/CLS; `unhandled` = window/table-calc + exotic visuals + free-form/section
+layout + FilterGroups + S3/SaaS source.
+
+{{shortlist_table}}
+
+The top {{shortlist_top_n}} analyses have **{{shortlist_total_unhandled}}
+unhandled features between them**.
+
+---
+
+## 7. Per-analysis complexity
+
+{{complexity_table}}
+
+**Total unhandled features across the account: {{total_unhandled}}** spanning
+{{n_with_unhandled}} analyses. Each gets a `gap-scout`-style triage at conversion
+time.
+
+---
+
+## 8. What this skill found vs. what it didn't
+
+**Found (read-only, AWS-CLI delegated):**
+- Environment counts (analyses, dashboards, datasets, data sources)
+- Per-analysis: sheet count, visual count, visual-kind histogram
+- Per-analysis: calc-field count + a/b/c convertibility buckets, window-function detection
+- Per-analysis: parameter count, FilterGroup count, layout shape (free-form / section-based)
+- Per-dataset: source type(s), import mode (SPICE/DirectQuery), custom-sql, joins, transform count, RLS/CLS
+
+{{#has_usage}}
+**Added by supplied usage data:**
+- Per-analysis view counts and distinct-user counts
+- Usage-weighted migration shortlist
+- Cold-analysis detection
+{{/has_usage}}
+
+**Not gathered (out of scope):**
+- Per-visual field-level bindings (the converter re-derives these from the analysis definition at conversion time)
+{{^has_usage}}
+- Usage / adoption — QuickSight has no per-analysis view-count API on the
+  standard surface; supply a CloudTrail/CloudWatch-derived `usage.json` to add it.
+{{/has_usage}}
+
+---
+
+## 9. Privacy
+
+What crossed Anthropic's API on its way through Claude during this assessment:
+
+- Aggregate counts (analysis / dataset / data-source counts)
+- Analysis, dataset, and data-source names
+- **Analysis definitions** — visual configuration + **calc-field expressions**
+- Dataset metadata — physical source kinds, custom-sql presence, RLS/CLS flags
+
+What did NOT cross:
+- Warehouse / SPICE rows (this skill never queries the underlying data)
+- AWS credentials (handled by the AWS CLI, not surfaced)
+- Actual visual cell values
+
+---
+
+## 10. Hand-off package
+
+This directory contains:
+
+- `readout.md` — this report
+- `inventory.json` — raw environment + per-analysis + per-dataset metadata
+- `complexity.json` — per-analysis convertibility scoring
+- `shortlist.json` — value/cost-ranked migration shortlist
+- `migration-plan.json` — per-analysis `recommended_path` + DM clusters (by shared dataset)
+- `raw-defs/` — decoded analysis definitions (delete after review if you'd rather not retain calc-field text)
+- `raw-datasets/` — decoded dataset describes
+
+Nothing is uploaded automatically. To share, zip and send deliberately.
+
+---
+
+## 11. Next steps
+
+1. **Pilot the top {{recommended_pilot_n}} analyses** with the
+   `quicksight-to-sigma` skill — the migration-plan groups them into DM clusters
+   that share a Sigma data model (by shared dataset).
+2. **Triage the `needs-gap-scout` queue** ({{n_needs_scout}} analyses):
+   window/table-calc functions, exotic visuals, or free-form layout that need a
+   design decision first.
+{{#has_usage}}
+3. **Retire the `retire` queue** ({{n_retire}} analyses): zero views, no migration value.
+{{/has_usage}}
+4. **Supply usage data** (CloudTrail/CloudWatch) to get a usage-weighted (not
+   complexity-only) shortlist.

--- a/quicksight-migration-skills/quicksight-assessment/refs/token-model.json
+++ b/quicksight-migration-skills/quicksight-assessment/refs/token-model.json
@@ -1,0 +1,53 @@
+{
+  "_doc": "Per-dashboard token/$ estimator for migration assessments. Estimate = per_dashboard[bucket] * n_dashboards + per_review_item * n_review_items (n_review_items = items the assessment flags with unsupported/needs-review features, n_unhandled > 0). Tokens are the portable unit; rescale $ by your coding agent's model pricing. ALL numbers below are MEASURED from controlled end-to-end conversions (2026-06-07) unless noted.",
+  "calibration": {
+    "date": "2026-06-07",
+    "models": ["opus", "sonnet"],
+    "rates_per_million_usd": {
+      "opus":   { "input": 15.0, "output": 75.0, "cache_write": 18.75, "cache_read": 1.50 },
+      "sonnet": { "input": 3.0,  "output": 15.0, "cache_write": 3.75,  "cache_read": 0.30 }
+    },
+    "real_samples": {
+      "quicksight_D8_orchestrator":  { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "qlik_RetailOrders_orchestrator": { "opus_usd": 0.72, "sonnet_usd": 0.08 },
+      "tableau_Superstore_full":     { "opus_usd": 29.35, "sonnet_usd": 6.55 },
+      "per_review_interactive_delta_opus": 0.46
+    },
+    "for_reference_naive_vs_orchestrator": {
+      "quicksight_D8_naive": { "opus_usd": 8.56, "sonnet_usd": 2.79 },
+      "quicksight_D8_optimized_brief": { "opus_usd": 3.48, "sonnet_usd": 1.16 },
+      "quicksight_D8_orchestrator": { "opus_usd": 0.69, "sonnet_usd": 0.14 },
+      "note": "For tools WITH a mechanical converter, the one-shot orchestrator is ~12-20x cheaper than a naive agent-driven migration."
+    }
+  },
+  "per_dashboard": {
+    "mechanical": {
+      "tools": ["quicksight", "powerbi", "qlik", "thoughtspot"],
+      "opus_usd": 0.70,
+      "sonnet_usd": 0.11,
+      "tokens_output_plus_cache_creation": 25000,
+      "basis": "measured — one-shot orchestrator path (mechanical converter → deterministic; cost flat & tool-independent across QuickSight + Qlik)"
+    },
+    "tableau": {
+      "opus_usd": 29.0,
+      "sonnet_usd": 6.5,
+      "tokens_output_plus_cache_creation": 480000,
+      "range_opus_usd": [15.0, 45.0],
+      "basis": "measured — full agent-authored conversion (Superstore Overview: 7 KPIs + map + 2 area charts + controls)",
+      "note": "Tableau has NO mechanical converter, so the agent authors the entire DM+workbook spec from the .twb — ~40x the mechanical tools. The one-shot orchestrator does NOT reduce this (spec-authoring is the irreducible agent work, not the post-spec pipeline). Scales with dashboard richness + calc/LOD/custom-SQL complexity. The real lever to cut Tableau cost is building a mechanical Tableau->Sigma converter."
+    }
+  },
+  "per_review_item": {
+    "opus_usd": 0.46,
+    "sonnet_usd": 0.08,
+    "basis": "measured — interactive decision-checkpoint delta vs the --yes floor (QuickSight D8; one OPEN QUESTIONS round). Negligible at Sonnet pricing.",
+    "note": "Each item the assessment flags with unsupported/needs-review features (n_unhandled > 0) adds ~one human decision round at the orchestrator checkpoint. Does not apply to the mechanical floor when run with auto-accepted defaults."
+  },
+  "caveats": [
+    "Calibrated on Claude Code; rescale $ by your coding agent's per-token pricing — tokens are portable, $ is not.",
+    "Mechanical-converter tools (QuickSight/PowerBI/Qlik/ThoughtSpot) assume the one-shot orchestrator path; a naive agent-driven migration is ~12-20x more expensive.",
+    "Tableau is the outlier (~40x) because its spec is agent-authored; its number is a full-conversion measurement, not an orchestrator floor.",
+    "Warehouse/compute cost (Sigma + Snowflake query) is separate and NOT included — this is LLM cost only.",
+    "Tableau is one measured sample (a rich standard dashboard); expect variance with dashboard complexity (range shown)."
+  ]
+}

--- a/quicksight-migration-skills/quicksight-assessment/scripts/build-shortlist.rb
+++ b/quicksight-migration-skills/quicksight-assessment/scripts/build-shortlist.rb
@@ -1,0 +1,112 @@
+#!/usr/bin/env ruby
+# Phase 4 (QuickSight): cross-tabulate per-analysis usage with per-analysis
+# complexity and emit a value/cost-ranked migration shortlist.
+#
+# Adapted from powerbi-assessment/scripts/build-shortlist.rb — same scoring
+# shape + tag vocabulary so the readout renderer is shared. The VALUE signal:
+#
+#   - QuickSight has no per-analysis view-count API on the standard surface, so
+#     value defaults to a complexity-only proxy: value = 10 × (sheets +
+#     visuals/4), ranking "bigger / richer analyses first".
+#   - If the agent supplied usage.json (e.g. CloudTrail / CloudWatch-derived
+#     view counts, optional), value = views × √(distinct_users) — the tableau/
+#     powerbi formula.
+#
+#   cost  = 10·unhandled + 3·manual + 1·hint      (same weights as the others)
+#   score = value / (1 + cost)
+#
+# Tags (same vocabulary as powerbi/tableau-assessment):
+#   usage available AND views == 0                → "retire"
+#   unhandled >= 1                                → "needs-gap-scout"
+#   score >= 20 and (manual + unhandled) == 0     → "migrate-first"
+#   score >= 10                                   → "easy-win"
+#   else                                          → "moderate"
+#
+# Usage:  ruby scripts/build-shortlist.rb --out /tmp/qs-assessment-<acct>
+# Reads:  <out>/inventory.json, <out>/complexity.json, [<out>/usage.json]
+# Writes: <out>/shortlist.json
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new { |p| p.on('--out DIR') { |v| opts[:out] = v } }.parse!
+abort('--out required') unless opts[:out]
+
+complexity = JSON.parse(File.read(File.join(opts[:out], 'complexity.json')))
+
+usage_path = File.join(opts[:out], 'usage.json')
+usage = File.exist?(usage_path) ? JSON.parse(File.read(usage_path)) : nil
+usage_available = !usage.nil? && usage['available'] != false
+
+# usage.json (when supplied) shape: { "available": true,
+#   "by_analysis": { "<analysisId>": { "views": N, "users": M } } }
+usage_by_id = {}
+usage_by_id = usage['by_analysis'] if usage_available && usage['by_analysis']
+
+rows = []
+complexity.each do |aid, r|
+  u = usage_by_id[aid]
+  views = u ? u['views'].to_i : nil
+  users = u ? u['users'].to_i : nil
+
+  cost = r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3 + r['n_hint'].to_i * 1
+
+  value =
+    if usage_available && views
+      views * Math.sqrt([users || 1, 1].max).to_f
+    else
+      # complexity-only proxy: bigger / richer analyses rank first
+      10.0 * (r['sheets'].to_i + r['visuals'].to_i / 4.0)
+    end
+  score = value / (1 + cost).to_f
+
+  tag =
+    if usage_available && views && views.zero?
+      'retire'
+    elsif r['n_unhandled'].to_i >= 1
+      'needs-gap-scout'
+    elsif score >= 20 && (r['n_manual'].to_i + r['n_unhandled'].to_i).zero?
+      'migrate-first'
+    elsif score >= 10
+      'easy-win'
+    else
+      'moderate'
+    end
+
+  rows << {
+    'name'        => r['name'],
+    'id'          => aid,
+    'sheets'      => r['sheets'],
+    'visuals'     => r['visuals'],
+    'views'       => views,
+    'users'       => users,
+    'auto'        => r['n_auto'],
+    'hint'        => r['n_hint'],
+    'manual'      => r['n_manual'],
+    'unhandled'   => r['n_unhandled'],
+    'calc_buckets' => r['calc_buckets'],
+    'dataset_source_types' => r['dataset_source_types'],
+    'value'       => value.round(1),
+    'cost'        => cost,
+    'score'       => score.round(2),
+    'tag'         => tag
+  }
+end
+
+rows.sort_by! { |r| -r['score'] }
+
+result = {
+  'usage_available' => usage_available,
+  'value_basis'     => usage_available ? 'usage (views × √users)' : 'complexity-only proxy (sheets + visuals/4)',
+  'analyses'        => rows
+}
+
+File.write(File.join(opts[:out], 'shortlist.json'), JSON.pretty_generate(result))
+puts "wrote shortlist.json (#{rows.size} analyses, value_basis=#{result['value_basis']})"
+puts
+printf "%-40s %6s %5s %5s %7s %s\n", 'Analysis', 'views', 'manl', 'unhd', 'score', 'tag'
+rows.each do |r|
+  printf "%-40s %6s %5d %5d %7.2f %s\n",
+    (r['name'] || '')[0, 39], (r['views'] || '-').to_s, r['manual'], r['unhandled'], r['score'], r['tag']
+end

--- a/quicksight-migration-skills/quicksight-assessment/scripts/dup-dashboards.py
+++ b/quicksight-migration-skills/quicksight-assessment/scripts/dup-dashboards.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""dup-dashboards.py — detect DUPLICATE / consolidatable dashboards in a BI estate.
+
+Shared across the *-assessment skills (ThoughtSpot, Power BI, QuickSight, Qlik,
+Looker, Cognos, MicroStrategy). Tableau already has its own deeper
+`consolidation-candidates.rb`; this is the lighter, tool-neutral detector the
+other assessments call so EVERY readout flags "these N dashboards look like the
+same report rebuilt — migrate once, not N times."
+
+Input: a normalized dashboard list (the adapter in each scan script maps that
+tool's inventory into this shape — only `id` + `name` are required; the rest are
+used when present):
+
+    [{ "id": "...", "name": "Q1 Sales (copy)",
+       "sources": ["DB.SALES.ORDERS", ...],   # datasets / models / warehouse tables
+       "fields":  ["Region", "Net Revenue", ...],
+       "viz":     ["bar", "line", "kpi", ...], # chart-kind tokens
+       "usage":   1234 }, ... ]               # optional view count (a tiebreaker)
+
+Output (JSON): groups of likely-duplicate dashboards, each with a recommendation
+(`consolidate` | `review`), the similarity drivers, and the conversions a merge
+would avoid. Pure — no network. Also renders an HTML fragment + a Markdown block
+for the assessment readout.
+
+    python3 dup-dashboards.py --in dashboards.json --out dup-groups.json \
+        [--html dup.html] [--md]            # --md prints a Markdown block to stdout
+
+The grouping is intentionally CONSERVATIVE (it pools only dashboards that share a
+data source or a near-identical name, then needs real field/structure overlap to
+emit) so the readout flags genuine rebuilds, not coincidental name collisions.
+"""
+import argparse, json, re, sys
+from itertools import combinations
+
+# Tokens that mark a NAME VARIANT rather than a different report — stripped before
+# comparing names so "Sales", "Sales (copy)", "Sales v2", "Sales 2023 FINAL" pool.
+_VARIANT = set("""copy copies clone dup duplicate v1 v2 v3 v4 v5 v6 version final
+draft wip test temp old new prod dev uat backup bak archive archived
+q1 q2 q3 q4 h1 h2 fy ytd mtd qtd jan feb mar apr may jun jul aug sep oct nov dec
+january february march april june july august september october november december
+2018 2019 2020 2021 2022 2023 2024 2025 2026 monthly weekly daily quarterly annual
+""".split())
+
+# Emit a group only when at least one pair scores >= this. Below it the dashboards
+# are too different to call a duplicate.
+EMIT_FLOOR = 0.45
+# A group is "consolidate" (vs the softer "review") when its WEAKEST internal pair
+# still shares most fields AND a data source — i.e. genuinely the same report.
+CONSOLIDATE_FIELD = 0.70
+CONSOLIDATE_SOURCE = 0.50
+REVIEW_SCORE = 0.55
+
+
+def _norm_name_tokens(name):
+    toks = re.split(r"[^a-z0-9]+", str(name or "").lower())
+    core = [t for t in toks if t and t not in _VARIANT and not t.isdigit()]
+    return set(core or [t for t in toks if t])      # fall back if name was ALL variant tokens
+
+
+def _norm_set(xs):
+    out = set()
+    for x in xs or []:
+        k = re.sub(r"[^a-z0-9]+", "", str(x).lower())
+        if k:
+            out.add(k)
+    return out
+
+
+def _jaccard(a, b):
+    if not a and not b:
+        return 0.0
+    if not a or not b:
+        return 0.0
+    return len(a & b) / float(len(a | b))
+
+
+def _prep(dashboards):
+    prepped = []
+    for d in dashboards:
+        prepped.append({
+            "id": d.get("id"),
+            "name": d.get("name") or d.get("id") or "(unnamed)",
+            "name_toks": _norm_name_tokens(d.get("name")),
+            "sources": _norm_set(d.get("sources")),
+            "fields": _norm_set(d.get("fields")),
+            "viz": _norm_set(d.get("viz")),
+            "usage": d.get("usage"),
+        })
+    return prepped
+
+
+def _pair_score(a, b):
+    """Weighted similarity in [0,1]. Weights shift onto whatever signals are
+    actually present so a tool that exposes only names+sources still scores."""
+    name = _jaccard(a["name_toks"], b["name_toks"])
+    have_fields = bool(a["fields"] and b["fields"])
+    have_viz = bool(a["viz"] and b["viz"])
+    have_src = bool(a["sources"] and b["sources"])
+    field = _jaccard(a["fields"], b["fields"]) if have_fields else 0.0
+    viz = _jaccard(a["viz"], b["viz"]) if have_viz else 0.0
+    src = _jaccard(a["sources"], b["sources"]) if have_src else 0.0
+
+    w = {"name": 0.30, "field": 0.40 if have_fields else 0.0,
+         "viz": 0.10 if have_viz else 0.0, "src": 0.20 if have_src else 0.0}
+    tot = sum(w.values()) or 1.0
+    w = {k: v / tot for k, v in w.items()}                  # renormalize onto present signals
+    score = w["name"] * name + w["field"] * field + w["viz"] * viz + w["src"] * src
+    return round(score, 3), {"name_similarity": round(name, 2), "field_overlap": round(field, 2),
+                             "viz_overlap": round(viz, 2), "source_overlap": round(src, 2)}
+
+
+def detect(dashboards):
+    """Return {groups:[...], summary:{...}}. A group = a connected component of
+    dashboards linked by a pair scoring >= EMIT_FLOOR, where the pair also shares
+    a data source OR a near-identical name (the pooling guard against coincidental
+    field overlap across unrelated reports)."""
+    items = _prep(dashboards)
+    n = len(items)
+    idx = {i: i for i in range(n)}                          # union-find
+
+    def find(x):
+        while idx[x] != x:
+            idx[x] = idx[idx[x]]
+            x = idx[x]
+        return x
+
+    def union(x, y):
+        idx[find(x)] = find(y)
+
+    pair_ev = {}
+    for i, j in combinations(range(n), 2):
+        a, b = items[i], items[j]
+        shares_source = bool(a["sources"] & b["sources"])
+        name_close = _jaccard(a["name_toks"], b["name_toks"]) >= 0.6
+        if not (shares_source or name_close):               # pooling guard
+            continue
+        score, drivers = _pair_score(a, b)
+        if score >= EMIT_FLOOR:
+            pair_ev[(i, j)] = {"score": score, **drivers}
+            union(i, j)
+
+    comps = {}
+    for i in range(n):
+        comps.setdefault(find(i), []).append(i)
+
+    groups = []
+    for members in comps.values():
+        if len(members) < 2:
+            continue
+        ev = [pair_ev[(i, j)] for i, j in combinations(sorted(members), 2) if (i, j) in pair_ev]
+        if not ev:
+            continue
+        min_field = min(e["field_overlap"] for e in ev)
+        min_source = min(e["source_overlap"] for e in ev)
+        max_score = max(e["score"] for e in ev)
+        if min_field >= CONSOLIDATE_FIELD and min_source >= CONSOLIDATE_SOURCE:
+            rec = "consolidate"
+        elif max_score >= REVIEW_SCORE:
+            rec = "review"
+        else:
+            rec = "review"
+        mem = sorted((items[m] for m in members),
+                     key=lambda x: -(x["usage"] or 0))       # most-used first = the survivor
+        groups.append({
+            "recommendation": rec,
+            "members": [{"id": m["id"], "name": m["name"], "usage": m["usage"]} for m in mem],
+            "size": len(members),
+            "drivers": {
+                "max_pair_score": max_score,
+                "min_field_overlap": round(min_field, 2),
+                "min_source_overlap": round(min_source, 2),
+                "shared_sources": sorted(set.intersection(*[items[m]["sources"] for m in members]) or set()),
+            },
+            "conversions_avoided": len(members) - 1,          # build 1, retire the rest
+        })
+
+    groups.sort(key=lambda g: (g["recommendation"] != "consolidate", -g["size"], -g["drivers"]["max_pair_score"]))
+    return {
+        "groups": groups,
+        "summary": {
+            "dashboards_scanned": n,
+            "duplicate_groups": len(groups),
+            "dashboards_in_groups": sum(g["size"] for g in groups),
+            "conversions_avoided": sum(g["conversions_avoided"] for g in groups),
+        },
+    }
+
+
+def render_md(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return "### Duplicate / consolidation candidates\n\n_None found — no two dashboards overlap enough to merge._\n"
+    out = ["### Duplicate / consolidation candidates", "",
+           f"**{s['duplicate_groups']} group(s)** spanning **{s['dashboards_in_groups']}** dashboards — "
+           f"consolidating would avoid **{s['conversions_avoided']}** redundant migration(s).", ""]
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        out.append(f"**Group {i} — {grp['recommendation'].upper()}** "
+                   f"(field overlap ≥{int(d['min_field_overlap']*100)}%, "
+                   f"shared sources: {', '.join(d['shared_sources']) or '—'})")
+        for m in grp["members"]:
+            u = f" · {m['usage']} views" if m.get("usage") is not None else ""
+            out.append(f"- {m['name']}  `{m['id']}`{u}")
+        out.append("")
+    return "\n".join(out)
+
+
+def render_html(result):
+    g = result["groups"]
+    s = result["summary"]
+    if not g:
+        return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+                '<p>None found — no two dashboards overlap enough to merge.</p></section>')
+    rows = []
+    for i, grp in enumerate(g, 1):
+        d = grp["drivers"]
+        badge = "#b91c1c" if grp["recommendation"] == "consolidate" else "#b45309"
+        def _li(m):
+            usage = "" if m.get("usage") is None else f" · {m['usage']} views"
+            return f'<li>{_esc(m["name"])} <code>{_esc(str(m["id"]))}</code>{usage}</li>'
+        mem = "".join(_li(m) for m in grp["members"])
+        rows.append(
+            f'<div class="dup-group" style="margin:.5em 0;padding:.6em .8em;border-left:4px solid {badge}">'
+            f'<strong>Group {i} — <span style="color:{badge}">{grp["recommendation"].upper()}</span></strong> '
+            f'<span style="color:#555">(field overlap ≥{int(d["min_field_overlap"]*100)}%, '
+            f'shared sources: {_esc(", ".join(d["shared_sources"]) or "—")}, '
+            f'avoids {grp["conversions_avoided"]} migration(s))</span>'
+            f'<ul style="margin:.3em 0 0 1.2em">{mem}</ul></div>')
+    return ('<section class="dup-dashboards"><h2>Duplicate / consolidation candidates</h2>'
+            f'<p>{s["duplicate_groups"]} group(s) across {s["dashboards_in_groups"]} dashboards — '
+            f'consolidating avoids {s["conversions_avoided"]} redundant migration(s).</p>'
+            + "".join(rows) + "</section>")
+
+
+def _esc(t):
+    return (str(t).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", required=True, help="normalized dashboard list JSON (or '-' for stdin)")
+    ap.add_argument("--out", help="write the groups JSON here (default stdout)")
+    ap.add_argument("--html", help="also write an HTML fragment here")
+    ap.add_argument("--md", action="store_true", help="print a Markdown block to stderr")
+    ap.add_argument("--md-stdout", dest="md_stdout", action="store_true",
+                    help="print ONLY the Markdown block to stdout (for renderers that embed it)")
+    ap.add_argument("--html-stdout", dest="html_stdout", action="store_true",
+                    help="print ONLY the HTML fragment to stdout (for renderers that embed it)")
+    ap.add_argument("--render", action="store_true",
+                    help="--in is an already-detected result (a {groups,summary} dict, "
+                         "e.g. inventory.json's duplicate_dashboards); render it instead of re-detecting")
+    a = ap.parse_args()
+    raw = sys.stdin.read() if a.inp == "-" else open(a.inp).read()
+    parsed = json.loads(raw)
+    if a.render:
+        # Accept either the bare result or a wrapper carrying duplicate_dashboards.
+        result = parsed.get("duplicate_dashboards", parsed) if isinstance(parsed, dict) else {"groups": [], "summary": {}}
+    else:
+        dashboards = parsed
+        if isinstance(dashboards, dict):                     # tolerate {"dashboards":[...]} or {"liveboards":[...]}
+            dashboards = (dashboards.get("dashboards") or dashboards.get("liveboards")
+                          or dashboards.get("items") or [])
+        result = detect(dashboards)
+    if a.md_stdout:
+        # Embed-only mode: emit just the Markdown block on stdout, nothing else.
+        sys.stdout.write(render_md(result))
+        return
+    if a.html_stdout:
+        # Embed-only mode: emit just the HTML fragment on stdout, nothing else.
+        sys.stdout.write(render_html(result))
+        return
+    out_json = json.dumps(result, indent=2)
+    if a.out:
+        open(a.out, "w").write(out_json)
+    else:
+        print(out_json)
+    if a.html:
+        open(a.html, "w").write(render_html(result))
+    if a.md:
+        sys.stderr.write(render_md(result) + "\n")
+    s = result.get("summary") or {}
+    sys.stderr.write(f"[dup-dashboards] {s.get('duplicate_groups', 0)} group(s), "
+                     f"{s.get('conversions_avoided', 0)} conversion(s) avoidable\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/quicksight-migration-skills/quicksight-assessment/scripts/migration-plan.rb
+++ b/quicksight-migration-skills/quicksight-assessment/scripts/migration-plan.rb
@@ -1,0 +1,146 @@
+#!/usr/bin/env ruby
+# Phase 6 (QuickSight): compose migration-plan.json — the input contract the
+# assessment hands to the `quicksight-to-sigma` conversion skill.
+#
+# Adapted from powerbi-assessment/scripts/migration-plan.rb. Differences:
+#   - per-ANALYSIS (not report); the analysis inherits its datasets' source
+#     types + data-prep + RLS via dataset_ids.
+#   - DM clusters are formed on SHARED DATASET — analyses that reference the same
+#     QuickSight dataset share a Sigma data model by construction (the clean,
+#     reliable signal, like Power BI's shared-model clustering). Analyses with
+#     overlapping dataset sets are merged into one cluster.
+#
+# recommended_path values:
+#   "quicksight-to-sigma"            → analysis ready for conversion
+#   "quicksight-to-sigma-with-scout" → has window calcs / exotic visuals / free-form; needs a design decision first
+#   "retire"                         → zero views (only when usage supplied); recommend not migrating
+#   "blocked"                        → > 5 manual/unhandled features; manual rework first
+#
+# Usage:  ruby scripts/migration-plan.rb --out /tmp/qs-assessment-<acct>
+# Reads:  <out>/shortlist.json, <out>/complexity.json, <out>/inventory.json
+# Writes: <out>/migration-plan.json
+
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new { |p| p.on('--out DIR') { |v| opts[:out] = v } }.parse!
+abort('--out required') unless opts[:out]
+
+shortlist  = JSON.parse(File.read(File.join(opts[:out], 'shortlist.json')))
+complexity = JSON.parse(File.read(File.join(opts[:out], 'complexity.json')))
+inventory  = JSON.parse(File.read(File.join(opts[:out], 'inventory.json')))
+
+datasets_by_id   = (inventory['datasets'] || []).each_with_object({}) { |d, h| h[d['id']] = d }
+analysis_dsids   = (inventory['analyses'] || []).each_with_object({}) { |a, h| h[a['id']] = (a['dataset_ids'] || []) }
+analyses = shortlist['analyses'] || []
+
+analysis_entries = analyses.map do |r|
+  aid = r['id']
+  cx = complexity[aid] || {}
+  manual = cx['n_manual'].to_i
+  unhandled = cx['n_unhandled'].to_i
+  ds_ids = analysis_dsids[aid] || []
+  src_types = ds_ids.flat_map { |id| (datasets_by_id[id] || {})['physical_kinds'] || [] }.uniq.sort
+
+  recommended_path =
+    case r['tag']
+    when 'retire'          then 'retire'
+    when 'needs-gap-scout' then 'quicksight-to-sigma-with-scout'
+    else
+      (manual + unhandled) > 5 ? 'blocked' : 'quicksight-to-sigma'
+    end
+
+  blockers = []
+  blockers << "#{unhandled} unhandled feature(s) (window calc / exotic visual / free-form layout / FilterGroups)" if unhandled.positive?
+  blockers << "#{manual} restructuring/join/transform/RLS/param feature(s)" if manual.positive?
+  blockers << 'no views (retire)' if r['tag'] == 'retire'
+
+  {
+    'analysisId'        => aid,
+    'name'              => r['name'],
+    'dataset_ids'       => ds_ids,
+    'dataset_source_types' => src_types,
+    'recommended_path'  => recommended_path,
+    'priority_tier'     => r['tag'],
+    'score'             => r['score'],
+    'views'             => r['views'],
+    'calc_buckets'      => r['calc_buckets'],
+    'blockers'          => blockers
+  }
+end
+
+# --- DM clustering: shared dataset ------------------------------------------
+# Analyses referencing the same dataset MUST share a Sigma data model. Union
+# analyses by overlapping dataset sets into clusters.
+clusterable = analysis_entries.select do |r|
+  %w[quicksight-to-sigma quicksight-to-sigma-with-scout].include?(r['recommended_path'])
+end
+
+# union-find over dataset overlap
+parent = {}
+find = lambda { |x| parent[x] = (parent[x] == x ? x : find.call(parent[x])); parent[x] }
+clusterable.each { |r| parent[r['analysisId']] = r['analysisId'] }
+by_dataset = Hash.new { |h, k| h[k] = [] }
+clusterable.each { |r| (r['dataset_ids'].empty? ? ["no-ds-#{r['analysisId']}"] : r['dataset_ids']).each { |d| by_dataset[d] << r['analysisId'] } }
+by_dataset.each_value do |aids|
+  aids.each_cons(2) { |a, b| parent[find.call(a)] = find.call(b) }
+end
+
+groups = Hash.new { |h, k| h[k] = [] }
+clusterable.each { |r| groups[find.call(r['analysisId'])] << r }
+
+clusters = groups.values.each_with_index.map do |members, i|
+  ds_ids = members.flat_map { |m| m['dataset_ids'] }.uniq.sort
+  ds_names = ds_ids.map { |id| (datasets_by_id[id] || {})['name'] }.compact
+  src = members.flat_map { |m| m['dataset_source_types'] }.uniq.sort
+  label = (ds_names.first || members.first['name'] || 'misc').downcase.gsub(/[^a-z0-9]+/, '-')[0, 24]
+  cluster_id = "cluster-#{(i + 1).to_s.rjust(2, '0')}-#{label}"
+  members.each { |m| m['cluster_id'] = cluster_id }
+  {
+    'id'                => cluster_id,
+    'dataset_ids'       => ds_ids,
+    'dataset_names'     => ds_names,
+    'analysisIds'       => members.map { |m| m['analysisId'] },
+    'analysis_names'    => members.map { |m| m['name'] },
+    'shared_source_types' => src,
+    'cluster_size'      => members.size
+  }
+end
+
+by_path = analysis_entries.group_by { |r| r['recommended_path'] }
+suggested_batch = analysis_entries
+  .select { |r| r['recommended_path'] == 'quicksight-to-sigma' }
+  .sort_by { |r| -(r['score'].to_f) }
+  .first(8)
+  .map { |r| { 'analysisId' => r['analysisId'], 'name' => r['name'], 'cluster_id' => r['cluster_id'] } }
+
+result = {
+  'analyses'    => analysis_entries,
+  'dm_clusters' => clusters,
+  'summary' => {
+    'analyses_total'      => analysis_entries.size,
+    'analyses_ready'      => (by_path['quicksight-to-sigma']            || []).size,
+    'analyses_need_scout' => (by_path['quicksight-to-sigma-with-scout'] || []).size,
+    'analyses_blocked'    => (by_path['blocked']                        || []).size,
+    'analyses_retire'     => (by_path['retire']                         || []).size,
+    'cluster_count'       => clusters.size,
+    'usage_available'     => shortlist['usage_available'] == true,
+    'suggested_batch'     => suggested_batch
+  }
+}
+
+File.write(File.join(opts[:out], 'migration-plan.json'), JSON.pretty_generate(result))
+s = result['summary']
+puts "wrote migration-plan.json"
+puts "analyses total: #{s['analyses_total']}"
+puts "  ready for quicksight-to-sigma: #{s['analyses_ready']}"
+puts "  need gap-scout:                #{s['analyses_need_scout']}"
+puts "  blocked:                       #{s['analyses_blocked']}"
+puts "  retire:                        #{s['analyses_retire']}"
+puts "DM clusters: #{s['cluster_count']}"
+clusters.each { |c| puts "  #{c['id']}: #{c['cluster_size']} analysis(es), datasets=#{c['dataset_names'].join(', ')}" }
+puts
+puts "suggested first batch (top #{suggested_batch.size} by score):"
+suggested_batch.each_with_index { |r, i| puts "  #{i + 1}. #{r['name']} (cluster: #{r['cluster_id'] || '-'})" }

--- a/quicksight-migration-skills/quicksight-assessment/scripts/quicksight-inventory.py
+++ b/quicksight-migration-skills/quicksight-assessment/scripts/quicksight-inventory.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Phase 1-3 inventory extractor for the quicksight-assessment skill.
+
+READ-ONLY. Surveys an Amazon QuickSight account (what the configured AWS
+credentials can reach) and writes raw JSON the Ruby renderers consume:
+
+  <out>/inventory.json          — environment + per-analysis + per-dataset metadata
+  <out>/raw-defs/<id>.json      — describe-analysis-definition response per analysis
+  <out>/raw-datasets/<id>.json  — describe-data-set response per referenced dataset
+
+Auth is whatever the AWS CLI is already configured with: a named --profile, SSO
+(`aws sso login`), or gimme-aws-creds (Okta orgs). We shell out to `aws
+quicksight ...` via subprocess — NO boto3 dependency.
+
+Enterprise edition is REQUIRED: the describe-*-definition / describe-data-set
+calls are Enterprise-only. On a Standard account they 4xx; we record that and
+degrade gracefully (the analysis still inventories from list-* metadata, but
+without visual/calc-field complexity).
+
+QuickSight's identity region is often us-east-1 even when the data lives
+elsewhere — pass --region accordingly.
+
+Usage:
+  python3 scripts/quicksight-inventory.py --account-id <ID> --region us-east-1 \
+      --profile <p> --out /tmp/qs-assessment-<acct>
+  ... [--limit-analyses N]  [--dashboards-too]
+"""
+import argparse, json, os, re, subprocess, sys, time
+
+
+def aws(args, acct, region, profile):
+    """Run an aws quicksight subcommand; return (ok, parsed_json_or_errtext)."""
+    cmd = ["aws", "quicksight"] + args + [
+        "--aws-account-id", acct, "--region", region, "--output", "json"]
+    if profile:
+        cmd += ["--profile", profile]
+    p = subprocess.run(cmd, capture_output=True, text=True)
+    if p.returncode != 0:
+        return False, (p.stderr.strip() or "aws call failed: " + " ".join(args[:2]))
+    try:
+        return True, json.loads(p.stdout)
+    except Exception:
+        return True, {}
+
+
+def arn_id(arn):
+    return arn.rsplit("/", 1)[-1] if arn else None
+
+
+# ---------------------------------------------------------------------------
+# Complexity classification
+# ---------------------------------------------------------------------------
+
+# Visuals the workbook builder reproduces vs. not. From refs/migration-test-slate.md.
+VISUAL_BUILT = {"KPIVisual", "BarChartVisual", "LineChartVisual", "PieChartVisual"}
+VISUAL_MID = {  # in the catalog but not built — manual rebuild
+    "ComboChartVisual", "TableVisual", "PivotTableVisual", "ScatterPlotVisual",
+    "HeatMapVisual", "GaugeChartVisual", "FunnelChartVisual", "TreeMapVisual",
+    "HistogramVisual", "BoxPlotVisual", "WaterfallVisual", "RadarChartVisual",
+}
+VISUAL_UNHANDLED = {  # no Sigma equivalent / best-effort only
+    "SankeyDiagramVisual", "WordCloudVisual", "GeospatialMapVisual",
+    "FilledMapVisual", "LayerMapVisual", "InsightVisual",
+    "CustomContentVisual", "PluginVisual",
+}
+
+# QuickSight calc-field functions that have no clean Sigma formula equivalent —
+# the converter degrades these to a /* TODO */ placeholder. From the test slate.
+WINDOW_FUNCS = [
+    "sumOver", "avgOver", "countOver", "maxOver", "minOver", "runningSum",
+    "runningAvg", "runningCount", "runningMax", "runningMin", "rank",
+    "denseRank", "percentOfTotal", "percentileOver", "periodOverPeriodDifference",
+    "periodOverPeriodPercentDifference", "periodToDateSum", "periodToDateAvg",
+    "lag", "lead", "windowSum", "windowAvg", "windowCount", "windowMax",
+    "windowMin", "firstValue", "lastValue", "difference",
+]
+WINDOW_RE = re.compile(r"\b(" + "|".join(WINDOW_FUNCS) + r")\s*\(")
+FUNC_RE = re.compile(r"\b([a-zA-Z][a-zA-Z0-9]*)\s*\(")
+
+
+def classify_calc(expr):
+    """Return 'a' (mechanical) | 'b' (restructure) | 'c' (no-equiv window/table-calc)."""
+    if not expr:
+        return "a"
+    if WINDOW_RE.search(expr):
+        return "c"
+    # ifelse/switch nesting or aggregation-of-aggregation hints at restructuring;
+    # otherwise a direct rewrite.
+    funcs = set(f.lower() for f in FUNC_RE.findall(expr))
+    if {"percentiledisc", "percentilecont", "medianif", "distinctcountif"} & funcs:
+        return "b"
+    return "a"
+
+
+def analyze_definition(defn):
+    """Walk an AnalysisDefinition: visual-kind histogram, calc-field buckets, params,
+    sheet/layout shape. Returns a complexity-signal dict."""
+    out = {
+        "sheet_count": 0,
+        "visual_count": 0,
+        "visual_kinds": {},
+        "visuals_built": 0,
+        "visuals_mid": 0,
+        "visuals_unhandled": 0,
+        "calc_field_count": 0,
+        "calc_buckets": {"a": 0, "b": 0, "c": 0},
+        "window_calc_count": 0,
+        "parameter_count": 0,
+        "filter_group_count": 0,
+        "free_form_sheets": 0,
+        "section_based_sheets": 0,
+        "dataset_identifiers": [],
+    }
+    for sh in defn.get("Sheets", []):
+        out["sheet_count"] += 1
+        for v in sh.get("Visuals", []):
+            for vtype in v.keys():
+                out["visual_count"] += 1
+                out["visual_kinds"][vtype] = out["visual_kinds"].get(vtype, 0) + 1
+                if vtype in VISUAL_BUILT:
+                    out["visuals_built"] += 1
+                elif vtype in VISUAL_UNHANDLED:
+                    out["visuals_unhandled"] += 1
+                elif vtype in VISUAL_MID:
+                    out["visuals_mid"] += 1
+                else:
+                    out["visuals_mid"] += 1  # EmptyVisual/unknown → treat as mid
+        # layout shape per sheet
+        for lay in sh.get("Layouts", []):
+            cfg = lay.get("Configuration", {}) or {}
+            if "FreeFormLayout" in cfg:
+                out["free_form_sheets"] += 1
+            if "SectionBasedLayout" in cfg:
+                out["section_based_sheets"] += 1
+    for c in defn.get("CalculatedFields", []):
+        out["calc_field_count"] += 1
+        bucket = classify_calc(c.get("Expression"))
+        out["calc_buckets"][bucket] += 1
+        if bucket == "c":
+            out["window_calc_count"] += 1
+    out["parameter_count"] = len(defn.get("ParameterDeclarations", []))
+    out["filter_group_count"] = len(defn.get("FilterGroups", []))
+    out["dataset_identifiers"] = [
+        d.get("Identifier") for d in defn.get("DataSetIdentifierDeclarations", [])]
+    return out
+
+
+def analyze_dataset(dso):
+    """Source type(s), import mode, RLS/CLS presence, custom-sql usage."""
+    out = {
+        "import_mode": dso.get("ImportMode"),
+        "physical_kinds": [],
+        "has_custom_sql": False,
+        "has_joins": False,
+        "transform_count": 0,
+        "rls_enabled": bool(dso.get("RowLevelPermissionDataSet")),
+        "cls_enabled": bool(dso.get("ColumnLevelPermissionRules")),
+        "column_count": len(dso.get("OutputColumns", []) or []),
+    }
+    for ptv in (dso.get("PhysicalTableMap") or {}).values():
+        for kind in ptv.keys():
+            out["physical_kinds"].append(kind)
+            if kind == "CustomSql":
+                out["has_custom_sql"] = True
+    for ltv in (dso.get("LogicalTableMap") or {}).values():
+        src = ltv.get("Source", {}) or {}
+        if "JoinInstruction" in src:
+            out["has_joins"] = True
+        out["transform_count"] += len(ltv.get("DataTransforms", []) or [])
+    out["physical_kinds"] = sorted(set(out["physical_kinds"]))
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--account-id", required=True)
+    ap.add_argument("--region", default="us-east-1",
+                    help="QuickSight identity region (often us-east-1)")
+    ap.add_argument("--profile")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--limit-analyses", type=int, default=0, help="cap analyses scanned (0=all)")
+    ap.add_argument("--dashboards-too", action="store_true",
+                    help="also list dashboards (counts only; conversion targets analyses)")
+    args = ap.parse_args()
+
+    acct, region, profile = args.account_id, args.region, args.profile
+    out = os.path.expanduser(args.out)
+    os.makedirs(os.path.join(out, "raw-defs"), exist_ok=True)
+    os.makedirs(os.path.join(out, "raw-datasets"), exist_ok=True)
+
+    inv = {
+        "account": {
+            "account_id": acct, "region": region,
+            "generated_at": time.strftime("%Y-%m-%d"),
+            "edition": None, "enterprise": None,
+        },
+        "analyses": [],
+        "datasets": [],
+        "data_sources": [],
+        "environment_overview": {
+            "analyses": 0, "dashboards": 0, "datasets": 0, "data_sources": 0,
+        },
+    }
+
+    # --- list analyses ------------------------------------------------------
+    ok, res = aws(["list-analyses"], acct, region, profile)
+    if not ok:
+        print(f"[list-analyses] FAILED: {res}", file=sys.stderr)
+        sys.exit(3)
+    analyses = [a for a in res.get("AnalysisSummaryList", [])
+                if a.get("Status") != "DELETED"]
+    inv["environment_overview"]["analyses"] = len(analyses)
+
+    # --- list datasets (catalog; describe per referenced dataset later) -----
+    ok, res = aws(["list-data-sets"], acct, region, profile)
+    ds_summaries = res.get("DataSetSummaries", []) if ok else []
+    inv["environment_overview"]["datasets"] = len(ds_summaries)
+
+    ok, res = aws(["list-data-sources"], acct, region, profile)
+    src_summaries = res.get("DataSources", []) if ok else []
+    inv["environment_overview"]["data_sources"] = len(src_summaries)
+    for s in src_summaries:
+        inv["data_sources"].append({
+            "id": arn_id(s.get("Arn")), "name": s.get("Name"), "type": s.get("Type")})
+
+    if args.dashboards_too:
+        ok, res = aws(["list-dashboards"], acct, region, profile)
+        inv["environment_overview"]["dashboards"] = len(res.get("DashboardSummaryList", [])) if ok else 0
+
+    # --- describe each analysis definition (Enterprise-only) ----------------
+    seen_datasets = {}
+    edition_flagged = False
+    scanned = 0
+    for a in analyses:
+        if args.limit_analyses and scanned >= args.limit_analyses:
+            break
+        aid, aname = a.get("AnalysisId"), a.get("Name")
+        print(f"[analysis] {aname}", file=sys.stderr)
+        entry = {"id": aid, "name": aname,
+                 "last_updated": a.get("LastUpdatedTime")}
+        ok, d = aws(["describe-analysis-definition", "--analysis-id", aid],
+                    acct, region, profile)
+        if not ok:
+            entry["def_error"] = str(d)[:200]
+            # First definition failure usually means Standard edition / no perms.
+            if not edition_flagged and re.search(
+                    r"Standard|Enterprise|not supported|AccessDenied", str(d), re.I):
+                inv["account"]["enterprise"] = False
+                inv["account"]["edition"] = "Standard? (definition API rejected)"
+                edition_flagged = True
+            inv["analyses"].append(entry)
+            scanned += 1
+            continue
+        inv["account"]["enterprise"] = True
+        inv["account"]["edition"] = "Enterprise"
+        defn = d.get("Definition", {}) or {}
+        with open(os.path.join(out, "raw-defs", f"{aid}.json"), "w") as fh:
+            json.dump(d, fh, indent=2)
+        entry.update(analyze_definition(defn))
+
+        # describe each referenced dataset once
+        for decl in defn.get("DataSetIdentifierDeclarations", []):
+            ds_id = arn_id(decl.get("DataSetArn"))
+            if not ds_id or ds_id in seen_datasets:
+                continue
+            ok2, ds = aws(["describe-data-set", "--data-set-id", ds_id],
+                          acct, region, profile)
+            if not ok2:
+                seen_datasets[ds_id] = {"id": ds_id, "ds_error": str(ds)[:160]}
+                continue
+            dso = ds.get("DataSet", {}) or {}
+            with open(os.path.join(out, "raw-datasets", f"{ds_id}.json"), "w") as fh:
+                json.dump(ds, fh, indent=2)
+            seen_datasets[ds_id] = dict(
+                {"id": ds_id, "name": dso.get("Name")}, **analyze_dataset(dso))
+        entry["dataset_ids"] = [arn_id(decl.get("DataSetArn"))
+                                for decl in defn.get("DataSetIdentifierDeclarations", [])]
+        inv["analyses"].append(entry)
+        scanned += 1
+
+    inv["datasets"] = list(seen_datasets.values())
+
+    # --- duplicate / consolidation candidates -------------------------------
+    # Flag analyses that are the same report rebuilt (shared dataset + overlapping
+    # visual set + near-identical name) so the estate migrates ONCE instead of N
+    # times. Shared, tool-neutral detector (the hyphenated filename blocks a normal
+    # import). Only signals actually captured by the inventory are passed —
+    # QuickSight inventory has dataset references + visual kinds, but no per-analysis
+    # column refs and no view counts on this surface, so `fields` reuses the
+    # source/viz proxy and `usage` is omitted.
+    import importlib.util
+    _dd_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "dup-dashboards.py")
+    _spec = importlib.util.spec_from_file_location("dup_dashboards", _dd_path)
+    _dd = importlib.util.module_from_spec(_spec)
+    _spec.loader.exec_module(_dd)
+
+    def _ds_name(ds_id):
+        return (seen_datasets.get(ds_id) or {}).get("name") or ds_id
+
+    normalized = []
+    for a in inv["analyses"]:
+        sources = [_ds_name(i) for i in (a.get("dataset_ids") or []) if i]
+        viz = list((a.get("visual_kinds") or {}).keys())
+        normalized.append({
+            "id": a["id"], "name": a["name"],
+            "sources": sources,
+            "viz": viz,
+            "fields": sources + viz,
+        })
+    inv["duplicate_dashboards"] = _dd.detect(normalized)
+    with open(os.path.join(out, "dup-normalized.json"), "w") as fh:
+        json.dump(normalized, fh, indent=2)
+
+    with open(os.path.join(out, "inventory.json"), "w") as fh:
+        json.dump(inv, fh, indent=2)
+
+    eo = inv["environment_overview"]
+    print(f"\nWROTE {os.path.join(out, 'inventory.json')}", file=sys.stderr)
+    print(f"  analyses={eo['analyses']} dashboards={eo['dashboards']} "
+          f"datasets={eo['datasets']} data_sources={eo['data_sources']}", file=sys.stderr)
+    print(f"  edition={inv['account']['edition']}  analyses scanned for definition: {scanned}",
+          file=sys.stderr)
+    _ds = inv["duplicate_dashboards"]["summary"]
+    print(f"  duplicate/consolidation: {_ds['duplicate_groups']} group(s) across "
+          f"{_ds['dashboards_in_groups']} analyses ({_ds['conversions_avoided']} avoidable)",
+          file=sys.stderr)
+    if inv["account"]["enterprise"] is False:
+        print("  WARNING: definition API rejected — this looks like a Standard-edition "
+              "account; complexity is unavailable (counts only).", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/quicksight-migration-skills/quicksight-assessment/scripts/render-readout-html.rb
+++ b/quicksight-migration-skills/quicksight-assessment/scripts/render-readout-html.rb
@@ -1,0 +1,1048 @@
+#!/usr/bin/env ruby
+# Render <out>/readout.html — a customer-facing, share-friendly HTML report for
+# a QuickSight→Sigma migration assessment.
+#
+# Reads the same JSON inputs as render-readout.rb (inventory.json,
+# complexity.json, shortlist.json). Customer-facing, so:
+#   - leads with the actionable finding (migration shortlist)
+#   - drops internal-skill jargon and methodology asides
+#   - assumes Enterprise mode (complexity + shortlist sections present)
+#
+# Sigma-branded — the <style> block + helper methods are copied VERBATIM from
+# tableau-assessment/scripts/render-readout-html.rb (the gold standard). Only the
+# gather-and-fill body is QuickSight-specific (analysis/dashboard, sheet, visual,
+# dataset, data source, calc field, SPICE vs DIRECT_QUERY).
+#
+# Usage: ruby scripts/render-readout-html.rb --out /tmp/qs-assessment-<acct>
+
+require 'json'
+require 'optparse'
+require 'cgi'
+require 'set'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--out DIR') { |v| opts[:out] = v }
+end.parse!
+abort('--out required') unless opts[:out]
+
+inv_path        = File.join(opts[:out], 'inventory.json')
+complexity_path = File.join(opts[:out], 'complexity.json')
+shortlist_path  = File.join(opts[:out], 'shortlist.json')
+abort("inventory.json not found in #{opts[:out]}") unless File.exist?(inv_path)
+
+def load_json(path); File.exist?(path) ? JSON.parse(File.read(path)) : nil; end
+inventory  = JSON.parse(File.read(inv_path))
+complexity = load_json(complexity_path)
+shortlist_doc = load_json(shortlist_path)
+
+shortlist  = shortlist_doc ? (shortlist_doc['analyses'] || []) : nil
+has_shortlist = !shortlist.nil? && !shortlist.empty?
+has_usage     = shortlist_doc && shortlist_doc['usage_available'] == true
+
+def h(s); CGI.escapeHTML(s.to_s); end
+def num(n); n.to_i.to_s.reverse.scan(/.{1,3}/).join(',').reverse; end
+
+# ---------- gather computed values ----------
+account = inventory['account'] || {}
+env     = inventory['environment_overview'] || {}
+analyses = inventory['analyses'] || []
+datasets = inventory['datasets'] || []
+data_sources = inventory['data_sources'] || []
+
+account_id   = account['account_id'] || File.basename(opts[:out]).sub(/^qs-assessment-/, '')
+region       = account['region'] || ''
+edition      = account['edition'] || 'unknown'
+enterprise   = account['enterprise'] != false
+generated_at = account['generated_at'] || Time.now.strftime('%Y-%m-%d')
+formatted_date = Date.parse(generated_at).strftime('%B %d, %Y') rescue generated_at
+
+# Sheet / visual totals (account-wide)
+total_sheets  = analyses.sum { |a| a['sheet_count'].to_i }
+total_visuals = analyses.sum { |a| a['visual_count'].to_i }
+
+# Ingestion split (SPICE vs DIRECT_QUERY)
+n_spice  = datasets.count { |d| d['import_mode'] == 'SPICE' }
+n_direct = datasets.count { |d| d['import_mode'] == 'DIRECT_QUERY' }
+
+# Value basis / usage proxy
+value_basis = shortlist_doc ? (shortlist_doc['value_basis'] || 'complexity-only proxy') : 'n/a'
+
+# Usage source (for section 02). When usage isn't available, fall back to the
+# complexity-proxy value already computed in the shortlist.
+usage_source =
+  if has_shortlist
+    shortlist.map do |r|
+      {
+        'name'    => r['name'],
+        'id'      => r['id'],
+        'sheets'  => r['sheets'].to_i,
+        'visuals' => r['visuals'].to_i,
+        'views'   => r['views'],
+        'users'   => r['users'],
+        'value'   => r['value'].to_f
+      }
+    end
+  else
+    []
+  end
+total_views = has_usage ? usage_source.sum { |w| w['views'].to_i } : 0
+# "cold" = zero-view analyses (only meaningful when usage is available)
+cold_analyses = has_usage ? usage_source.select { |w| w['views'].to_i.zero? } : []
+
+# Shortlist roll-ups
+sl_top5_unhandled = 0
+sl_total_unhandled = 0
+sl_needs_scout = 0
+sl_retire = 0
+sl_migrate_first = 0
+sl_easy_win = 0
+sl_top5_value = 0.0
+sl_total_value = 0.0
+if has_shortlist
+  top5 = shortlist.first(5)
+  sl_top5_unhandled  = top5.sum { |r| r['unhandled'].to_i }
+  sl_total_unhandled = shortlist.sum { |r| r['unhandled'].to_i }
+  sl_needs_scout = shortlist.count { |r| r['tag'] == 'needs-gap-scout' }
+  sl_retire      = shortlist.count { |r| r['tag'] == 'retire' }
+  sl_migrate_first = shortlist.count { |r| r['tag'] == 'migrate-first' }
+  sl_easy_win      = shortlist.count { |r| r['tag'] == 'easy-win' }
+  sl_top5_value  = top5.sum { |r| r['value'].to_f }
+  sl_total_value = shortlist.sum { |r| r['value'].to_f }
+end
+top5_pct = sl_total_value.zero? ? 0 : (sl_top5_value / sl_total_value * 100).round
+
+# Dataset reuse / concentration (the QuickSight analog of ownership concentration).
+# Which datasets back the most analyses — the DM-cluster signal.
+ds_name_by_id = datasets.each_with_object({}) { |d, m| m[d['id']] = d['name'] }
+dataset_fanout = Hash.new { |hsh, k| hsh[k] = { 'analyses' => 0, 'name' => k } }
+analyses.each do |a|
+  (a['dataset_ids'] || []).uniq.each do |dsid|
+    dataset_fanout[dsid]['analyses'] += 1
+    dataset_fanout[dsid]['name'] = ds_name_by_id[dsid] || dsid
+  end
+end
+top_dataset_pct = 0
+top_dataset_name = 'unknown'
+unless dataset_fanout.empty?
+  total_refs = dataset_fanout.values.sum { |d| d['analyses'] }
+  if total_refs > 0
+    top = dataset_fanout.values.max_by { |d| d['analyses'] }
+    top_dataset_pct = (top['analyses'].to_f / total_refs * 100).round
+    top_dataset_name = top['name']
+  end
+end
+
+# Complexity roll-ups
+n_scanned = complexity ? complexity.size : 0
+n_with_unhandled = complexity ? complexity.values.count { |r| r['n_unhandled'].to_i.positive? } : 0
+total_calc = { 'a' => 0, 'b' => 0, 'c' => 0 }
+(complexity || {}).each_value do |r|
+  (r['calc_buckets'] || {}).each { |k, v| total_calc[k] += v.to_i }
+end
+
+# ---------- HTML helpers (copied verbatim from tableau-assessment) ----------
+TAG_LABELS = {
+  'migrate-first'   => 'Migrate first',
+  'easy-win'        => 'Easy win',
+  'moderate'        => 'Standard',
+  'needs-gap-scout' => 'Needs review',
+  'retire'          => 'Retire'
+}
+TAG_CLASSES = {
+  'migrate-first'   => 'tag-go',
+  'easy-win'        => 'tag-blue',
+  'moderate'        => 'tag-gray',
+  'needs-gap-scout' => 'tag-warn',
+  'retire'          => 'tag-mute'
+}
+
+def tag_pill(t)
+  %(<span class="tag #{TAG_CLASSES[t]}">#{h(TAG_LABELS[t] || t)}</span>)
+end
+
+# Horizontal bar cell — value normalized to max
+def bar_cell(value, max, color = 'bar-blue')
+  pct = max.zero? ? 0 : (value.to_f / max * 100).round
+  %(<div class="bar-cell"><div class="bar-track"><div class="bar-fill #{color}" style="width:#{pct}%"></div></div><div class="bar-num">#{num(value)}</div></div>)
+end
+
+def kpi(label, value, sub = nil)
+  s = sub ? %(<div class="kpi-sub">#{h(sub)}</div>) : ''
+  %(<div class="kpi"><div class="kpi-v">#{h(value)}</div><div class="kpi-l">#{h(label)}</div>#{s}</div>)
+end
+
+# Generic data table renderer (verbatim from tableau-assessment).
+def table(headers, rows, opts = {})
+  cls = opts[:class] || ''
+  cols = headers.size
+  align = opts[:align] || Array.new(cols, 'left')
+  thead = "<thead><tr>" + headers.each_with_index.map { |c, i| %(<th class="al-#{align[i]}">#{h(c)}</th>) }.join + "</tr></thead>"
+  tbody = "<tbody>" + rows.map do |r|
+    "<tr>" + r.each_with_index.map { |c, i|
+      cell = c.to_s
+      content = cell.start_with?('<') ? cell : h(cell)
+      %(<td class="al-#{align[i]}">#{content}</td>)
+    }.join + "</tr>"
+  end.join + "</tbody>"
+  %(<table class="data #{cls}">#{thead}#{tbody}</table>)
+end
+
+# ---------- section content ----------
+
+# Hero: headline finding
+hero_finding =
+  if has_shortlist
+    if sl_top5_unhandled.zero? && (sl_migrate_first.positive? || sl_easy_win.positive?)
+      'Pilot migration is low-risk: the top analyses contain no unsupported QuickSight features.'
+    elsif sl_total_unhandled.positive?
+      "The top-5 pilot is feasible. #{n_with_unhandled} analys#{n_with_unhandled == 1 ? 'is' : 'es'} elsewhere include feature#{n_with_unhandled == 1 ? '' : 's'} (window/table calcs, exotic visuals, or free-form layout) that warrant individual review when planning their conversion."
+    else
+      'Migration shortlist ranked by value and conversion complexity.'
+    end
+  else
+    'Environment scan complete.'
+  end
+
+# Section 1: KPI tiles
+kpi_html = [
+  kpi('Analyses',     env['analyses']),
+  kpi('Dashboards',   env['dashboards']),
+  kpi('Datasets',     env['datasets'], "#{n_spice} SPICE · #{n_direct} direct query"),
+  kpi('Data sources', env['data_sources']),
+  kpi('Sheets',       total_sheets),
+  kpi('Visuals',      total_visuals)
+].join
+
+# Section 2: Analysis priority & usage
+usage_html = ''
+if !usage_source.empty?
+  ranked = usage_source.sort_by { |w| -w['value'].to_f }
+  max_val = ranked.first['value'].to_f
+  max_val = 1.0 if max_val.zero?
+  rows = ranked.first(10).each_with_index.map do |w, i|
+    bar_basis = has_usage ? w['views'].to_i : w['value']
+    bar_max   = has_usage ? (ranked.map { |r| r['views'].to_i }.max || 1) : max_val
+    views_cell = has_usage ? w['views'].to_i : '—'
+    users_cell = has_usage ? w['users'].to_i : '—'
+    %(<tr>
+      <td class="rank">#{i + 1}</td>
+      <td>#{h(w['name'])}</td>
+      <td class="al-right num muted">#{w['sheets']}</td>
+      <td class="al-right num muted">#{w['visuals']}</td>
+      <td>#{bar_cell(bar_basis, bar_max)}</td>
+      <td class="al-right num muted">#{views_cell}</td>
+      <td class="al-right num muted">#{users_cell}</td>
+    </tr>)
+  end.join
+  usage_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th class="al-right">#</th>
+          <th>Analysis / dashboard</th>
+          <th class="al-right">Sheets</th>
+          <th class="al-right">Visuals</th>
+          <th>#{has_usage ? 'Views' : 'Value (proxy)'}</th>
+          <th class="al-right">Views</th>
+          <th class="al-right">Users</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 3: Dataset reuse & concentration
+ownership_html = ''
+unless dataset_fanout.empty?
+  rows_data = dataset_fanout.values.sort_by { |d| -d['analyses'] }
+  max_fan = rows_data.first['analyses']
+  max_fan = 1 if max_fan.zero?
+  rows = rows_data.map do |d|
+    %(<tr>
+      <td>#{h(d['name'])}</td>
+      <td>#{bar_cell(d['analyses'], max_fan)}</td>
+    </tr>)
+  end.join
+  ownership_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Dataset</th>
+          <th>Analyses backed</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 4: Data-source patterns (SPICE/DIRECT_QUERY, source types, file/S3 flagged)
+FILE_SOURCE_KINDS = %w[S3Source UploadedFile S3 File].freeze
+FILE_DS_TYPES     = %w[S3 FILE UPLOAD].freeze
+
+# Source-kind histogram across datasets (physical_kinds)
+src_kind = Hash.new(0)
+datasets.each { |d| (d['physical_kinds'] || []).each { |k| src_kind[k] += 1 } }
+src_rows_data = src_kind.sort_by { |_, n| -n }
+max_src = src_rows_data.empty? ? 1 : src_rows_data.first[1]
+src_kind_html = ''
+unless src_rows_data.empty?
+  rows = src_rows_data.map do |kind, n|
+    flagged = FILE_SOURCE_KINDS.include?(kind)
+    badge = flagged ? %(<span class="ds-bucket ds-embedded">file-based</span>) : %(<span class="ds-bucket ds-published">warehouse</span>)
+    %(<tr>
+      <td><code>#{h(kind)}</code></td>
+      <td>#{badge}</td>
+      <td>#{bar_cell(n, max_src)}</td>
+    </tr>)
+  end.join
+  src_kind_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Physical source kind</th>
+          <th>Sigma readiness</th>
+          <th>Datasets</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Connection (data-source) type table — the warehouse/engine each source points at
+ds_type_html = ''
+if !data_sources.empty?
+  type_hist = Hash.new(0)
+  data_sources.each { |s| type_hist[s['type'] || 'unknown'] += 1 }
+  rows_data = type_hist.sort_by { |_, n| -n }
+  max_t = rows_data.first[1]
+  rows = rows_data.map do |t, n|
+    flagged = FILE_DS_TYPES.include?(t.to_s.upcase)
+    cls = flagged ? 'ds-embedded' : 'ds-published'
+    label = flagged ? 'file / object store' : 'warehouse / engine'
+    %(<tr>
+      <td><code>#{h(t)}</code></td>
+      <td><span class="ds-bucket #{cls}">#{label}</span></td>
+      <td>#{bar_cell(n, max_t)}</td>
+    </tr>)
+  end.join
+  ds_type_html = "<h3>Data-source connection types</h3>" + <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Connection type</th>
+          <th>Sigma readiness</th>
+          <th>Count</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# File-based / S3 flagged callout
+n_file_datasets = datasets.count { |d| (d['physical_kinds'] || []).any? { |k| FILE_SOURCE_KINDS.include?(k) } }
+n_custom_sql    = datasets.count { |d| d['has_custom_sql'] }
+n_rls           = datasets.count { |d| d['rls_enabled'] }
+ds_callout = ''
+if n_file_datasets.positive?
+  ds_callout = %(<div class="callout"><strong>#{n_file_datasets} dataset#{n_file_datasets == 1 ? '' : 's'}</strong> source from S3 / uploaded files. Sigma reads from a cloud warehouse, not directly from S3 objects — these need to land in your warehouse first (the <code>quicksight-to-sigma</code> converter flags them as a gap). Warehouse-backed datasets (Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres) are drop-in: Sigma reads the same tables directly.</div>)
+end
+
+# Section 5: Refresh / ingestion activity (SPICE vs DIRECT_QUERY)
+ingestion_html = ''
+unless datasets.empty?
+  rows = datasets.sort_by { |d| d['import_mode'] == 'SPICE' ? 0 : 1 }.map do |d|
+    mode = d['import_mode'] || '—'
+    mode_cls = mode == 'SPICE' ? 'tag-blue' : 'tag-go'
+    rls_chip = d['rls_enabled'] ? %(<span class="risk-chip risk-amber"><span class="risk-dot"></span>RLS</span>) : '<span class="muted">—</span>'
+    %(<tr>
+      <td>#{h(d['name'])}</td>
+      <td><span class="tag #{mode_cls}">#{h(mode)}</span></td>
+      <td class="al-right num muted">#{d['column_count']}</td>
+      <td class="al-right num muted">#{d['transform_count']}</td>
+      <td>#{rls_chip}</td>
+    </tr>)
+  end.join
+  ingestion_html = <<~HTML
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Dataset</th>
+          <th>Ingestion</th>
+          <th class="al-right">Columns</th>
+          <th class="al-right">Transforms</th>
+          <th>Security</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+  HTML
+end
+
+# Section 6: Migration shortlist (HERO table)
+shortlist_html = ''
+if has_shortlist
+  max_val = shortlist.map { |r| r['value'].to_f }.max || 1.0
+  max_val = 1.0 if max_val.zero?
+  rows = shortlist.first(15).map do |r|
+    risk_cls, risk_txt =
+      if r['unhandled'].to_i.positive?
+        ['risk-red',   "#{r['unhandled']} to review"]
+      elsif r['manual'].to_i.positive?
+        ['risk-amber', "#{r['manual']} setup"]
+      else
+        ['risk-clean', 'No issues']
+      end
+    cb = r['calc_buckets'] || {}
+    %(<tr>
+      <td>#{h(r['name'])}</td>
+      <td>#{bar_cell(r['value'].round, max_val.round)}</td>
+      <td class="al-right num muted">#{cb['a'].to_i}/#{cb['b'].to_i}/#{cb['c'].to_i}</td>
+      <td><span class="risk-chip #{risk_cls}"><span class="risk-dot"></span>#{h(risk_txt)}</span></td>
+      <td class="al-right num">#{format('%.1f', r['score'])}</td>
+      <td>#{tag_pill(r['tag'])}</td>
+    </tr>)
+  end.join
+  shortlist_html = <<~HTML
+    <table class="data shortlist">
+      <thead>
+        <tr>
+          <th>Analysis</th>
+          <th>#{has_usage ? 'Usage value' : 'Value (proxy)'}</th>
+          <th class="al-right">Calc a/b/c</th>
+          <th>Conversion risk</th>
+          <th class="al-right">Score</th>
+          <th>Recommendation</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+    <p class="note">Conversion risk legend: <strong>No issues</strong> = converts automatically · <strong>N setup</strong> = brief post-conversion setup in Sigma (dataset joins, parameters, RLS) · <strong>N to review</strong> = uses a QuickSight feature that warrants individual evaluation (window/table calcs, exotic visuals, free-form layout) when planning the conversion. Calc a/b/c = mechanical / restructuring / no-Sigma-equivalent calc fields.</p>
+  HTML
+end
+
+# Per-analysis complexity table
+complexity_html = ''
+if complexity
+  rows = complexity.values.sort_by do |r|
+    -(r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3 + r['n_hint'].to_i)
+  end.map do |r|
+    unh_cell = r['n_unhandled'].to_i.positive? ? %(<span class="warn-num">#{r['n_unhandled']}</span>) : '<span class="muted">0</span>'
+    cb = r['calc_buckets'] || {}
+    %(<tr>
+      <td>#{h(r['name'])}</td>
+      <td class="al-right num muted">#{r['sheets']}</td>
+      <td class="al-right num">#{r['visuals']}</td>
+      <td class="al-right num muted">#{cb['a'].to_i}/#{cb['b'].to_i}/#{cb['c'].to_i}</td>
+      <td class="al-right num muted">#{r['window_calc_count']}</td>
+      <td class="al-right num">#{r['n_manual']}</td>
+      <td class="al-right">#{unh_cell}</td>
+    </tr>)
+  end.join
+  complexity_html = <<~HTML
+    <h3>Per-analysis conversion profile</h3>
+    <table class="data">
+      <thead>
+        <tr>
+          <th>Analysis</th>
+          <th class="al-right">Sheets</th>
+          <th class="al-right">Visuals</th>
+          <th class="al-right">Calc a/b/c</th>
+          <th class="al-right">Window calcs</th>
+          <th class="al-right">Setup</th>
+          <th class="al-right">Review</th>
+        </tr>
+      </thead>
+      <tbody>#{rows}</tbody>
+    </table>
+    <p class="note">Window/table-calc functions (the "c" calc bucket — <code>sumOver</code>, <code>runningSum</code>, <code>rank</code>, <code>percentOfTotal</code>, …) have no clean Sigma equivalent and convert to a <code>/* TODO */</code> placeholder. Across all scanned analyses: <strong>#{total_calc['a']} mechanical / #{total_calc['b']} restructuring / #{total_calc['c']} no-equivalent</strong> calc fields.</p>
+  HTML
+end
+
+# ---------- estimated migration effort (token model) ----------
+effort_html = ''
+token_model_path = File.join(__dir__, '..', 'refs', 'token-model.json')
+if has_shortlist && File.exist?(token_model_path)
+  tm = JSON.parse(File.read(token_model_path)) rescue nil
+  if tm
+    bucket  = 'mechanical'
+    n_dash  = shortlist.size
+    n_rev   = n_with_unhandled
+    pd      = (tm['per_dashboard'] || {})[bucket] || {}
+    pr      = tm['per_review_item'] || {}
+    cal     = tm['calibration'] || {}
+    est = lambda { |m| (pd["#{m}_usd"].to_f * n_dash) + (pr["#{m}_usd"].to_f * n_rev) }
+    opus_usd   = est.call('opus')
+    sonnet_usd = est.call('sonnet')
+    fmt = lambda { |v| '$' + format('%.2f', v) }
+    effort_html = <<~HTML
+      <section>
+        <div class="section-head">
+          <span class="section-num">07</span>
+          <h2 class="section-title">Estimated migration effort (tokens / $)</h2>
+          <span class="section-aside">one-shot orchestrator path</span>
+        </div>
+        <p class="section-lede">A planning estimate of the LLM cost to migrate the shortlisted analyses via the <code>quicksight-to-sigma</code> one-shot orchestrator. The mechanical model converter is deterministic, so per-dashboard cost is flat; each analysis flagged for review adds one human-decision round.</p>
+        <div class="stat-row">
+          <div class="stat stat-go">
+            <div class="stat-l">Estimated cost · Opus</div>
+            <div class="stat-v go">#{fmt.call(opus_usd)}</div>
+            <div class="stat-sub">#{n_dash} analyses + #{n_rev} review</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Estimated cost · Sonnet</div>
+            <div class="stat-v">#{fmt.call(sonnet_usd)}</div>
+            <div class="stat-sub">same scope, Sonnet pricing</div>
+          </div>
+          <div class="stat">
+            <div class="stat-l">Basis</div>
+            <div class="stat-v" style="font-size:20px;">#{n_dash}<span style="font-size:14px;color:var(--mute);font-weight:600;"> × per-dashboard</span></div>
+            <div class="stat-sub">+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</div>
+          </div>
+        </div>
+        <table class="data">
+          <thead>
+            <tr><th>Component</th><th class="al-right">Opus</th><th class="al-right">Sonnet</th></tr>
+          </thead>
+          <tbody>
+            <tr><td>#{n_dash} analyses × per-dashboard</td><td class="al-right num">#{fmt.call(pd['opus_usd'].to_f * n_dash)}</td><td class="al-right num">#{fmt.call(pd['sonnet_usd'].to_f * n_dash)}</td></tr>
+            <tr><td>+ #{n_rev} item#{n_rev == 1 ? '' : 's'} need review</td><td class="al-right num">#{fmt.call(pr['opus_usd'].to_f * n_rev)}</td><td class="al-right num">#{fmt.call(pr['sonnet_usd'].to_f * n_rev)}</td></tr>
+            <tr><td><strong>Total estimated</strong></td><td class="al-right num"><strong>#{fmt.call(opus_usd)}</strong></td><td class="al-right num"><strong>#{fmt.call(sonnet_usd)}</strong></td></tr>
+          </tbody>
+        </table>
+        <p class="note">Calibrated #{h(cal['date'])}, one-shot orchestrator path — LLM cost only; rescale $ by your coding agent's pricing. A naive agent-driven migration is ~12–20× more expensive.</p>
+      </section>
+    HTML
+  end
+end
+
+# ---------- duplicate / consolidation candidates ----------
+# Shell out to the shared, tool-neutral detector for the HTML fragment. Prefer
+# the normalized list written by quicksight-inventory.py; embed only if the scan
+# actually found overlapping analyses (flag-not-fake).
+dup_html = ''
+dup_doc = inventory['duplicate_dashboards']
+dup_norm_path = File.join(opts[:out], 'dup-normalized.json')
+if dup_doc && (dup_doc['summary'] || {})['duplicate_groups'].to_i.positive? && File.exist?(dup_norm_path)
+  dd_script = File.join(__dir__, 'dup-dashboards.py')
+  frag_path = File.join(opts[:out], 'dup-frag.html')
+  system('python3', dd_script, '--in', dup_norm_path,
+         '--out', File.join(opts[:out], 'dup-groups.json'), '--html', frag_path)
+  if File.exist?(frag_path)
+    frag = File.read(frag_path)
+    dup_html = <<~HTML
+      <section>
+        <div class="section-head">
+          <span class="section-num">DUP</span>
+          <h2 class="section-title">Duplicate / consolidation candidates</h2>
+          <span class="section-aside">migrate once, not N times</span>
+        </div>
+        <p class="section-lede">These analyses look like the same report rebuilt — shared datasets, overlapping visuals, near-identical names. Consolidating them before migration means you build each in Sigma once and retire the redundant copies.</p>
+        #{frag}
+      </section>
+    HTML
+  end
+end
+
+# ---------- assemble HTML ----------
+html = <<~HTML
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>QuickSight Environment Report — #{h(account_id)}</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    /* Sigma brand palette — Shadow/Nimbus/White neutrals, Insight (CTA only), brand accents */
+    --bg:#fafafa; --card:#ffffff; --ink:#292929; --ink-2:#3d3d3d;
+    --line:#e5e5e5; --line-soft:#f5f5f5;
+    --accent:#292929; --accent-soft:#f0f0f0;
+    --insight:#f0ff45;
+    --go:#1f9d57; --go-soft:#e6fbef;
+    --warn:#c2562a; --warn-soft:#fff1ea;
+    --blue:#2b8ca6; --blue-soft:#eaf8fc;
+    --mute:#6e7877; --mute-soft:#f0f0f0;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; background: var(--bg); color: var(--ink); }
+  body {
+    font-family: "DM Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px; line-height: 1.55; -webkit-font-smoothing: antialiased;
+  }
+  main { max-width: 1120px; margin: 0 auto; padding: 48px 48px 80px; }
+
+  /* Brand masthead */
+  .brand-bar { display: flex; align-items: center; gap: 10px; margin-bottom: 28px; }
+  .brand-mark { font-weight: 700; font-size: 21px; letter-spacing: -0.02em; color: var(--ink); }
+  .brand-dot  { width: 9px; height: 9px; border-radius: 2px; background: var(--blue);
+                -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .brand-tag  { font-size: 12px; color: var(--mute); font-weight: 500;
+                text-transform: uppercase; letter-spacing: 0.08em; }
+
+  /* Header */
+  .doc-header { margin-bottom: 40px; }
+  .doc-eyebrow { font-size: 11px; font-weight: 600; color: var(--accent);
+                 text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+  .doc-title { font-size: 36px; font-weight: 700; letter-spacing: -0.02em;
+               margin: 0 0 8px; line-height: 1.1; color: var(--ink); }
+  .doc-meta { font-size: 13px; color: var(--ink-2); }
+  .doc-meta a { color: var(--ink-2); text-decoration: none; border-bottom: 1px dashed var(--line); }
+  .doc-meta a:hover { color: var(--ink); }
+
+  /* Hero finding banner */
+  .hero {
+    background: var(--accent-soft); border: 1px solid var(--line);
+    border-left: 4px solid var(--blue);
+    border-radius: 8px;
+    padding: 18px 22px; margin-bottom: 40px;
+    display: flex; align-items: center; gap: 16px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .hero-label { font-size: 11px; font-weight: 700; color: var(--accent);
+                text-transform: uppercase; letter-spacing: 0.08em;
+                white-space: nowrap; padding-right: 16px;
+                border-right: 1px solid var(--line); }
+  .hero-text { font-size: 15px; color: var(--ink); font-weight: 500; line-height: 1.4; }
+
+  /* Section */
+  section { margin-bottom: 56px; }
+  section.section-tight { margin-bottom: 36px; }
+  .section-head { display: flex; align-items: baseline; justify-content: space-between;
+                  margin-bottom: 16px; padding-bottom: 12px;
+                  border-bottom: 1px solid var(--line); }
+  .section-num { font-size: 12px; font-weight: 600; color: var(--mute);
+                 letter-spacing: 0.06em; }
+  .section-title { font-size: 22px; font-weight: 600; letter-spacing: -0.01em;
+                   margin: 0; flex: 1; padding-left: 14px; }
+  .section-aside { font-size: 12px; color: var(--mute); }
+  .section-lede { font-size: 14px; color: var(--ink-2); margin: -4px 0 16px; }
+
+  /* KPIs */
+  .kpi-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: 12px; }
+  .kpi {
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    padding: 18px 16px;
+  }
+  .kpi-v { font-size: 28px; font-weight: 700; letter-spacing: -0.01em;
+           color: var(--ink); line-height: 1; }
+  .kpi-l { font-size: 11px; color: var(--mute); text-transform: uppercase;
+           letter-spacing: 0.06em; font-weight: 600; margin-top: 10px; }
+  .kpi-sub { font-size: 11px; color: var(--mute); margin-top: 4px; line-height: 1.4; }
+
+  /* Stat callouts */
+  .stat-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px;
+              margin-bottom: 24px; }
+  .stat {
+    background: #fafafa;
+    border: 1px solid var(--line); border-left: 3px solid var(--accent);
+    border-radius: 8px;
+    padding: 16px 18px;
+    -webkit-print-color-adjust: exact; print-color-adjust: exact;
+  }
+  .stat.stat-go   { border-left-color: var(--go);   background: var(--go-soft); }
+  .stat.stat-warn { border-left-color: var(--warn); background: var(--warn-soft); }
+  .stat-l { font-size: 10px; color: var(--mute); text-transform: uppercase;
+            letter-spacing: 0.06em; font-weight: 700; margin-bottom: 6px; }
+  .stat-v { font-size: 30px; font-weight: 700; line-height: 1; letter-spacing: -0.02em;
+            color: var(--ink); }
+  .stat-v.go   { color: var(--go); }
+  .stat-v.warn { color: var(--warn); }
+  .stat-sub { font-size: 12px; color: var(--mute); margin-top: 6px; }
+
+  /* Tables */
+  table.data { width: 100%; border-collapse: collapse; background: var(--card);
+               border: 1px solid var(--line); border-radius: 10px; overflow: hidden;
+               font-size: 13px; }
+  table.data th { font-weight: 600; font-size: 11px; color: var(--mute);
+                  text-transform: uppercase; letter-spacing: 0.06em;
+                  padding: 12px 16px; background: #fafafa;
+                  border-bottom: 1px solid var(--line); text-align: left; }
+  table.data td { padding: 12px 16px; border-bottom: 1px solid var(--line-soft);
+                  vertical-align: middle; }
+  table.data tbody tr:last-child td { border-bottom: 0; }
+  table.data tbody tr:hover td { background: #fafafa; }
+  .al-right { text-align: right; }
+  .al-left  { text-align: left; }
+  /* Pin numeric + bar columns to content width so the text column absorbs the
+     slack — keeps a short value tight against its header instead of stranding it
+     across an over-wide column. */
+  table.data td.al-right, table.data th.al-right,
+  table.data td:has(.bar-cell) { width: 1%; white-space: nowrap; }
+  .num { font-variant-numeric: tabular-nums; }
+  .muted { color: var(--mute); }
+  .warn { color: var(--warn); }
+  .warn-num { color: var(--warn); font-weight: 700; }
+  .rank { font-variant-numeric: tabular-nums; color: var(--mute); font-weight: 600; width: 32px; }
+  .workbook-link { color: var(--ink); text-decoration: none;
+                   border-bottom: 1px solid var(--line); }
+  .workbook-link:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  .breakdown { font-size: 12px; font-variant-numeric: tabular-nums; }
+  .breakdown span { margin-right: 8px; }
+
+  /* Tags */
+  .tag { display: inline-block; padding: 3px 10px; border-radius: 99px;
+         font-size: 11px; font-weight: 600; letter-spacing: 0.01em;
+         white-space: nowrap; }
+  .tag-go    { background: var(--go-soft);    color: var(--go); }
+  .tag-blue  { background: var(--blue-soft);  color: var(--blue); }
+  .tag-gray  { background: #f5f5f5;           color: var(--ink-2); }
+  .tag-warn  { background: var(--warn-soft);  color: var(--warn); }
+  .tag-mute  { background: var(--mute-soft);  color: var(--mute); }
+
+  /* Bar cells (in tables) */
+  .bar-cell { display: flex; align-items: center; gap: 10px;
+              justify-content: flex-start; }
+  .bar-track { flex: none; width: 84px; height: 6px; background: #f5f5f5; border-radius: 4px;
+               overflow: hidden; }
+  .bar-fill { height: 100%; border-radius: 4px; }
+  .bar-blue { background: linear-gradient(90deg, #4cec8c, #2fb874); }
+  .bar-num { font-variant-numeric: tabular-nums; font-weight: 600;
+             min-width: 36px; text-align: right; }
+
+  /* Data-source bucket badge */
+  .ds-bucket { display: inline-block; padding: 3px 10px; border-radius: 6px;
+               font-size: 11px; font-weight: 600;
+               -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .ds-published { background: var(--blue-soft); color: var(--blue); }
+  .ds-embedded  { background: #f5f5f5; color: var(--ink-2); }
+
+  /* Risk chip — used in shortlist + verdicts + coverage */
+  .risk-chip { display: inline-flex; align-items: center; gap: 6px;
+               font-size: 12px; font-variant-numeric: tabular-nums; }
+  .risk-dot { width: 8px; height: 8px; border-radius: 50%;
+              -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .risk-clean .risk-dot { background: var(--go); }
+  .risk-clean             { color: var(--go); font-weight: 600; }
+  .risk-green .risk-dot { background: #84cc16; }
+  .risk-green             { color: var(--ink-2); }
+  .risk-amber .risk-dot { background: #f59e0b; }
+  .risk-amber             { color: #a16207; font-weight: 600; }
+  .risk-red   .risk-dot { background: var(--warn); }
+  .risk-red               { color: var(--warn); font-weight: 700; }
+  .risk-mute  .risk-dot { background: var(--mute); }
+  .risk-mute              { color: var(--mute); }
+
+  /* Cluster member display */
+  .cluster-member { padding: 2px 0; font-size: 12px; line-height: 1.4; }
+  .cluster-member + .cluster-member { border-top: 1px dashed var(--line-soft); }
+
+  /* Inline user pill (top-users cell) */
+  .inline-pill { display: inline-block; padding: 1px 7px; border-radius: 99px;
+                 font-size: 11px; background: #f1f5f9; color: var(--ink-2);
+                 font-variant-numeric: tabular-nums; margin-right: 4px;
+                 -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+
+  /* Top-view cell — most-used view per workbook */
+  .top-view-cell { font-size: 12px; line-height: 1.3; }
+  .top-view-pct  { font-size: 11px; margin-top: 2px; }
+
+  /* Per-user top-workbook list (inside table cell) */
+  .top-wb { font-size: 11px; line-height: 1.4; display: flex;
+            justify-content: space-between; gap: 12px;
+            padding: 1px 0; }
+  .top-wb + .top-wb { border-top: 1px dotted var(--line-soft); padding-top: 3px; margin-top: 3px; }
+  .top-wb span:first-child { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 220px; }
+
+  /* Unique-to-user expander */
+  details.unique-detail { font-size: 11px; }
+  details.unique-detail summary { cursor: pointer; color: var(--accent); font-weight: 600;
+                                  list-style: none; padding: 2px 0; }
+  details.unique-detail summary::-webkit-details-marker { display: none; }
+  details.unique-detail summary::before { content: '▸ '; color: var(--mute); }
+  details.unique-detail[open] summary::before { content: '▾ '; }
+  details.unique-detail div { padding-left: 12px; font-size: 11px; line-height: 1.4; }
+
+  /* Notes + callouts */
+  .note { font-size: 12px; color: var(--mute); font-style: italic;
+          margin: 12px 0 0; }
+  .callout {
+    background: var(--warn-soft); border-left: 3px solid var(--warn);
+    padding: 12px 16px; border-radius: 6px; margin-top: 16px;
+    font-size: 13px; color: #7c2d12;
+  }
+  .callout strong { color: #7c2d12; }
+  .callout code { background: rgba(0,0,0,0.06); padding: 1px 5px; border-radius: 3px;
+                  font-size: 12px; }
+
+  code { font-family: "DM Mono", ui-monospace, "SF Mono", Menlo, monospace; font-size: 12.5px;
+         background: var(--line-soft); padding: 1px 6px; border-radius: 4px; }
+
+  /* Next steps */
+  ol.next-steps { margin: 0; padding-left: 0; counter-reset: step;
+                  list-style: none; }
+  ol.next-steps li { counter-increment: step; padding: 14px 0 14px 44px;
+                     position: relative; border-bottom: 1px solid var(--line-soft);
+                     font-size: 14px; }
+  ol.next-steps li:last-child { border-bottom: 0; }
+  ol.next-steps li::before {
+    content: counter(step); position: absolute; left: 0; top: 14px;
+    width: 28px; height: 28px; border-radius: 50%;
+    background: var(--accent-soft); color: var(--accent);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 13px; font-weight: 700; font-variant-numeric: tabular-nums;
+  }
+  ol.next-steps li strong { color: var(--ink); }
+
+  /* Privacy two-column */
+  .priv-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }
+  .priv-col h3 { font-size: 13px; font-weight: 600; color: var(--ink);
+                 margin: 0 0 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+  .priv-col ul { margin: 0; padding-left: 0; list-style: none; }
+  .priv-col li { padding: 6px 0 6px 22px; position: relative;
+                 font-size: 13px; color: var(--ink-2); }
+  .priv-col.crossed li::before {
+    content: '→'; position: absolute; left: 0; color: var(--warn); font-weight: 700;
+  }
+  .priv-col.local li::before {
+    content: '◊'; position: absolute; left: 0; color: var(--go); font-weight: 700;
+  }
+
+  footer { color: var(--mute); font-size: 11px; text-align: center;
+           margin-top: 56px; padding-top: 20px; border-top: 1px solid var(--line); }
+
+  @media print {
+    @page { margin: 0.6in 0.5in 0.6in; size: letter portrait; }
+    body { background: white; font-size: 11.5px; }
+    main { max-width: none; padding: 0; }
+    .doc-header { margin-bottom: 18px; }
+    .doc-title { font-size: 26px; }
+    .hero { margin-bottom: 24px; padding: 12px 16px; page-break-after: avoid; }
+    .hero-text { font-size: 13px; }
+    section { margin-bottom: 24px; page-break-inside: auto; }
+    section.section-tight { margin-bottom: 18px; }
+    .section-head { margin-bottom: 10px; padding-bottom: 8px; page-break-after: avoid; }
+    .section-title { font-size: 16px; }
+    .section-lede { font-size: 12px; margin: -2px 0 10px; }
+    .kpi-grid { gap: 8px; }
+    .kpi { padding: 12px; }
+    .kpi-v { font-size: 22px; }
+    .kpi-l { font-size: 10px; margin-top: 6px; }
+    .kpi-sub { font-size: 10px; margin-top: 3px; }
+    .stat-row { gap: 8px; margin-bottom: 14px; }
+    .stat { padding: 12px 14px; }
+    .stat-v { font-size: 24px; }
+    table.data { font-size: 11px; page-break-inside: auto; }
+    table.data thead { display: table-header-group; }
+    table.data th { padding: 8px 10px; font-size: 10px; }
+    table.data td { padding: 8px 10px; }
+    table.data tr { page-break-inside: avoid; page-break-after: auto; }
+    .tag, .ds-bucket { font-size: 10px; padding: 2px 8px; }
+    .bar-track { max-width: 60px; height: 5px; }
+    .note { font-size: 11px; }
+    .callout { padding: 8px 12px; font-size: 11px; }
+    ol.next-steps li { padding: 10px 0 10px 36px; font-size: 12px; }
+    ol.next-steps li::before { width: 22px; height: 22px; font-size: 11px; top: 10px; }
+    .priv-col li { font-size: 11px; padding: 4px 0 4px 18px; }
+    footer { margin-top: 24px; padding-top: 12px; }
+    /* Force backgrounds + colors to render */
+    .hero, .kpi, .stat, table.data, table.data th, .ds-bucket, .tag,
+    .bar-track, .bar-fill, .risk-dot, .callout, ol.next-steps li::before {
+      -webkit-print-color-adjust: exact !important; print-color-adjust: exact !important;
+    }
+    /* Avoid awkward page splits at section boundaries */
+    section h2, .section-head { page-break-after: avoid; }
+    .stat-row, .priv-grid { page-break-inside: avoid; }
+  }
+</style>
+</head>
+<body>
+<main>
+
+<div class="brand-bar">
+  <span class="brand-dot"></span>
+  <span class="brand-mark">sigma</span>
+  <span class="brand-tag">Migration Assessment</span>
+</div>
+<div class="doc-header">
+  <div class="doc-eyebrow">QuickSight Environment Report</div>
+  <h1 class="doc-title">#{h(account_id)}</h1>
+  <div class="doc-meta">
+    Account #{h(account_id)} · #{h(region)} · #{h(edition)} edition · Generated #{h(formatted_date)}
+  </div>
+</div>
+
+<div class="hero">
+  <div class="hero-label">Headline finding</div>
+  <div class="hero-text">#{h(hero_finding)}</div>
+</div>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">01</span>
+    <h2 class="section-title">Environment overview</h2>
+  </div>
+  <div class="kpi-grid">#{kpi_html}</div>
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">02</span>
+    <h2 class="section-title">Analysis &amp; dashboard priority</h2>
+    <span class="section-aside">Top 10 of #{env['analyses']} analyses · ranked #{has_usage ? "by #{num(total_views)} total views" : 'by complexity proxy'}</span>
+  </div>
+  <p class="section-lede">#{has_usage ? 'Most-used analyses across the account, ranked by all-time view count. This is the foundation of any migration plan — focus effort where audience attention already is.' : 'QuickSight has no per-analysis view-count API on the standard surface, so analyses are ranked by a complexity proxy (sheets + visuals/4) rather than real usage. Supply a CloudTrail/CloudWatch-derived <code>usage.json</code> to add the usage axis.'}</p>
+  #{usage_html}
+  #{cold_analyses.any? ? %(<p class="note"><strong>#{cold_analyses.size} analys#{cold_analyses.size == 1 ? 'is has' : 'es have'}</strong> never been viewed: ) + cold_analyses.map { |w| %(<code>#{h(w['name'])}</code>) }.join(', ') + ' — strong candidates for retirement.</p>' : ''}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">03</span>
+    <h2 class="section-title">Dataset reuse &amp; concentration</h2>
+    <span class="section-aside">#{datasets.size} datasets</span>
+  </div>
+  <p class="section-lede">QuickSight has no per-analysis owner surface, so concentration here is measured by <strong>dataset reuse</strong>: how many analyses each dataset backs. Datasets shared across multiple analyses become a single Sigma data model by construction — the migration plan groups analyses into DM clusters on exactly this signal.</p>
+  #{ownership_html}
+  #{dataset_fanout.empty? ? '' : %(<p class="note">Most-reused dataset: <strong>#{top_dataset_pct}%</strong> of dataset references point at <code>#{h(top_dataset_name)}</code>. High reuse is a <em>good</em> migration signal — those analyses collapse into one shared Sigma data model.</p>)}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">04</span>
+    <h2 class="section-title">Data sources &amp; patterns</h2>
+    <span class="section-aside">#{datasets.size} datasets · #{n_spice} SPICE · #{n_direct} direct query</span>
+  </div>
+  <p class="section-lede">How data flows into your QuickSight analyses. Datasets backed by a cloud warehouse Sigma already supports (Snowflake, Redshift, Athena, BigQuery, Databricks, Postgres) are drop-in. File-based sources (S3, uploaded files) must land in a warehouse first.</p>
+  #{src_kind_html}
+  #{ds_type_html}
+  <p class="note"><strong>#{n_custom_sql} dataset#{n_custom_sql == 1 ? '' : 's'}</strong> use Custom SQL (converted via the <code>[Custom SQL/&lt;ALIAS&gt;]</code> fixup) · <strong>#{n_rls} dataset#{n_rls == 1 ? '' : 's'}</strong> have row-level security enabled.</p>
+  #{ds_callout}
+</section>
+
+<section>
+  <div class="section-head">
+    <span class="section-num">05</span>
+    <h2 class="section-title">Ingestion &amp; refresh activity</h2>
+    <span class="section-aside">#{n_spice} SPICE · #{n_direct} direct query</span>
+  </div>
+  <p class="section-lede">QuickSight datasets either pre-ingest into SPICE (its in-memory cache, refreshed on a schedule) or query the warehouse live (DIRECT_QUERY). SPICE datasets carry a refresh schedule that becomes a Sigma data-model materialization; direct-query datasets read live and need no ingestion plan.</p>
+  #{ingestion_html}
+</section>
+
+HTML
+
+if has_shortlist
+  html += <<~HTML
+  <section>
+    <div class="section-head">
+      <span class="section-num">06</span>
+      <h2 class="section-title">Migration to Sigma — recommended sequence</h2>
+      <span class="section-aside">#{value_basis}</span>
+    </div>
+    <p class="section-lede">If you choose to migrate to Sigma, this is the order that minimizes risk while covering the most value. Analyses are ranked by <code>value / (1 + cost)</code>, where <code>cost = 10·unhandled + 3·manual</code>. The top of the list is the recommended starting point for a pilot.</p>
+
+    <div class="stat-row">
+      <div class="stat">
+        <div class="stat-l">Top-5 #{has_usage ? 'usage' : 'value'} share</div>
+        <div class="stat-v">#{top5_pct}<span style="font-size: 16px; color: var(--mute); font-weight: 600;">%</span></div>
+        <div class="stat-sub">of total #{has_usage ? 'usage value' : 'value (proxy)'} across #{shortlist.size} analyses</div>
+      </div>
+      <div class="stat stat-#{sl_top5_unhandled.zero? ? 'go' : 'warn'}">
+        <div class="stat-l">Top-5 conversion complexity</div>
+        <div class="stat-v #{sl_top5_unhandled.zero? ? 'go' : 'warn'}">#{sl_top5_unhandled}</div>
+        <div class="stat-sub">advanced features to review across pilot</div>
+      </div>
+      <div class="stat">
+        <div class="stat-l">Needs review · Retire</div>
+        <div class="stat-v">#{sl_needs_scout}<span style="font-size: 16px; color: var(--mute); font-weight: 600;"> · #{sl_retire}</span></div>
+        <div class="stat-sub">analyses of #{shortlist.size} total</div>
+      </div>
+    </div>
+
+    #{shortlist_html}
+
+    #{complexity_html}
+
+    #{sl_total_unhandled.positive? ?
+      %(<div class="callout"><strong>#{n_with_unhandled} analys#{n_with_unhandled == 1 ? 'is' : 'es'}</strong> include features that warrant individual review when planning their conversion — typically window/table-calc functions (no clean Sigma equivalent), exotic visuals (maps, sankey, insight ML), or free-form / section-based layout. Identifying these up-front means no surprises mid-migration.</div>) : ''}
+  </section>
+
+  HTML
+  html += effort_html
+end
+
+html += dup_html
+
+priv_num = has_shortlist ? '08' : '06'
+next_num = has_shortlist ? '09' : '07'
+
+html += <<~HTML
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{priv_num}</span>
+    <h2 class="section-title">Data handling</h2>
+  </div>
+  <p class="section-lede">This report was generated by an LLM-driven scan of your QuickSight account via the AWS CLI. What that means for the data that left your environment:</p>
+  <div class="priv-grid">
+    <div class="priv-col crossed">
+      <h3>Read by the scanner</h3>
+      <ul>
+        <li>Aggregate counts (analysis, dashboard, dataset, data-source totals)</li>
+        <li>Analysis, dataset, and data-source names</li>
+        <li>Analysis definitions — visual configuration and <strong>calc-field expressions</strong></li>
+        <li>Dataset metadata — physical source kinds, custom-SQL presence, RLS/CLS flags</li>
+      </ul>
+    </div>
+    <div class="priv-col local">
+      <h3>Never left your environment</h3>
+      <ul>
+        <li>Underlying warehouse rows — the scan never queries source data</li>
+        <li>SPICE in-memory rows — never read</li>
+        <li>AWS credentials (held by the AWS CLI, not surfaced to the agent)</li>
+        <li>Actual visual cell values</li>
+      </ul>
+    </div>
+  </div>
+  <p class="note">If your calc-field expressions encode business-sensitive logic, that text crossed the Anthropic API. See <code>PRIVACY.md</code> for the full disclosure to review with your privacy / legal team.</p>
+</section>
+
+<section class="section-tight">
+  <div class="section-head">
+    <span class="section-num">#{next_num}</span>
+    <h2 class="section-title">Recommended next steps</h2>
+  </div>
+  <ol class="next-steps">
+HTML
+
+if has_shortlist
+  html += <<~HTML
+    <li><strong>Pilot the top #{[5, shortlist.size].min} analyses.</strong> They represent #{top5_pct}% of total #{has_usage ? 'usage value' : 'value (proxy)'} with #{sl_top5_unhandled} feature#{sl_top5_unhandled == 1 ? '' : 's'} flagged for review between them — the lowest-risk way to demonstrate end-to-end migration. The <code>quicksight-to-sigma</code> skill converts them, grouped into DM clusters that share a Sigma data model by shared dataset.</li>
+  HTML
+  if sl_needs_scout.positive?
+    html += "    <li><strong>Plan individual review time for #{sl_needs_scout} analys#{sl_needs_scout == 1 ? 'is' : 'es'}.</strong> Each contains a window/table-calc function, an exotic visual, or free-form layout that benefits from a tailored conversion approach — identifying them up-front prevents surprises mid-migration.</li>\n"
+  end
+  if sl_retire.positive?
+    html += "    <li><strong>Retire #{sl_retire} analys#{sl_retire == 1 ? 'is' : 'es'}</strong> with zero views. No migration value, and dropping them simplifies the cutover.</li>\n"
+  end
+  unless has_usage
+    html += "    <li><strong>Supply usage data</strong> (CloudTrail / CloudWatch-derived <code>usage.json</code>) to upgrade the shortlist from a complexity-only proxy to a usage-weighted ranking and unlock cold-analysis detection.</li>\n"
+  end
+  html += "    <li><strong>Land any file-based datasets in your warehouse</strong> before converting. S3 / uploaded-file sources are a converter gap — Sigma reads from a warehouse, not directly from S3 objects.</li>\n"
+else
+  html += <<~HTML
+    <li><strong>Enable per-analysis conversion analysis</strong> by running against an Enterprise-edition account. The <code>describe-analysis-definition</code> / <code>describe-data-set</code> APIs are Enterprise-only; on Standard the readout degrades to counts-only.</li>
+    <li><strong>Supply usage data</strong> (CloudTrail / CloudWatch) to add a usage-weighted shortlist.</li>
+  HTML
+end
+
+html += <<~HTML
+  </ol>
+</section>
+
+<footer>
+  Report generated #{h(formatted_date)} · supporting JSON files alongside in the same folder · value basis: #{h(value_basis)}
+</footer>
+
+</main>
+</body>
+</html>
+HTML
+
+out_path = File.join(opts[:out], 'readout.html')
+File.write(out_path, html)
+puts "wrote #{out_path} (#{File.size(out_path)} bytes)"

--- a/quicksight-migration-skills/quicksight-assessment/scripts/render-readout.rb
+++ b/quicksight-migration-skills/quicksight-assessment/scripts/render-readout.rb
@@ -1,0 +1,188 @@
+#!/usr/bin/env ruby
+# Compose <out>/readout.md from inventory.json, complexity.json, shortlist.json.
+#
+# Adapted from powerbi-assessment/scripts/render-readout.rb — the section_block /
+# md_table / md_cell helpers are reused verbatim (vendor-agnostic); the gather-
+# and-fill body is QuickSight-specific (analysis visual mix, calc-field buckets,
+# dataset source types, no license/cost section).
+#
+# Usage:  ruby scripts/render-readout.rb --out /tmp/qs-assessment-<acct>
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--out DIR') { |v| opts[:out] = v }
+  p.on('--template PATH') { |v| opts[:template] = v }
+end.parse!
+abort('--out required') unless opts[:out]
+
+template_path = opts[:template] || File.expand_path('../refs/readout-template.md', __dir__)
+tpl = File.read(template_path)
+
+inventory  = JSON.parse(File.read(File.join(opts[:out], 'inventory.json')))
+complexity_path = File.join(opts[:out], 'complexity.json')
+shortlist_path  = File.join(opts[:out], 'shortlist.json')
+complexity = File.exist?(complexity_path) ? JSON.parse(File.read(complexity_path)) : {}
+shortlist  = File.exist?(shortlist_path)  ? JSON.parse(File.read(shortlist_path))  : nil
+
+shortlist_analyses = shortlist ? (shortlist['analyses'] || []) : []
+has_usage = shortlist && shortlist['usage_available'] == true
+limited_mode = !has_usage
+account = inventory['account'] || {}
+enterprise = account['enterprise'] != false
+
+# -------- helpers (verbatim from powerbi/tableau-assessment) -----------------
+def md_cell(v)
+  v.to_s.gsub('|', '\\|')
+end
+
+def md_table(headers, rows)
+  out = '| ' + headers.map { |h| md_cell(h) }.join(' | ') + " |\n"
+  out += '|' + headers.map { '---' }.join('|') + "|\n"
+  rows.each { |r| out += '| ' + r.map { |c| md_cell(c) }.join(' | ') + " |\n" }
+  out
+end
+
+def section_block(tpl, key, keep)
+  opposite_open = keep ? "{{^#{key}}}" : "{{##{key}}}"
+  kept_open     = keep ? "{{##{key}}}" : "{{^#{key}}}"
+  close         = "{{/#{key}}}"
+  tpl = tpl.gsub(/#{Regexp.escape(opposite_open)}.*?#{Regexp.escape(close)}/m, '')
+  tpl.gsub(/#{Regexp.escape(kept_open)}(.*?)#{Regexp.escape(close)}/m) { $1 }
+end
+
+# -------- gather -------------------------------------------------------------
+eo = inventory['environment_overview'] || {}
+analyses = inventory['analyses'] || []
+datasets = inventory['datasets'] || []
+
+mode = has_usage ? 'Usage + complexity' : 'Complexity-only'
+
+# Section 3 — analysis complexity
+total_calc = { 'a' => 0, 'b' => 0, 'c' => 0 }
+analysis_rows = complexity.values.sort_by { |r| -(r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3) }.map do |r|
+  d = r['calc_buckets'] || {}
+  %w[a b c].each { |k| total_calc[k] += d[k].to_i }
+  [r['name'], r['sheets'], r['visuals'], r['calc_field_count'], r['window_calc_count'],
+   r['parameter_count'], "#{d['a'].to_i}/#{d['b'].to_i}/#{d['c'].to_i}"]
+end
+analyses_table = analysis_rows.empty? ? '_No analyses scanned (definition API unavailable?)._' :
+  md_table(['Analysis', 'Sheets', 'Visuals', 'CalcFields', 'Window', 'Params', 'Calc a/b/c'], analysis_rows)
+
+# Section 3b — visual-kind histogram (account-wide)
+vk = Hash.new(0)
+complexity.each_value { |r| (r['visual_kinds'] || {}).each { |k, n| vk[k] += n } }
+visual_rows = vk.sort_by { |_, n| -n }.map { |k, n| [k, n] }
+visuals_table = visual_rows.empty? ? '_No visuals parsed._' : md_table(['Visual type', 'Count'], visual_rows)
+
+# Section 4 — datasets / source types
+src = Hash.new(0)
+datasets.each { |d| (d['physical_kinds'] || []).each { |k| src[k] += 1 } }
+source_rows = src.sort_by { |_, n| -n }.map { |k, n| [k, n] }
+source_table = source_rows.empty? ? '_No dataset physical sources parsed._' :
+  md_table(['Physical source kind', 'Datasets'], source_rows)
+n_rls = datasets.count { |d| d['rls_enabled'] }
+n_custom_sql = datasets.count { |d| d['has_custom_sql'] }
+
+# Section 6 — priority
+usage_basis = has_usage ? 'by view count' : 'by complexity proxy'
+usage_rows = shortlist_analyses.first(15).map do |r|
+  [r['name'], r['sheets'], r['visuals'],
+   has_usage ? (r['views'] || 0) : '—',
+   has_usage ? (r['users'] || 0) : '—']
+end
+usage_table = usage_rows.empty? ? '_No analyses._' :
+  md_table(['Analysis', 'Sheets', 'Visuals', 'Views', 'Users'], usage_rows)
+n_cold = has_usage ? shortlist_analyses.count { |r| r['views'].to_i.zero? } : 0
+
+# Section 7 — shortlist
+value_basis = shortlist ? shortlist['value_basis'] : 'n/a'
+shortlist_rows = shortlist_analyses.first(15).map do |r|
+  tag_md = case r['tag']
+           when 'migrate-first'   then '**migrate-first**'
+           when 'needs-gap-scout' then '⚠️ needs-gap-scout'
+           when 'retire'          then '🗑 retire'
+           else r['tag'] end
+  d = r['calc_buckets'] || {}
+  [r['name'], has_usage ? (r['views'] || 0) : '—',
+   "#{d['a'].to_i}/#{d['b'].to_i}/#{d['c'].to_i}",
+   "#{r['auto']}/#{r['hint']}/#{r['manual']}/#{r['unhandled']}",
+   format('%.1f', r['value']), format('%.2f', r['score']), tag_md]
+end
+shortlist_table = shortlist_rows.empty? ? '_No shortlist._' :
+  md_table(['Analysis', 'Views', 'Calc a/b/c', 'Auto/Hint/Man/Unh', 'Value', 'Score', 'Tag'], shortlist_rows)
+top5 = shortlist_analyses.first(5)
+shortlist_top_n = top5.size
+shortlist_total_unhandled = top5.sum { |r| r['unhandled'].to_i }
+n_needs_scout = shortlist_analyses.count { |r| r['tag'] == 'needs-gap-scout' }
+n_retire = shortlist_analyses.count { |r| r['tag'] == 'retire' }
+
+# Section 8 — per-analysis complexity
+crows = complexity.values.sort_by { |r| -(r['n_unhandled'].to_i * 10 + r['n_manual'].to_i * 3) }.map do |r|
+  [r['name'], r['sheets'], r['visuals'], r['calc_field_count'], r['window_calc_count'],
+   r['rls_role_count'], r['n_manual'], r['n_unhandled'].to_i.positive? ? "**#{r['n_unhandled']}**" : 0]
+end
+complexity_table = crows.empty? ? '_No complexity rows._' :
+  md_table(['Analysis', 'Sheets', 'Visuals', 'CalcFields', 'Window', 'RLS', 'Manual', 'Unhandled'], crows)
+total_unhandled = complexity.values.sum { |r| r['n_unhandled'].to_i }
+n_with_unhandled = complexity.values.count { |r| r['n_unhandled'].to_i.positive? }
+recommended_pilot_n = top5.size
+
+# -------- apply --------------------------------------------------------------
+out = tpl.dup
+out = section_block(out, 'limited_mode_banner', limited_mode)
+out = section_block(out, 'standard_edition_banner', !enterprise)
+out = section_block(out, 'has_usage', has_usage)
+
+repl = {
+  '{{account_name}}'    => (account['account_id'] || File.basename(opts[:out]).sub(/^qs-assessment-/, '')).to_s,
+  '{{region}}'          => account['region'].to_s,
+  '{{edition}}'         => (account['edition'] || 'unknown').to_s,
+  '{{mode}}'            => mode,
+  '{{generated_at}}'    => account['generated_at'] || Time.now.strftime('%Y-%m-%d'),
+  '{{analyses}}'        => eo['analyses'].to_s,
+  '{{dashboards}}'      => eo['dashboards'].to_s,
+  '{{datasets}}'        => eo['datasets'].to_s,
+  '{{data_sources}}'    => eo['data_sources'].to_s,
+  '{{analyses_table}}'  => analyses_table,
+  '{{visuals_table}}'   => visuals_table,
+  '{{total_calc_a}}'    => total_calc['a'].to_s,
+  '{{total_calc_b}}'    => total_calc['b'].to_s,
+  '{{total_calc_c}}'    => total_calc['c'].to_s,
+  '{{source_table}}'    => source_table,
+  '{{n_rls}}'           => n_rls.to_s,
+  '{{n_custom_sql}}'    => n_custom_sql.to_s,
+  '{{usage_basis}}'     => usage_basis,
+  '{{usage_table}}'     => usage_table,
+  '{{n_cold}}'          => n_cold.to_s,
+  '{{value_basis}}'     => value_basis,
+  '{{shortlist_table}}' => shortlist_table,
+  '{{shortlist_top_n}}' => shortlist_top_n.to_s,
+  '{{shortlist_total_unhandled}}' => shortlist_total_unhandled.to_s,
+  '{{complexity_table}}' => complexity_table,
+  '{{total_unhandled}}' => total_unhandled.to_s,
+  '{{n_with_unhandled}}' => n_with_unhandled.to_s,
+  '{{n_needs_scout}}'   => n_needs_scout.to_s,
+  '{{n_retire}}'        => n_retire.to_s,
+  '{{recommended_pilot_n}}' => recommended_pilot_n.to_s
+}
+repl.each { |k, v| out.gsub!(k, v.to_s) }
+
+# Duplicate / consolidation candidates — append the shared detector's Markdown
+# block when the inventory scan found overlapping analyses (flag-not-fake).
+dup_doc = inventory['duplicate_dashboards']
+dup_norm_path = File.join(opts[:out], 'dup-normalized.json')
+if dup_doc && (dup_doc['summary'] || {})['duplicate_groups'].to_i.positive? && File.exist?(dup_norm_path)
+  dd_script = File.join(__dir__, 'dup-dashboards.py')
+  # --md writes the Markdown block to stderr (alongside a one-line summary, which
+  # we drop). Capture stderr; discard stdout (the groups JSON, already on disk).
+  md = `python3 #{dd_script.inspect} --in #{dup_norm_path.inspect} --out #{File.join(opts[:out], 'dup-groups.json').inspect} --md 2>&1 1>/dev/null`
+  md = md.lines.reject { |l| l.start_with?('[dup-dashboards]') }.join
+  out += "\n\n" + md unless md.strip.empty?
+end
+
+readout_path = File.join(opts[:out], 'readout.md')
+File.write(readout_path, out)
+puts "wrote #{readout_path}"

--- a/quicksight-migration-skills/quicksight-assessment/scripts/requirements.txt
+++ b/quicksight-migration-skills/quicksight-assessment/scripts/requirements.txt
@@ -1,0 +1,8 @@
+# QuickSight assessment — Python deps.
+# The inventory script shells out to the AWS CLI via subprocess (NO boto3), so
+# the only hard requirement is the AWS CLI v2 on PATH, configured for the
+# target account. The standard library covers JSON/argparse/subprocess.
+#
+# (No third-party Python packages are required. The AWS CLI itself is installed
+# separately — see https://docs.aws.amazon.com/cli/ — and authenticated via
+# `aws configure`, `aws sso login`, or gimme-aws-creds for Okta orgs.)

--- a/quicksight-migration-skills/quicksight-assessment/scripts/score-quicksight-complexity.rb
+++ b/quicksight-migration-skills/quicksight-assessment/scripts/score-quicksight-complexity.rb
@@ -1,0 +1,122 @@
+#!/usr/bin/env ruby
+# Phase 3 (QuickSight): derive per-analysis migration-effort and convertibility
+# scores from inventory.json (written by quicksight-inventory.py) and emit
+# complexity.json.
+#
+# QuickSight's complexity lives in TWO places — the analysis (visual-kind mix,
+# calc fields, parameters, FilterGroups, layout shape) and its datasets
+# (source type, custom-sql, joins, data-prep transforms, RLS/CLS). An analysis
+# inherits its datasets' burden via dataset_ids.
+#
+# Convertibility buckets (grounded in refs/migration-test-slate.md):
+#   easy   → auto      (built visual + mechanical calc + relational/customsql source)
+#   medium → manual    (mid-catalog visual / restructuring calc / joins+transforms / params+filtergroups / RLS)
+#   hard   → unhandled (window-table-calc funcs / map+sankey+insight+custom+plugin visuals / free-form+section layout / dataset-of-datasets)
+#
+# These map onto the same four-tier vocabulary tableau-assessment uses so the
+# downstream renderer/shortlist code is shared:
+#   easy → auto      medium → manual      hard → unhandled
+# (no "hint" tier analog — n_hint stays 0; kept for renderer/shortlist compat.)
+#
+# Usage:  ruby scripts/score-quicksight-complexity.rb --out /tmp/qs-assessment-<acct>
+# Reads:  <out>/inventory.json
+# Writes: <out>/complexity.json   (keyed by analysis id, tableau-compatible shape)
+
+require 'json'
+require 'optparse'
+
+opts = {}
+OptionParser.new { |p| p.on('--out DIR') { |v| opts[:out] = v } }.parse!
+abort('--out required') unless opts[:out]
+
+inv = JSON.parse(File.read(File.join(opts[:out], 'inventory.json')))
+
+datasets_by_id = (inv['datasets'] || []).each_with_object({}) { |d, h| h[d['id']] = d }
+
+complexity = {}
+(inv['analyses'] || []).each do |an|
+  buckets = an['calc_buckets'] || { 'a' => 0, 'b' => 0, 'c' => 0 }
+  ca = buckets['a'].to_i
+  cb = buckets['b'].to_i
+  cc = buckets['c'].to_i
+
+  visuals_built     = an['visuals_built'].to_i
+  visuals_mid       = an['visuals_mid'].to_i
+  visuals_unhandled = an['visuals_unhandled'].to_i
+  window_calcs      = an['window_calc_count'].to_i
+  params            = an['parameter_count'].to_i
+  filter_groups     = an['filter_group_count'].to_i
+  free_form         = an['free_form_sheets'].to_i
+  section_based     = an['section_based_sheets'].to_i
+  sheets            = an['sheet_count'].to_i
+  visuals           = an['visual_count'].to_i
+
+  # roll up dataset-level burden
+  ds = (an['dataset_ids'] || []).map { |id| datasets_by_id[id] }.compact
+  ds_custom_sql = ds.count { |d| d['has_custom_sql'] }
+  ds_joins      = ds.count { |d| d['has_joins'] }
+  ds_transforms = ds.sum { |d| d['transform_count'].to_i }
+  ds_rls        = ds.count { |d| d['rls_enabled'] }
+  ds_cls        = ds.count { |d| d['cls_enabled'] }
+  ds_exotic_src = ds.count { |d| (d['physical_kinds'] || []).any? { |k| %w[S3Source].include?(k) } }
+
+  # Map → tableau-compatible feature tiers.
+  n_auto      = ca + visuals_built
+  n_hint      = 0
+  n_manual    = cb + visuals_mid + ds_joins + (ds_transforms.positive? ? 1 : 0) +
+                (params.positive? ? 1 : 0) + ds_rls + ds_cls
+  n_unhandled = cc + visuals_unhandled + free_form + section_based +
+                (filter_groups.positive? ? 1 : 0) + ds_exotic_src
+
+  features = []
+  features << { 'name' => 'calc_mechanical', 'status' => 'auto',      'count' => ca } if ca.positive?
+  features << { 'name' => 'calc_restructure', 'status' => 'manual',   'count' => cb } if cb.positive?
+  features << { 'name' => 'calc_window',      'status' => 'unhandled', 'count' => cc } if cc.positive?
+  features << { 'name' => 'visuals_built',    'status' => 'auto',      'count' => visuals_built } if visuals_built.positive?
+  features << { 'name' => 'visuals_rebuild',  'status' => 'manual',    'count' => visuals_mid } if visuals_mid.positive?
+  features << { 'name' => 'visuals_exotic',   'status' => 'unhandled', 'count' => visuals_unhandled } if visuals_unhandled.positive?
+  features << { 'name' => 'dataset_joins',    'status' => 'manual',    'count' => ds_joins } if ds_joins.positive?
+  features << { 'name' => 'dataset_transforms', 'status' => 'manual',  'count' => ds_transforms } if ds_transforms.positive?
+  features << { 'name' => 'parameters',       'status' => 'manual',    'count' => params } if params.positive?
+  features << { 'name' => 'filter_groups',    'status' => 'unhandled', 'count' => filter_groups } if filter_groups.positive?
+  features << { 'name' => 'rls_cls',          'status' => 'manual',    'count' => ds_rls + ds_cls } if (ds_rls + ds_cls).positive?
+  features << { 'name' => 'free_form_layout', 'status' => 'unhandled', 'count' => free_form + section_based } if (free_form + section_based).positive?
+  features << { 'name' => 'exotic_source',    'status' => 'unhandled', 'count' => ds_exotic_src } if ds_exotic_src.positive?
+
+  source_types = ds.flat_map { |d| d['physical_kinds'] || [] }.uniq.sort
+
+  complexity[an['id']] = {
+    'name'              => an['name'],
+    'sheets'            => sheets,
+    'visuals'           => visuals,
+    'visual_kinds'      => an['visual_kinds'] || {},
+    'calc_field_count'  => an['calc_field_count'].to_i,
+    'window_calc_count' => window_calcs,
+    'parameter_count'   => params,
+    'filter_group_count' => filter_groups,
+    'dataset_count'     => ds.size,
+    'dataset_source_types' => source_types,
+    'has_custom_sql'    => ds_custom_sql.positive?,
+    'has_joins'         => ds_joins.positive?,
+    'rls_role_count'    => ds_rls,
+    'cls_count'         => ds_cls,
+    'calc_buckets'      => { 'a' => ca, 'b' => cb, 'c' => cc },
+    'twb_size_kb'       => 0, # n/a; kept for renderer compat
+    'n_features'        => n_auto + n_hint + n_manual + n_unhandled,
+    'n_auto'            => n_auto,
+    'n_hint'            => n_hint,
+    'n_manual'          => n_manual,
+    'n_unhandled'       => n_unhandled,
+    'features'          => features
+  }
+end
+
+File.write(File.join(opts[:out], 'complexity.json'), JSON.pretty_generate(complexity))
+puts "wrote complexity.json (#{complexity.size} analyses)"
+puts
+printf "%-40s %4s %4s %5s %4s %5s %5s\n", 'Analysis', 'sht', 'vis', 'calc', 'win', 'manl', 'unhd'
+complexity.each_value do |r|
+  printf "%-40s %4d %4d %5d %4d %5d %5d\n",
+    (r['name'] || '')[0, 39], r['sheets'], r['visuals'], r['calc_field_count'],
+    r['window_calc_count'], r['n_manual'], r['n_unhandled']
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/SKILL.md
+++ b/quicksight-migration-skills/quicksight-to-sigma/SKILL.md
@@ -1,0 +1,254 @@
+---
+name: quicksight-to-sigma
+description: Convert an Amazon QuickSight analysis or dashboard into a Sigma data model and matching dashboard. Use when the user has a QuickSight analysis/dashboard and wants to recreate it in Sigma. Covers AWS-CLI extraction of the analysis definition + datasets + data sources, calc-field / data-prep translation via the convert_quicksight_to_sigma MCP, posting the data model + workbook via the Sigma REST API, layout, and parity verification against the same warehouse.
+user-invocable: true
+---
+
+# QuickSight → Sigma
+
+## Preflight the workbook spec before POST (mandatory)
+
+Before POSTing any workbook spec, run `ruby scripts/lib/preflight_lint.rb <spec.json>` — it exits 1 with a precise message on the two migration-killer bugs: a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows), and a malformed `control` (missing `id`/`controlId`/`controlType` or nesting value fields under a `value` object instead of flat, a non-double-nested `source`, or a list control wired to neither `source` nor `filters` — a filters-only list control is valid). Fix every violation first — never POST past it, and **never conclude a feature is "unsupported" from an `Invalid kind` error** (it means the inner fields are wrong). Verified shapes: `sigma-workbooks` `controls.md` / `tables.md`.
+
+## Phase 0 — Choose where to build (ask first when no destination given)
+
+Don't silently land the migrated data model + workbook in an auto-picked folder.
+If the user didn't supply a destination (no `--folder <id-or-name>`), ASK before building:
+
+1. `ruby scripts/pick-destination.rb list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root),
+   an existing **folder**, **My Documents** (when non-null — null for service tokens), or
+   **create a new folder**: `ruby scripts/pick-destination.rb create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder <id>` (the downstream `--fixup` step requires a folderId).
+
+If a destination is already supplied, honor it silently — don't ask.
+
+> Status: **foundation** (converter MCP + browser shipped 2026-05-28).
+> Beads: converter = `beads-sigma-j5e`; CustomSql/DIRECT_QUERY fixup = `beads-sigma-vy4k`.
+> Defers to: `sigma-workbooks` (canonical workbook spec), `sigma-data-models` (DM spec), the `convert_quicksight_to_sigma` MCP tool, and the shared vendor-neutral Sigma-side scripts (`post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `verify-parity.rb`) reused across the migration skills.
+
+## What's proven (the happy path)
+```
+1. AUTH      AWS CLI → QuickSight (Enterprise edition REQUIRED); Sigma creds via get-token.sh
+2. DISCOVER  describe-analysis-definition + describe-data-set(s) + describe-data-source(s)  → quicksight-discover.py → signals.json
+3. CONVERT   convert_quicksight_to_sigma MCP (analysis.json + dataset jsons + connectionId)  → Sigma DM JSON      [MCP gate]
+4. POST DM   fixup (name elements + passthrough cols, rewrite sql refs, schemaVersion=1) → validate → POST /v2/dataModels/spec
+5. WORKBOOK  master tables per DM element + chart elements mirroring the QS visuals → POST /v2/workbooks/spec
+6. LAYOUT    QS grid x,y,w,h → 24-col layout XML → put-layout.rb
+7. VERIFY    sigma-mcp-v2 query each element returns real rows; Phase 6 parity vs the QuickSight aggregation    [hard gate]
+```
+
+See `refs/migration-test-slate.md` for the complexity taxonomy + 20-dashboard test slate that grounds the converter's coverage and known gaps.
+
+## One command (preferred): `scripts/migrate-quicksight.rb`
+
+The single-process orchestrator chains every phase below — discover (live AWS or `--from-fixtures <dir>`), convert (local MCP build, or `convert-model.rb --emit-mcp` gate + `--converted` resume), the **Phase 3.5 DM-reuse check** (`qs-dm-signature.py` + `find-or-pick-dm.rb`; **reuse-first** — auto-reuses an existing DM covering all the analysis's source tables, `--reuse-dm <id>` pins one, `--skip-reuse-check` forces build new), fixup `--folder-id` → validate → post-and-readback, workbook build, layout, then the **two-pass Phase 7 parity** (`phase6-parity-quicksight.rb` emits the per-chart query list and gates; write `parity-expected.json` + `parity-actuals.json` and re-run the SAME command — phases 1–5 skip automatically) and the `assert-phase6-ran.rb --workdir` hard gate:
+
+```bash
+ruby scripts/migrate-quicksight.rb \
+  --analysis-id <ID> --account-id <ACCT> --region us-east-1 --profile <P> \
+  --connection <SIGMA_CONN_UUID> --folder <FOLDER_ID> \
+  [--database DB --schema SCH] [--name "My Dashboard"] [--out DIR] [--yes]
+# offline / fixtures: swap the first line for --from-fixtures fixtures/
+```
+
+Exit 0 = parity + hard gate green; exit 10 = a gate (converter MCP / parity collection / OPEN QUESTIONS) printed its exact resume command; exit 3 = parity fail. Each phase prints a visible header — it is not a black box. The per-script phases below remain the reference for running any stage by hand.
+
+`--folder` accepts a folder **id or exact name** (name is looked up via `/v2/files`; ambiguous names abort with candidates). Re-running the same command with the same `--out` after a mid-run crash is **idempotent**: a DM/workbook already posted by that workdir is detected (dm-readback.json / wb-id.txt), verified live, and reused — never duplicated. Use a fresh `--out` for a fresh build.
+
+## Phase 1 — Auth
+
+**QuickSight (AWS CLI).**
+- The `describe-analysis-definition`, `describe-dashboard-definition`, and `describe-data-set` APIs are **Enterprise-edition only**. A Standard-edition account rejects them — there is no extraction path on Standard. Confirm the edition first.
+- QuickSight's **identity region is often `us-east-1`** even when the data lives elsewhere; the analysis/dataset/data-source resources are read from the identity region. Pass `--region us-east-1` unless you know the account is regionalized differently.
+- Auth is whatever the AWS CLI / boto3 is already configured with: a named `--profile`, SSO (`aws sso login`), or — for Okta-fronted orgs — `gimme-aws-creds` writing a profile. The discovery script uses an **in-process boto3 client when boto3 is importable** (one session for the whole run) and only **falls back to shelling out to `aws quicksight ...`** when it isn't — boto3 is NOT a hard dependency, and `QS_FORCE_CLI=1` forces the CLI path.
+- You need the account id (`aws sts get-caller-identity`) and the analysis (or dashboard) id.
+
+**Sigma.** Same as the other migration skills: `SIGMA_CLIENT_ID` / `SIGMA_CLIENT_SECRET` → `scripts/get-token.sh` exchanges them for a `SIGMA_API_TOKEN`. You also need a **Sigma connection** that reaches the same warehouse the QuickSight datasets query (its `connection_id` feeds the converter), and a target **folder id**.
+
+## Phase 2 — Discover
+
+```bash
+python3 scripts/quicksight-discover.py \
+  --account-id <ACCOUNT_ID> --region <REGION> --profile <PROFILE> \
+  --analysis-id <ANALYSIS_ID> \
+  --out-dir ~/quicksight-migration/<name>
+# (or --dashboard-id <DASHBOARD_ID> instead of --analysis-id)
+```
+
+Pulls `describe-analysis-definition` (or `-dashboard-definition`) + `describe-data-set` for every `DataSetIdentifierDeclarations` entry + `describe-data-source` for each referenced source, and writes into the out-dir:
+- `analysis.json` — the full describe-*-definition response (the converter's primary input).
+- `datasets/<id>.json` — one per dataset (PhysicalTableMap, LogicalTableMap/transforms, calc fields, output columns).
+- `datasources/<id>.json` — one per source (the `Type` tells you Snowflake / Redshift / Athena / S3 / SaaS).
+- `signals.json` — normalized: per-sheet visuals (type + VisualId + title + referenced ColumnNames), calc fields, parameters, datasets, sources. Drives the convert + workbook + layout phases.
+- `timings.json` — per-call wall clock + transport; **always written**.
+
+### Fast discovery (designed for 20-40 dashboard estates sharing datasets)
+- **In-process boto3 transport.** Each `aws` CLI subprocess pays a 0.4-0.7s interpreter-startup tax (measured ~0.7s wall); a 1-analysis discovery makes 4-5 calls and an estate re-pays it per dashboard. With boto3 importable, ONE session serves every call; the CLI fallback keeps zero-dependency installs working (identical call/response shapes — boto3 responses are normalized: datetimes → ISO strings, `ResponseMetadata` stripped).
+- **Estate-level dataset cache** (`/tmp/qs-estate-cache/<acct>__<region>/`, override `QS_ESTATE_CACHE`): describe responses cached keyed **DataSetArn + LastUpdatedTime** — shared datasets are described ONCE per estate, not per dashboard. Freshness is validated against ONE `list-data-sets` call per process; any LastUpdatedTime mismatch (or a denied/empty listing) re-describes. **Data sources are described once, lazily** and cached without a probe (they change rarely). `--no-cache` bypasses, `--refresh-cache` forces re-describe.
+- **Batch mode**: `--analysis-ids a,b,c --pool 4` (cap 8) runs per-analysis discovery in parallel into `<out-dir>/<id>/`, sharing the estate cache with single-flight de-duplication (concurrent threads needing the same dataset trigger exactly one describe).
+- **Test coverage (live AWS is IAM-blocked — see below)**: `python3 scripts/tests/test-quicksight-discover.py` — 11 tests covering both transports (fake-boto3 injection + stubbed CLI), datetime normalization, cache hit/invalidation/single-flight, batch mode, and the offline fixture path. **Still awaiting live-AWS validation**: real boto3 session/profile auth, real `list-data-sets` pagination + permissions, Enterprise-edition `describe-*-definition` latency, and measured before/after numbers on a real estate. The mocked harness + the `--from-fixtures` E2E (`migrate-quicksight.rb`, parity 5/5 strict) are the offline proof.
+
+## Phase 3 — Convert (MCP gate)
+
+```bash
+ruby scripts/convert-model.rb --emit-mcp \
+  --discover-dir ~/quicksight-migration/<name> \
+  --connection-id <SIGMA_CONNECTION_ID> \
+  [--database <DB> --schema <SCHEMA>]
+```
+
+This prints the exact `convert_quicksight_to_sigma` MCP-tool call — `files` = `analysis.json` + each `datasets/*.json`, plus `connection_id` (and `database`/`schema` overrides if a dataset's source path is incomplete). **The agent then runs that MCP tool** and saves the returned Sigma data-model JSON (e.g. `converter-out.json`).
+
+What the converter handles vs. what it doesn't (see `refs/migration-test-slate.md` for the full taxonomy):
+- **Handled**: RelationalTable, CustomSql, JoinInstruction, DataTransforms (CreateColumns/Rename/Cast/Filter/Project), ~40 calc-field functions (`ifelse`→`If`, `switch`→nested `If`), parameters → Sigma controls. KPI / bar / line / donut/pie visuals on the workbook side.
+- **Gaps (degrade to `/* TODO */` placeholder or skipped)**: window / table-calc functions (`sumOver`, `runningSum`, `rank`, `percentOfTotal`, `periodOverPeriod*`, `window*`, `percentile*Over`); S3Source & SaaSTable physical sources; analysis-level FilterGroups; ColumnConfigurations (formatting); dataset-of-datasets. Un-migratable visuals (Insight ML, CustomContent, Plugin, Sankey, map family) → emit a partial migration + warning manifest; never call these "failed".
+
+For an untranslated calc-field expression, spawn the **gap-scout subagent** (see `scripts/gap-scout.md`): it proposes a Sigma formula, validates it against the live DM via `scripts/scout-validate-and-persist.rb`, and on success persists a rule to `~/.quicksight-to-sigma/learned-rules.yaml` (customer home — `git pull` can't clobber; the build script auto-applies it next run via `LearnedRules.load`). On failure the scout returns an **opt-in** `escalate-gap.py` command — filing a tracking issue is never automatic: run the returned `escalation.dry_run_cmd` to draft the issue (shows target repo + dedupe), show the user, and only re-run with `--yes` if they accept. Calc-field gaps route to the converter repos (`sigma-data-model-manager` + `sigma-data-model-mcp`, mirrored) with a cross-linked bead.
+
+## Phase 3.5 — Reuse an existing DM? (avoid sprawl — mirrors tableau Phase 1.5 / powerbi Phase 3.5)
+
+Before Phase 4 POSTs a NEW data model, check whether an existing Sigma DM already covers
+the same warehouse tables (don't add a 4th near-identical "Orders" DM):
+
+```bash
+python3 scripts/qs-dm-signature.py --discover-dir ~/quicksight-migration/<name> \
+  --out dm-signature.json
+ruby scripts/find-or-pick-dm.rb --workbook-signature dm-signature.json \
+  --out dm-match.json --auto-pick           # exit 0 = candidate ≥ min-score
+```
+
+`qs-dm-signature.py` derives `{warehouse_tables, referenced_columns}` from the Phase-2
+dataset JSONs (RelationalTable FQNs; CustomSql tables lifted from the SQL's FROM/JOIN;
+calc columns from CreateColumnsOperation). Decision:
+- **Score ≥ 0.6** → **ASK the user** reuse-vs-new: surface the candidate name, matched cols
+  (N/M), and the inherited-extras warning from `dm-match.json`. If they reuse, run a
+  **shape preflight** first — read the candidate DM's spec back and confirm every column
+  the analysis references resolves on the element you'll wire to (no `error` columns; fact
+  vs separate-dim location) — then **skip Phase 4** and point Phase 5's masters at the
+  matched `recommended_dm_id` + its element ids. With `--auto-pick` a clear winner (no tie
+  within 0.05) skips the prompt — still WARN about inherited columns/RLS/metrics.
+- **Score < 0.6** → build new (Phase 4) and TELL the user no reusable DM was found.
+
+## Phase 4 — Fixup + POST the data model
+
+The converter output needs fixups before `POST /v2/dataModels/spec` (gap `beads-sigma-vy4k`: CustomSql / DIRECT_QUERY elements come back nameless, and sql refs need rewriting):
+
+```bash
+ruby scripts/convert-model.rb --fixup \
+  --in converter-out.json \
+  --discover-dir ~/quicksight-migration/<name> \
+  --folder-id <FOLDER_ID> \
+  --out dm-spec.json
+ruby scripts/validate-spec.rb --type datamodel dm-spec.json
+ruby scripts/post-and-readback.rb --type datamodel --spec dm-spec.json --out dm-readback.json
+```
+
+`--fixup` forces `schemaVersion: 1`, names every element + its passthrough columns (so workbook masters can reference them), rewrites sql refs to `[Custom SQL/<ALIAS>]` form, and injects `folderId`. `post-and-readback.rb` confirms every column resolved to a concrete type — **no `error` columns**.
+
+## Phase 5 — Build the workbook
+
+```bash
+ruby scripts/build-workbook-from-quicksight.rb \
+  --analysis ~/quicksight-migration/<name>/analysis.json \
+  --dm-readback dm-readback.json \
+  --folder-id <FOLDER_ID> \
+  --out wb-spec.json
+ruby scripts/post-and-readback.rb --type workbook --spec wb-spec.json --out wb-readback.json
+```
+
+Mirrors the QuickSight visuals as Sigma elements off Data-page master tables, and emits a `wb-spec.map.json` (visualId → element-id) the layout phase consumes. Element shapes:
+- Workbook element column refs use **`[<source element name>/<col>]`** (the source element name comes from the DM element name set in Phase 4).
+- bar/line: `xAxis:{columnId}`, `yAxis:{columnIds:[...]}`.
+- **pie/donut: `color:{id}` + `value:{id}`** (NOT xAxis/yAxis).
+- KPI: a single measure formula wrapping the master column.
+
+## Phase 6 — Layout (do NOT skip — stacked ≠ done)
+
+```bash
+ruby scripts/build-quicksight-layout.rb \
+  --analysis ~/quicksight-migration/<name>/analysis.json \
+  --map wb-spec.map.json \
+  --out layout.xml
+ruby scripts/put-layout.rb --workbook <WORKBOOK_ID> --layout layout.xml
+```
+
+Maps each QuickSight visual's grid cell → a 24-col Sigma layout. **QuickSight grid lines are 1-based** — `ColumnIndex`/`RowIndex` start at 1, so subtract 1 before scaling to the 0-based Sigma grid. Free-form / section-based QS layouts are approximated to the grid.
+
+## Visual QA (mandatory gate — never skip)
+A workbook that POSTs 200 and passes parity can still be visually broken — **overlapping tiles, clipped KPI titles, dead zones, filters over charts.** QuickSight FreeForm pixel coords can overlap and Sigma's grid has no z-order; the build collapses collisions, but this visual gate is the safety net.
+
+1. Render every page to PNG (token first: `eval "$(scripts/get-token.sh)"`):
+   `python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/<page>.png --w 1600`
+2. **Read each PNG** and check it against `refs/layout-visual-qa.md` (no overlaps/stacking, no dead zones, controls in their own band, no clipped titles, even heights, right chart kind/format).
+3. Fix any failure in the spec — for multi-page workbooks use `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit → push) — then **re-render and re-read**.
+4. Declare the migration done on a **clean render**, not on HTTP 200.
+
+## Phase 7 — Parity (hard gate)
+
+```bash
+# PASS 1 — plan + per-chart fetch instructions (reads the live workbook spec)
+ruby scripts/phase6-parity-quicksight.rb --workdir /tmp/<name> --workbook-id <WORKBOOK_ID>
+# ... run the printed mcp__sigma-mcp-v2__query calls (Sigma ACTUAL rows) and
+#     compute EXPECTED rows from the warehouse with the same dim+aggregation,
+#     writing parity-actuals.json + parity-expected.json into the workdir ...
+# PASS 2 — verify + write the parity-final.json sentinel
+ruby scripts/phase6-parity-quicksight.rb --workdir /tmp/<name> --finalize
+# hard gate — must exit 0 before declaring GREEN
+ruby scripts/assert-phase6-ran.rb --workdir /tmp/<name> --workbook-id <WORKBOOK_ID>
+```
+
+**POST success ≠ working.** You MUST query-verify the built elements:
+- `sigma-mcp-v2 query` each element → confirm real rows (not blank / not all `error`).
+- True parity: compare each Sigma aggregation against the same aggregation computed from the QuickSight side (or the warehouse). `assert-phase6-ran.rb` is a hard gate — a subagent must run it and it must pass before reporting success.
+- `assert-phase6-ran.rb` runs 7 gates incl. layout lint (gate 6) and **control lint** (gate 7 — dead controls / ghost targets / partial same-page reach / `control-scope.json` coverage; `--skip-control-lint` escape; see `refs/control-parity.md`).
+- Optional flip test when the dashboard had parameters/filter controls: `ruby scripts/probe-controls.rb --workbook-id <wb> --check-out-of-closure` — runtime proof controls actually filter (export API `parameters` is the only way to set a control programmatically; MCP queries see saved defaults only).
+- **mcp-v2 warehouse-side (EXPECTED) queries can NOT use the raw warehouse FQN**
+  (`SELECT … FROM DB.SCHEMA.TABLE` fails): with `type=connection` the table must
+  be addressed as `"connection"."<inodeId>"`, where `<inodeId>` is the table's
+  inode from `GET /v2/connections/{connectionId}/lookup?path=…` (or a prior DM
+  spec's `source.path`). The Sigma-ACTUAL side (`type=workbook` →
+  `"workbook"."<elementId>"`) follows the same quoting pattern.
+
+## Gotchas (carry these forward)
+- **Enterprise edition is mandatory** for the `describe-*-definition` APIs. Standard rejects them outright — there's no fallback extraction.
+- **QuickSight identity region is usually `us-east-1`** — resources read from the identity region, not the data region.
+- **CustomSql / DIRECT_QUERY converter gap (`beads-sigma-vy4k`)**: those elements come back nameless and with raw sql refs; the `--fixup` step names them + rewrites refs to `[Custom SQL/<ALIAS>]`. Don't post the converter output unfixed.
+- **Workbook element refs** are `[<source element name>/<col>]`, where the source element name is the DM element name set during fixup.
+- **pie/donut** use `color:{id}` + `value:{id}`, not the bar/line `xAxis`/`yAxis` shape.
+- **Layout grid is 1-based** in QuickSight — offset by 1 before scaling to Sigma's grid.
+- **Window/table-calc functions are a known gap** — they degrade to a `/* TODO */` placeholder; verify the graceful degradation rather than treating it as a failure, and surface it in the migration warning manifest.
+
+### Carried forward from the first live customer run (Arine, RCA `refs/rca-arine-2026-06-17.md`)
+- **`PUT /workbooks/{id}/spec` WIPES the applied layout.** Layout is applied separately by `put-layout.rb`, so **always re-run `put-layout` after every spec PUT**. Worse: a **failed** spec PUT (4xx) followed by a layout PUT leaves the workbook referencing layout elements that don't exist in the spec → the whole page renders **N/A / blank**. If metrics show N/A after an edit, check spec/layout consistency first — query the element (it usually still returns data).
+- **Text element `body` rejects a bare `<p>`** — `<p> carries no non-default block style or alignment`. Use `<p class="p-small">`, `<p style="text-align: …">`, or a `#` heading / plain paragraph.
+- **Dynamic text date format = strftime, UNQUOTED**: `{{Max([El/Col]) | %B %-d, %Y}}` → "June 17, 2026". Quoted formats leak the quotes; `DateFormat()` echoes the pattern literally; `Date()` doesn't strip the time.
+- **QS `*_FLAG` columns are often warehouse BOOLEAN even when QS types them INTEGER** — `[flag] = 1` throws `Argument 2 invalid for '='` at query time. Verify via `/v2/connections/tables/{inode}/columns` and emit a boolean-safe predicate.
+- **Database name is usually NOT in the export** (it lives in the DataSource, which `describe-dashboard-definition` omits). Resolve it via `POST /v2/connection/{connectionId}/lookup` (**singular** `connection`) with `{"path":[DB,SCHEMA,TABLE]}`, probing candidate DBs until 200. A schema not granted to the connection's role 404s even when the DB resolves.
+- **Parity needs the customer's runtime control state + a rendered reference.** A customer screenshot is often filtered to a value that is NOT a saved default (e.g. `Organization = "Arine Demo Organization"` — 0 occurrences in the definition). Capture which control values are active before comparing, and request a screenshot + `describe-theme <id>` up front (the theme — hence the categorical color palette — is not in the definition export).
+- **Verify without MCP via the Export API**: when the customer org isn't wired to `sigma-mcp-v2`, query an element with `POST /v2/workbooks/{wb}/export {elementId, format:{type:csv}}` → poll `GET /v2/query/{queryId}/download`. This is how you confirm real values (and filtered parity) on any org.
+
+## Reuse, don't reinvent
+These vendor-agnostic Sigma-side scripts are reused across the migration skills: `get-token.sh`, `lib/sigma_rest.rb`, `post-and-readback.rb`, `put-layout.rb`, `find-or-pick-dm.rb`, `validate-spec.rb`, `verify-parity.rb`, `cleanup-orphan-workbooks.rb`. Only the QuickSight-specific stages (`quicksight-discover.py`, `convert-model.rb`, `build-workbook-from-quicksight.rb`, `build-quicksight-layout.rb`, `phase6-parity-quicksight.rb`, `qs-dm-signature.py`) are new. `scripts/sigma-export-png.py` renders a workbook page to PNG for the mandatory **Visual QA** gate (read each image against `refs/layout-visual-qa.md`).
+
+
+## Security: Row- & Column-Level Security (RLS/CLS)
+
+Row/column security is **never silently dropped and never silently ported** — and it is handled by the **skill**, not baked into the converted model. The converter (`convert_quicksight_to_sigma`) only **detects and reports** security in `result.security[]`; it does **not** inject it into the data-model spec (a stateless converter can't create Sigma user attributes or assign members, so an injected `CurrentUserAttributeText` filter would fail-closed to 0 rows). This skill provisions + applies it after the model is posted.
+
+**What is detected for QuickSight:** `RowLevelPermissionTagConfiguration` (tag-based RLS to a user-attribute), `ColumnLevelPermissionRules` (to CLS). A `RowLevelPermissionDataSet` is flagged (its grant rows live in a separate dataset not in the export — recreate as a user attribute).
+
+**Flow (only runs when `result.security` is non-empty — zero overhead otherwise):**
+1. **Convert + post** the data model as usual. Capture the `dataModelId` and the converter's `result.security[]` (write it to `security.json`).
+2. **Gate (opt-in/out, default _Port_).** Show a plain-English summary of each detected rule + recommended Sigma mapping, then ask: **Port** (recommended) / **Customize** (review per-rule attribute/team mapping + username-to-email reconciliation) / **Skip** (migrated model shows ALL rows to everyone). Reuse-first: existing Sigma user attributes/teams are matched before creating new ones.
+3. **Provision + apply** with the shared engine:
+   ```bash
+   eval "$(scripts/get-token.sh)"
+   python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <dataModelId>            # plan only (default)
+   python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <dataModelId> --provision --apply
+   ```
+   `--provision` creates missing user attributes / teams; `--apply` PATCHes the boolean RLS calc column + fail-closed `filters` entry and the `columnSecurities` (CLS) onto the matching element.
+4. **Assign membership.** Assign per-user attribute values / team membership from the source tool's group/role membership (the converter reports the attribute/team names; the values come from the source's user mapping).
+
+**Skip is loud:** opting out leaves the migrated model with NO RLS — all rows visible to everyone. Confirm before skipping.
+

--- a/quicksight-migration-skills/quicksight-to-sigma/fixtures/dataset-orders-enriched.json
+++ b/quicksight-migration-skills/quicksight-to-sigma/fixtures/dataset-orders-enriched.json
@@ -1,0 +1,218 @@
+{
+    "Status": 200,
+    "DataSet": {
+        "Arn": "arn:aws:quicksight:us-east-1:153722385948:dataset/orders-enriched",
+        "DataSetId": "orders-enriched",
+        "Name": "Orders Enriched",
+        "CreatedTime": "2026-06-06T07:54:15.422000-04:00",
+        "LastUpdatedTime": "2026-06-06T08:01:57.035000-04:00",
+        "PhysicalTableMap": {
+            "ordersSql": {
+                "CustomSql": {
+                    "DataSourceArn": "arn:aws:quicksight:us-east-1:153722385948:datasource/snowflake-csa-tj",
+                    "Name": "orders_enriched",
+                    "SqlQuery": "select f.ORDER_ID, f.ORDER_CHANNEL, f.ORDER_STATUS, f.QUANTITY_ORDERED, f.NET_REVENUE, f.GROSS_REVENUE, f.NET_PROFIT, f.DISCOUNT_AMOUNT, p.CATEGORY, p.SUBCATEGORY, p.BRAND, c.REGION, c.STATE, c.CUSTOMER_SEGMENT, c.LOYALTY_TIER, d.FULL_DATE, d.YEAR, d.QUARTER, d.MONTH_NUMBER, d.MONTH_NAME from CSA.TJ.ORDER_FACT f left join CSA.TJ.PRODUCT_DIM p on f.PRODUCT_KEY=p.PRODUCT_KEY left join CSA.TJ.CUSTOMER_DIM c on f.CUSTOMER_KEY=c.CUSTOMER_KEY left join CSA.TJ.DATE_DIM d on f.ORDER_DATE_KEY=d.DATE_KEY",
+                    "Columns": [
+                        {
+                            "Name": "ORDER_ID",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "ORDER_CHANNEL",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "ORDER_STATUS",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "QUANTITY_ORDERED",
+                            "Type": "INTEGER"
+                        },
+                        {
+                            "Name": "NET_REVENUE",
+                            "Type": "DECIMAL"
+                        },
+                        {
+                            "Name": "GROSS_REVENUE",
+                            "Type": "DECIMAL"
+                        },
+                        {
+                            "Name": "NET_PROFIT",
+                            "Type": "DECIMAL"
+                        },
+                        {
+                            "Name": "DISCOUNT_AMOUNT",
+                            "Type": "DECIMAL"
+                        },
+                        {
+                            "Name": "CATEGORY",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "SUBCATEGORY",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "BRAND",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "REGION",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "STATE",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "CUSTOMER_SEGMENT",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "LOYALTY_TIER",
+                            "Type": "STRING"
+                        },
+                        {
+                            "Name": "FULL_DATE",
+                            "Type": "DATETIME"
+                        },
+                        {
+                            "Name": "YEAR",
+                            "Type": "INTEGER"
+                        },
+                        {
+                            "Name": "QUARTER",
+                            "Type": "INTEGER"
+                        },
+                        {
+                            "Name": "MONTH_NUMBER",
+                            "Type": "INTEGER"
+                        },
+                        {
+                            "Name": "MONTH_NAME",
+                            "Type": "STRING"
+                        }
+                    ]
+                }
+            }
+        },
+        "LogicalTableMap": {
+            "ordersLogical": {
+                "Alias": "orders_enriched",
+                "Source": {
+                    "PhysicalTableId": "ordersSql"
+                }
+            }
+        },
+        "OutputColumns": [
+            {
+                "Name": "ORDER_ID",
+                "Id": "ordersLogical.ORDER_ID",
+                "Type": "STRING"
+            },
+            {
+                "Name": "ORDER_CHANNEL",
+                "Id": "ordersLogical.ORDER_CHANNEL",
+                "Type": "STRING"
+            },
+            {
+                "Name": "ORDER_STATUS",
+                "Id": "ordersLogical.ORDER_STATUS",
+                "Type": "STRING"
+            },
+            {
+                "Name": "QUANTITY_ORDERED",
+                "Id": "ordersLogical.QUANTITY_ORDERED",
+                "Type": "INTEGER"
+            },
+            {
+                "Name": "NET_REVENUE",
+                "Id": "ordersLogical.NET_REVENUE",
+                "Type": "DECIMAL"
+            },
+            {
+                "Name": "GROSS_REVENUE",
+                "Id": "ordersLogical.GROSS_REVENUE",
+                "Type": "DECIMAL"
+            },
+            {
+                "Name": "NET_PROFIT",
+                "Id": "ordersLogical.NET_PROFIT",
+                "Type": "DECIMAL"
+            },
+            {
+                "Name": "DISCOUNT_AMOUNT",
+                "Id": "ordersLogical.DISCOUNT_AMOUNT",
+                "Type": "DECIMAL"
+            },
+            {
+                "Name": "CATEGORY",
+                "Id": "ordersLogical.CATEGORY",
+                "Type": "STRING"
+            },
+            {
+                "Name": "SUBCATEGORY",
+                "Id": "ordersLogical.SUBCATEGORY",
+                "Type": "STRING"
+            },
+            {
+                "Name": "BRAND",
+                "Id": "ordersLogical.BRAND",
+                "Type": "STRING"
+            },
+            {
+                "Name": "REGION",
+                "Id": "ordersLogical.REGION",
+                "Type": "STRING"
+            },
+            {
+                "Name": "STATE",
+                "Id": "ordersLogical.STATE",
+                "Type": "STRING"
+            },
+            {
+                "Name": "CUSTOMER_SEGMENT",
+                "Id": "ordersLogical.CUSTOMER_SEGMENT",
+                "Type": "STRING"
+            },
+            {
+                "Name": "LOYALTY_TIER",
+                "Id": "ordersLogical.LOYALTY_TIER",
+                "Type": "STRING"
+            },
+            {
+                "Name": "FULL_DATE",
+                "Id": "ordersLogical.FULL_DATE",
+                "Type": "DATETIME"
+            },
+            {
+                "Name": "YEAR",
+                "Id": "ordersLogical.YEAR",
+                "Type": "INTEGER"
+            },
+            {
+                "Name": "QUARTER",
+                "Id": "ordersLogical.QUARTER",
+                "Type": "INTEGER"
+            },
+            {
+                "Name": "MONTH_NUMBER",
+                "Id": "ordersLogical.MONTH_NUMBER",
+                "Type": "INTEGER"
+            },
+            {
+                "Name": "MONTH_NAME",
+                "Id": "ordersLogical.MONTH_NAME",
+                "Type": "STRING"
+            }
+        ],
+        "ImportMode": "DIRECT_QUERY",
+        "ConsumedSpiceCapacityInBytes": 0,
+        "DataSetUsageConfiguration": {
+            "DisableUseAsDirectQuerySource": false,
+            "DisableUseAsImportedSource": false
+        }
+    },
+    "RequestId": "8ae2a6a3-e4b2-46cb-856b-39259276e5c7"
+}

--- a/quicksight-migration-skills/quicksight-to-sigma/fixtures/orders-overview-analysis.json
+++ b/quicksight-migration-skills/quicksight-to-sigma/fixtures/orders-overview-analysis.json
@@ -1,0 +1,401 @@
+{
+    "Status": 200,
+    "AnalysisId": "orders-overview",
+    "Name": "Orders Overview",
+    "ResourceStatus": "UPDATE_SUCCESSFUL",
+    "Definition": {
+        "DataSetIdentifierDeclarations": [
+            {
+                "Identifier": "orders",
+                "DataSetArn": "arn:aws:quicksight:us-east-1:153722385948:dataset/orders-enriched"
+            }
+        ],
+        "Sheets": [
+            {
+                "SheetId": "sheet1",
+                "Name": "Orders Overview",
+                "Visuals": [
+                    {
+                        "KPIVisual": {
+                            "VisualId": "kpiRevenue",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Total Net Revenue"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "Values": [
+                                        {
+                                            "NumericalMeasureField": {
+                                                "FieldId": "kpi-netrev",
+                                                "Column": {
+                                                    "DataSetIdentifier": "orders",
+                                                    "ColumnName": "NET_REVENUE"
+                                                },
+                                                "AggregationFunction": {
+                                                    "SimpleNumericalAggregation": "SUM"
+                                                },
+                                                "FormatConfiguration": {
+                                                    "FormatConfiguration": {
+                                                        "CurrencyDisplayFormatConfiguration": {
+                                                            "SeparatorConfiguration": {
+                                                                "ThousandsSeparator": {
+                                                                    "Symbol": "COMMA",
+                                                                    "Visibility": "VISIBLE"
+                                                                }
+                                                            },
+                                                            "Symbol": "USD",
+                                                            "DecimalPlacesConfiguration": {
+                                                                "DecimalPlaces": 0
+                                                            },
+                                                            "NumberScale": "NONE"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "TargetValues": [],
+                                    "TrendGroups": []
+                                },
+                                "SortConfiguration": {}
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": []
+                        }
+                    },
+                    {
+                        "KPIVisual": {
+                            "VisualId": "kpiMargin",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Avg Profit Margin"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "Values": [
+                                        {
+                                            "NumericalMeasureField": {
+                                                "FieldId": "kpi-margin",
+                                                "Column": {
+                                                    "DataSetIdentifier": "orders",
+                                                    "ColumnName": "Profit Margin"
+                                                },
+                                                "AggregationFunction": {
+                                                    "SimpleNumericalAggregation": "AVERAGE"
+                                                },
+                                                "FormatConfiguration": {
+                                                    "FormatConfiguration": {
+                                                        "PercentageDisplayFormatConfiguration": {
+                                                            "DecimalPlacesConfiguration": {
+                                                                "DecimalPlaces": 1
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ],
+                                    "TargetValues": [],
+                                    "TrendGroups": []
+                                },
+                                "SortConfiguration": {}
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": []
+                        }
+                    },
+                    {
+                        "BarChartVisual": {
+                            "VisualId": "barCategory",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Net Revenue by Category"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "BarChartAggregatedFieldWells": {
+                                        "Category": [
+                                            {
+                                                "CategoricalDimensionField": {
+                                                    "FieldId": "bar-cat",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "CATEGORY"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "Values": [
+                                            {
+                                                "NumericalMeasureField": {
+                                                    "FieldId": "bar-rev",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "NET_REVENUE"
+                                                    },
+                                                    "AggregationFunction": {
+                                                        "SimpleNumericalAggregation": "SUM"
+                                                    },
+                                                    "FormatConfiguration": {
+                                                        "FormatConfiguration": {
+                                                            "CurrencyDisplayFormatConfiguration": {
+                                                                "SeparatorConfiguration": {
+                                                                    "ThousandsSeparator": {
+                                                                        "Symbol": "COMMA",
+                                                                        "Visibility": "VISIBLE"
+                                                                    }
+                                                                },
+                                                                "Symbol": "USD",
+                                                                "DecimalPlacesConfiguration": {
+                                                                    "DecimalPlaces": 0
+                                                                },
+                                                                "NumberScale": "NONE"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "Colors": []
+                                    }
+                                },
+                                "SortConfiguration": {},
+                                "Orientation": "HORIZONTAL",
+                                "BarsArrangement": "CLUSTERED",
+                                "DataLabels": {
+                                    "Visibility": "VISIBLE",
+                                    "Overlap": "DISABLE_OVERLAP"
+                                }
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": []
+                        }
+                    },
+                    {
+                        "LineChartVisual": {
+                            "VisualId": "lineMonth",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Net Revenue Trend"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "LineChartAggregatedFieldWells": {
+                                        "Category": [
+                                            {
+                                                "DateDimensionField": {
+                                                    "FieldId": "line-date",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "FULL_DATE"
+                                                    },
+                                                    "DateGranularity": "MONTH",
+                                                    "HierarchyId": "line-date"
+                                                }
+                                            }
+                                        ],
+                                        "Values": [
+                                            {
+                                                "NumericalMeasureField": {
+                                                    "FieldId": "line-rev",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "NET_REVENUE"
+                                                    },
+                                                    "AggregationFunction": {
+                                                        "SimpleNumericalAggregation": "SUM"
+                                                    },
+                                                    "FormatConfiguration": {
+                                                        "FormatConfiguration": {
+                                                            "CurrencyDisplayFormatConfiguration": {
+                                                                "SeparatorConfiguration": {
+                                                                    "ThousandsSeparator": {
+                                                                        "Symbol": "COMMA",
+                                                                        "Visibility": "VISIBLE"
+                                                                    }
+                                                                },
+                                                                "Symbol": "USD",
+                                                                "DecimalPlacesConfiguration": {
+                                                                    "DecimalPlaces": 0
+                                                                },
+                                                                "NumberScale": "NONE"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "Colors": []
+                                    }
+                                },
+                                "SortConfiguration": {},
+                                "Type": "LINE"
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": [
+                                {
+                                    "DateTimeHierarchy": {
+                                        "HierarchyId": "line-date",
+                                        "DrillDownFilters": []
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    {
+                        "PieChartVisual": {
+                            "VisualId": "pieProfit",
+                            "Title": {
+                                "Visibility": "VISIBLE",
+                                "FormatText": {
+                                    "PlainText": "Net Revenue by Region"
+                                }
+                            },
+                            "Subtitle": {
+                                "Visibility": "VISIBLE"
+                            },
+                            "ChartConfiguration": {
+                                "FieldWells": {
+                                    "PieChartAggregatedFieldWells": {
+                                        "Category": [
+                                            {
+                                                "CategoricalDimensionField": {
+                                                    "FieldId": "pie-region",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "REGION"
+                                                    }
+                                                }
+                                            }
+                                        ],
+                                        "Values": [
+                                            {
+                                                "NumericalMeasureField": {
+                                                    "FieldId": "pie-rev",
+                                                    "Column": {
+                                                        "DataSetIdentifier": "orders",
+                                                        "ColumnName": "NET_REVENUE"
+                                                    },
+                                                    "AggregationFunction": {
+                                                        "SimpleNumericalAggregation": "SUM"
+                                                    },
+                                                    "FormatConfiguration": {
+                                                        "FormatConfiguration": {
+                                                            "CurrencyDisplayFormatConfiguration": {
+                                                                "SeparatorConfiguration": {
+                                                                    "ThousandsSeparator": {
+                                                                        "Symbol": "COMMA",
+                                                                        "Visibility": "VISIBLE"
+                                                                    }
+                                                                },
+                                                                "Symbol": "USD",
+                                                                "DecimalPlacesConfiguration": {
+                                                                    "DecimalPlaces": 0
+                                                                },
+                                                                "NumberScale": "NONE"
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                },
+                                "SortConfiguration": {},
+                                "DonutOptions": {
+                                    "ArcOptions": {
+                                        "ArcThickness": "MEDIUM"
+                                    }
+                                },
+                                "DataLabels": {
+                                    "Visibility": "VISIBLE",
+                                    "MeasureLabelVisibility": "VISIBLE",
+                                    "Overlap": "DISABLE_OVERLAP"
+                                }
+                            },
+                            "Actions": [],
+                            "ColumnHierarchies": []
+                        }
+                    }
+                ],
+                "Layouts": [
+                    {
+                        "Configuration": {
+                            "GridLayout": {
+                                "Elements": [
+                                    {
+                                        "ElementId": "kpiRevenue",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    },
+                                    {
+                                        "ElementId": "kpiMargin",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    },
+                                    {
+                                        "ElementId": "barCategory",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    },
+                                    {
+                                        "ElementId": "lineMonth",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    },
+                                    {
+                                        "ElementId": "pieProfit",
+                                        "ElementType": "VISUAL",
+                                        "ColumnSpan": 18,
+                                        "RowSpan": 12
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                ],
+                "ContentType": "INTERACTIVE"
+            }
+        ],
+        "CalculatedFields": [
+            {
+                "DataSetIdentifier": "orders",
+                "Name": "Profit Margin",
+                "Expression": "{NET_PROFIT} / {NET_REVENUE}"
+            },
+            {
+                "DataSetIdentifier": "orders",
+                "Name": "Profitability",
+                "Expression": "ifelse({NET_PROFIT} >= 0, 'Profitable', 'Unprofitable')"
+            }
+        ],
+        "ParameterDeclarations": [],
+        "FilterGroups": []
+    },
+    "RequestId": "851f9ff9-f441-419a-afef-ec68faa051f4"
+}

--- a/quicksight-migration-skills/quicksight-to-sigma/refs/GAP-LEDGER.md
+++ b/quicksight-migration-skills/quicksight-to-sigma/refs/GAP-LEDGER.md
@@ -1,0 +1,183 @@
+# QuickSight → Sigma · Honest Gap Ledger (Pass 3 — comprehensive audit)
+
+**Date:** 2026-06-06  ·  **Sigma org:** tj-wells-1989  ·  **QuickSight acct:** 153722385948 (us-east-1)
+**Scope:** all 20 migration test dashboards (D1–D20). Every QuickSight Sheet, Visual, and field-well
+was enumerated from `aws quicksight describe-analysis-definition` and compared against the produced
+Sigma workbook spec (`GET /v2/workbooks/{id}/spec`) and live element schemas/queries (sigma-mcp-v2).
+
+This ledger is deliberately blunt. Each row is classified **MATCH**, **FIXED-this-pass**, or
+**DOCUMENTED-SIGMA-LIMITATION ((c)-tail)** with the specific reason. Parity = the headline metric was
+re-computed directly from Snowflake (`CSA.TJ`) and confirmed against the Sigma element via MCP query.
+
+## The big fix this pass — multi-sheet → multi-page
+
+The builder previously flattened **all** of a QuickSight analysis's sheets onto a single Sigma page
+(`page-dash`). The layout step only ever read `Sheets[0]`, so for any multi-sheet analysis every
+visual on sheet 2..N existed in the spec **but received no layout placement** — i.e. it was invisible
+/ effectively lost. That is the "missing data from QuickSight" the user observed.
+
+`build-workbook-from-quicksight.rb` now emits **one Sigma PAGE per QuickSight SHEET** (page name =
+sheet name), each page holding only that sheet's visuals, plus the single shared master/Data page.
+`build-quicksight-layout.rb` now lays out **each page from its own sheet's QuickSight layout**.
+Affected in this corpus: **D13** and **D14** (2 sheets each). Sheet-2 content recovered and
+parity-verified (D13 page 2 "Revenue by Segment": Consumer $56,442.54 = Snowflake ✓).
+
+> Honesty note: only D13 and D14 are genuinely multi-sheet in this corpus. D20 (flagged in the
+> brief as possibly multi-sheet) is single-sheet — its gaps are the ML Insight + CustomContent drops,
+> not a lost sheet.
+
+## Other fixes this pass
+
+- **D7 (what-if):** the calc `ProjectedProfit = {NET_REVENUE} * ${TargetMargin}` was migrating to a
+  **broken** Sigma formula referencing a non-existent `[TargetMargin]` column (the live workbook was
+  erroring). QuickSight `${parameter}` refs are now resolved to the parameter's **default value**
+  inlined as a constant (0.25). ProjectedProfit = **$27,279.13** now matches `SUM(NET_REVENUE)*0.25`
+  from Snowflake ✓. The interactive control itself is a manual Sigma re-author ((c)-tail, warned).
+- **D12 (window):** the 4 window/table-calc columns (RunningRevenue, PctOfTotalRevenue, RevenueRank,
+  MoMDiff) neutralize to Null and rendered as **blank columns** in the table. They are now **dropped
+  from the workbook table** (kept in the data model with the original QuickSight expression in each
+  column's description). The window-only line chart (its single measure was RunningRevenue) is now
+  **skipped + warned** rather than drawn blank. The remaining table shows the 3 meaningful columns
+  (May/Online $16,462.19 = Snowflake ✓).
+- **D8 (scatter size):** the QuickSight scatter `Size` well (QUANTITY_ORDERED) is now **projected
+  into the data model master** so the data migrates. Sigma's scatter element has **no size/radius
+  channel** (verified against the element schema — the projected column is not bound to the viz), so
+  bubbles render uniform — DOCUMENTED-SIGMA-LIMITATION.
+
+---
+
+## Per-dashboard ledger
+
+### D1 — Single KPI · Total Revenue
+- QS: 1 sheet, 1 visual (KPI), 1 field. Sigma: 1 page, 1 kpi-chart.
+- **MATCH** — KPI total parity ✓.
+
+### D2 — Bar by Region
+- QS: 1 sheet, 1 visual (BarChart), 2 fields. Sigma: 1 page, 1 bar-chart.
+- **MATCH** — bar-by-region parity ✓.
+
+### D3 — Line + Pie
+- QS: 1 sheet, 2 visuals (LineChart, PieChart), 3 fields. Sigma: 1 page, 2 elements.
+- **MATCH** — line trend + pie (ArcThickness=WHOLE → pie not donut) ✓.
+
+### D4 — Exec Summary
+- QS: 1 sheet, 6 visuals (4 KPI, BarChart, LineChart), 5 fields. Sigma: 1 page, 6 elements.
+- **MATCH** — all 6 elements; West $38,408.6 ✓.
+
+### D5 — CustomSql Table
+- QS: 1 sheet, 2 visuals (BarChart, Table), 4 fields. Sigma: 1 page, 2 elements.
+- **MATCH** — CustomSql element named; parity ✓.
+
+### D6 — Orders×Customers Join
+- QS: 1 sheet, 2 visuals (KPI, BarChart), 2 fields. Sigma: 1 page, 2 elements.
+- **MATCH** — join collapsed to one denormalized DM element; parity ✓.
+
+### D7 — Orders What-If
+- QS: 1 sheet, 2 visuals (KPI, BarChart), what-if params TargetMargin/ForecastUnits.
+- **FIXED-this-pass** — `${TargetMargin}` was producing a broken `[TargetMargin]` ref; now inlined as
+  default 0.25. ProjectedProfit $27,279.13 = Snowflake ✓.
+- **(c)-tail** — interactive what-if control (slider/segmented) is a manual Sigma re-author.
+
+### D8 — Orders Combo + Scatter
+- QS: 1 sheet, 2 visuals (ComboChart, ScatterPlot), 5 fields.
+- **MATCH** — combo dual-axis persists (bars=Net Revenue primary axis, line=Net Profit secondary via
+  `{columnId,type:line}`); scatter X/Y + color-by-Category ✓.
+- **FIXED-this-pass (data)** — scatter Size measure (Quantity Ordered) now projected to the master.
+- **(c)-tail** — Sigma scatter has no size/bubble channel; bubbles render uniform-size.
+
+### D9 — Gauge / Funnel / TreeMap
+- QS: 1 sheet, 3 visuals, 3 fields. Sigma: 1 page, 3 elements.
+- **MATCH (approximated)** — gauge→kpi-chart, funnel→bar, treemap→bar (Sigma has no native gauge/
+  funnel/treemap kind; data + values parity ✓). Chart *kind* is the only (c)-tail.
+
+### D10 — Employees Transforms
+- QS: 1 sheet, 3 visuals, 4 fields. Sigma: 1 page, 3 elements.
+- **MATCH** — Cast/Create/Rename transforms + dataset row-filter applied → 347 active headcount ✓.
+
+### D11 — Multi-Level Pivot
+- QS: 1 sheet, 1 PivotTable, 5 fields. Sigma: 1 page, 1 pivot-table (rowsBy/columnsBy {id} arrays).
+- **MATCH** — multi-level pivot parity ✓.
+
+### D12 — Window Table-Calc
+- QS: 1 sheet, 2 visuals (Table, LineChart), 7 fields (incl. 4 window calcs).
+- **FIXED-this-pass** — 4 null window columns dropped from the table (no more blank columns); table
+  shows Month/Channel/Net Revenue (May/Online $16,462.19 = Snowflake ✓). Window-only line chart
+  skipped.
+- **(c)-tail** — runningSum/percentOfTotal/rank/difference have no live Sigma data-model equivalent;
+  kept in the data model with the original QuickSight expression in each column description for
+  re-authoring as Sigma window functions in the workbook.
+
+### D13 — Cascading Cross-Sheet Filters  ★ multi-sheet
+- QS: **2 sheets** (Overview: Revenue by Region; Detail: Revenue by Segment), 1 visual each.
+- **FIXED-this-pass** — now 2 Sigma pages. Sheet-2 (Revenue by Segment) was previously **lost**;
+  recovered + parity ✓ (Consumer $56,442.54 = Snowflake).
+- **(c)-tail** — cross-sheet cascading FilterGroups are not reconstructed (Sigma cross-page filter
+  wiring is a manual step).
+
+### D14 — Visual Actions  ★ multi-sheet
+- QS: **2 sheets** (Main: Revenue by Store Type; Detail: Revenue by Region), 1 visual each.
+- **FIXED-this-pass** — now 2 Sigma pages; sheet-2 recovered.
+- **(c)-tail** — QuickSight visual ACTIONS (filter / navigate / URL) have no spec-level equivalent;
+  dropped + warned.
+
+### D15 — Free-Form Overlap
+- QS: 1 sheet, 2 visuals (KPI, BarChart) in an overlapping free-form layout.
+- **MATCH** — data exact; pixel-overlap collision-resolved to a clean stacked grid (Sigma rejects
+  element collisions). Layout approximation is intentional, not data loss.
+
+### D16 — Paginated Ticket Report
+- QS: 1 sheet, 1 Table in a SectionBasedLayout (header/body/footer/page-break).
+- **MATCH (data)** — table exact.
+- **(c)-tail** — Sigma has no paginated/section report construct; sections flatten to a single
+  stacked grid. Page-break/header-footer pagination is not reproducible in a Sigma workbook.
+
+### D17 — Workforce Maps
+- QS: 1 sheet, 2 visuals (GeospatialMap points, FilledMap choropleth), 3 fields.
+- **MATCH** — both → Sigma region-map; avg-salary-by-state matches Snowflake ✓. (Point-map vs
+  region-map distinction handled by lat/long detection.)
+
+### D18 — Exotic Chart Zoo
+- QS: 1 sheet, 6 visuals: Waterfall, Sankey, BoxPlot, Histogram, WordCloud, Radar.
+- **MATCH (data-migrated)** — all 6 produce a Sigma element: waterfall+histogram→bar, the rest→
+  grouped tables. Top incident-type count 48 = Snowflake ✓.
+- **(c)-tail** — the chart KINDS (waterfall/sankey/box-plot/histogram-binning/word-cloud/radar) have
+  no Sigma equivalent; the data migrates, the exact visual encoding does not.
+
+### D19 — Secured Conditional Table
+- QS: 1 sheet, 1 Table with gradient ConditionalFormatting + (dataset) RLS/CLS.
+- **MATCH** — data exact; gradient conditional formatting MIGRATED (QS gradient → Sigma
+  backgroundScale, round-trips in spec).
+- **(c)-tail** — RLS/CLS live at the QuickSight dataset level (not in the analysis definition), so
+  they are not migratable from the analysis def — manual re-author in the Sigma data model.
+
+### D20 — Kitchen Sink
+- QS: 1 sheet (NOT multi-sheet), 4 visuals: BarChart, LineChart, Insight (ML), CustomContent.
+- **MATCH** — bar honors QS Orientation=HORIZONTAL; line aggregated by MONTH via DateTrunc (matches
+  Snowflake ✓). Window calc on the param-flagged bar neutralized to Null.
+- **(c)-tail** — ML Insight (forecast/anomaly/narrative) and CustomContent (iframe/HTML embed) have
+  no Sigma equivalent; dropped + warned.
+
+---
+
+## Honest summary
+
+| Bucket | Count | Dashboards |
+|---|---|---|
+| Full match (data + chart) | 11 | D1, D2, D3, D4, D5, D6, D10, D11, D15, D17, D19 |
+| Match w/ approximated chart kind (data exact) | 3 | D9 (gauge/funnel/treemap→kpi/bar), D18 (zoo→bars/tables), D20 (bar/line ok; ML+embed dropped) |
+| Fixed this pass | 4 | D7 (param), D8 (scatter size data), D12 (window cols), D13+D14 (multi-sheet pages) |
+| Documented Sigma limitation present | — | D7 (control), D8 (bubble-size), D12 (window funcs), D13 (cross-sheet filters), D14 (visual actions), D16 (pagination), D18 (chart kinds), D19 (RLS/CLS), D20 (ML/embed) |
+
+**Data parity:** every dashboard's headline metric reproduces the Snowflake `CSA.TJ` source. No parity
+regressions were introduced this pass (re-verified D7, D8, D12, D13, D14 via sigma-mcp-v2 after the
+in-place re-migration).
+
+**What is genuinely NOT parity (the real (c)-tail), stated plainly:**
+- Interactive QuickSight constructs with no Sigma spec equivalent: what-if controls (D7), cross-sheet
+  cascading filters (D13), visual actions (D14), ML Insights (D20), CustomContent embeds (D20).
+- Visual encodings Sigma cannot render: scatter bubble-size (D8), waterfall/sankey/box-plot/
+  histogram-binning/word-cloud/radar chart kinds (D18), gauge/funnel/treemap (D9, approximated to
+  kpi/bar), paginated section reports (D16).
+- Live window/table-calc functions in the data model (D12, D20) — migrated as documented Null columns
+  with the source expression preserved for manual re-authoring.
+- Dataset-level RLS/CLS (D19) — not present in the analysis definition, so not migratable from it.

--- a/quicksight-migration-skills/quicksight-to-sigma/refs/control-parity.md
+++ b/quicksight-migration-skills/quicksight-to-sigma/refs/control-parity.md
@@ -1,0 +1,99 @@
+# Control parity — lint, flip test, and the MCP/export answer
+
+SHARED ref, vendored byte-identical into every covered plugin's `refs/`
+(md5 discipline). Companion to `scripts/lib/control_lint.rb` (gate 7 /
+post-and-readback control lint) and `scripts/probe-controls.rb` (flip test).
+
+## Why this exists
+
+A migrated workbook can pass data parity, the column-type guard, and the
+layout lint and still ship **broken interactivity**. The 2026-06 estate audit
+of tj-wells-1989 found 86 controls across 36 kept workbooks: 8 DEAD (no
+filter target, no formula reference — pure furniture), 18 PARTIAL (same-page
+charts outside the control's reach; 8 of them bugs), and the Qlik class
+(source dashboards full of listboxes migrated with zero controls). None of
+the existing gates noticed, because every existing gate evaluates elements in
+their default state.
+
+## The three layers
+
+1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
+   dead controls, ghost filter targets, source-closure reach vs same-page
+   queryable elements, and source-signal coverage via the
+   `control-scope.json` sidecar. Runs automatically in
+   `post-and-readback.rb --type workbook` (exit 4) and as
+   `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
+2. **control-scope.json contract** — emitted by the builder next to the
+   workbook spec. Carries (a) `sourceFilterSignals`: how many filter-like
+   signals the SOURCE artifact had (Tableau quick filters + actions, PBI
+   slicers, Qlik listboxes, QuickSight/Cognos parameters+prompts, Looker
+   dashboard filters, TS Liveboard filters) — `>0` with zero spec controls
+   FAILS the lint; (b) per-control intent: `scope: "page"` (default — the
+   control must reach every same-page queryable element) or
+   `scope: ["Element name or id", ...]` (the **single-chart-switcher
+   allowlist** for intentional narrow controls like grain/geo-level toggles)
+   plus optional `mustReach` hard assertions. Full schema in the
+   `control_lint.rb` header CONTRACT block. The in-spec `controlScope` key on
+   a control element means the same thing but does NOT survive Sigma
+   readback — the sidecar is the durable form.
+3. **Flip test** (`scripts/probe-controls.rb`) — OPTIONAL Phase-6 runtime
+   evidence, not the mandatory inner loop. Exports one in-closure element CSV
+   with and without `parameters:{<controlId>: <first non-default value>}` —
+   they must differ; with `--check-out-of-closure`, an out-of-closure element
+   must NOT differ. Use it after hand-wiring controls, after estate repairs,
+   or when the lint's static reach needs runtime confirmation.
+
+## The MCP question — definitive answer (verified 2026-06-12, tj-wells-1989)
+
+Tested by setting a saved default (`values: ["West"]`) on a live workbook's
+Region list control (PHASEE, `64e78398`), then querying/exporting the same
+in-closure bar chart every way available:
+
+| Path | Control defaults applied? | Can set a control value? |
+|---|---|---|
+| `mcp__sigma-mcp-v2__query` (type=workbook) | **YES** — returned only the West row | **NO** — schema is `{type, workbookId, sql}` only; no parameter mechanism exists in the MCP query path |
+| REST export, no `parameters` | **YES** — only the West row | n/a |
+| REST `POST /v2/workbooks/{id}/export` with `"parameters": {"<controlId>": "<value>"}` | starts from defaults | **YES** — and the parameter **REPLACES** the saved default (parameters `{"ctl-region":"South"}` over a West default returned only South — no intersection) |
+
+Consequences:
+
+- MCP is fine for **default-state parity** (Phase 6 uses exactly that), and
+  default-state MCP rows DO move if you change a control's saved default.
+- MCP can NOT exercise a non-default control value — flip testing MUST go
+  through the export API's `parameters` map. That is why probe-controls.rb is
+  built on export.
+- A parameter value that matches no data row returns an EMPTY (header-only)
+  CSV, not an error — pick flip values from the column's actual domain
+  (probe-controls.rb auto-picks from the control's value-source column).
+
+## Repair recipes (what the lint tells you to do)
+
+- **dead control, column exists on a master** → add
+  `filters: [{source: {kind: "table", elementId: "<master>"}, columnId: "<col>"}]`
+  (and point the control's own `source` at the same column for its value
+  list).
+- **dead control, column does NOT exist anywhere** → REMOVE the control.
+  Honest beats decorative; do not fake-wire to an unrelated column.
+- **partial reach, multi-master page** → add one filter target per master the
+  control should govern (the column must exist on each); elements sourcing
+  from those masters inherit via the closure.
+- **partial reach, chart bypasses the master** (sources the DM directly) →
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
+- **intentional narrow control** (grain switcher driving one chart by
+  formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
+
+After any repair: flip-test the workbook
+(`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/quicksight-migration-skills/quicksight-to-sigma/refs/layout-visual-qa.md
+++ b/quicksight-migration-skills/quicksight-to-sigma/refs/layout-visual-qa.md
@@ -1,0 +1,157 @@
+# Layout Visual QA — mandatory render-and-inspect gate
+
+Shared across all `*-to-sigma` migration plugins. A workbook that POSTs cleanly (HTTP 200)
+and passes numeric/CSV parity can still be **wrong** — overlapping tiles, clipped titles, dead
+zones, orphaned filters, a render that looks nothing like the source, or a layout that reads as
+generic AI-templated output. The export API renders exactly what a user sees, so the only
+reliable check is to **render each page to PNG and actually read the image** before declaring the
+migration done.
+
+> **The rule that triggered this gate:** Sigma's grid layout has **no z-order**. Source tools
+> with floating/absolute canvases (Qlik's associative listboxes & filterpanes, Power BI free-form
+> visuals, QuickSight FreeForm, Tableau floating zones) routinely place a **filter/legend/listbox
+> on top of a chart**. Preserving those coordinates 1:1 makes the two elements render *stacked on
+> the same cell*. The build scripts now resolve this deterministically (controls lifted to their
+> own band; `decollide_bands` tiles any remaining 2-D overlap edge-to-edge) — but novel layouts
+> can still slip through, which is why this human/agent visual gate is mandatory.
+
+## Mandatory loop (run after the workbook is POSTed, before you call it done)
+
+1. **Render the FULL Sigma page** (the whole dashboard, one image — not per-element) at a
+   realistic width:
+   `python3 scripts/sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/<page>.png --w 1600`
+   (Contract: `POST /v2/workbooks/{id}/export` → poll `/v2/query/{q}/download`. Plugins that ship
+   their own renderer — `export-chart-png.rb`, `compare.py` — use the same contract.)
+1b. **Render the FULL SOURCE dashboard** as ONE image and compare full-dashboard ↔ full-dashboard:
+   Tableau MCP `get-view-image` on the **dashboard view** (not each worksheet); Power BI page
+   export; MicroStrategy `export-dossier-pdf.py`; the equivalent source export each plugin
+   captures in discovery. Place the two full images side by side. **Compare dashboard-to-dashboard,
+   never element-by-element** — per-element screenshots (e.g. `export-chart-png.rb`) miss
+   layout/relationship defects (overlaps, dead zones, a control stranded outside its chart, wrong
+   relative sizing) and are NOT a substitute for the full-page comparison. Use per-element PNGs
+   only as a drill-down after a full-page mismatch.
+2. **Read both full PNGs** and check the Sigma render against the source AND the three rubrics
+   below (source-fidelity → structural → design-quality, in that order).
+3. **Fix** any failure (re-band, resize, move a control into its chart's container, shorten a
+   map title) by editing the spec — for large multi-page workbooks use
+   `sigma-skills/sigma-workbooks/scripts/wb-rep.rb` (pull → edit element files → push) — then
+   **re-render and re-read**.
+4. **Loop until the render passes inspection.** Declare the migration done on a *clean render*,
+   never on an HTTP 200.
+
+## 1. Source-fidelity parity (run BEFORE the quality rubrics)
+
+Clean ≠ faithful. A workbook can be perfectly laid out and still look nothing like the dashboard
+it migrated. This check compares the render against the **source's own appearance**, captured as a
+full-page source export in discovery (Tableau dashboard image, Power BI page export, MicroStrategy
+`source_dossier.pdf`, etc.). Put the Sigma page PNG and the source page side-by-side and verify,
+page-for-page:
+
+- [ ] **Same element set** — every viz on the source page exists on the Sigma page (none dropped, none invented).
+- [ ] **Same arrangement** — relative position holds (a 3-column source stays 3-column; KPIs that sit under a chart stay under it). Pixel-exact isn't required; the *grouping and reading order* are.
+- [ ] **Matching chart KIND** — source KPI → Sigma `kpi-chart` (not a 1-row table); source horizontal bar → horizontal bar; microchart/indicator → the closest Sigma equivalent (conditional-formatted table / data bars), not a generic bar. The source's declared `visualizationType` (`kpi`, `microcharts`, `combo_chart`, `grid`, …) is the spec to match.
+- [ ] **KPI shows the source's VALUE** — confirm the big number equals what the source card shows (often a latest-period stat, not a windowed Sum). A KPI that's structurally a KPI but shows the wrong metric FAILS.
+- [ ] **Controls / selector panels present** — source filter panels, attribute/metric selectors, and chapter filters have Sigma equivalents (controls or an inherited base filter). An interactive source page rebuilt as a static grid FAILS.
+- [ ] **Branding bands** — header strips, logos, greeting/title bands present, OR explicitly descoped *with the user* and recorded.
+
+A render that diverges on any unchecked box is a FAIL even when row parity is green — fix the spec
+and re-compare. **Known spec ceilings** (don't loop on them — note them as editor follow-ups): KPI
+sparklines and comparison/delta badges are UI-only (`sigma-workbooks` `kpis.md`); source-tool
+chrome (theme toggles, native nav) has no spec equivalent. When the user scopes styling down
+("layout + metrics, skip branding"), record exactly what was descoped in the final summary — never
+drop it silently.
+
+## 2. Structural rubric (read the PNG against every item)
+
+- [ ] **No overlaps / no stacking.** No two elements occupy the same cell; no filter, legend, or
+      listbox sits on top of a chart or KPI. (This is the #1 failure for floating-canvas sources.)
+- [ ] **No dead zones.** The page title never shares a band with a chart; bands are stacked edge
+      to edge; no giant empty tile (usually an over-tall table — size to content).
+- [ ] **Controls placed correctly.** A global filter sits in a top control band; a control scoped
+      to one chart lives *inside that chart's container*, never floating loose on the page.
+- [ ] **No clipped titles/values.** KPI bands are ≥ 5 grid rows (titles hide below that); side
+      charts are ≥ 6 columns wide (narrower truncates the title); table tiles show all rows
+      without cutting off the summary bar.
+- [ ] **Even heights.** Charts in one band share an inner row span; sibling chart bands match.
+- [ ] **Right chart kind & formatting.** The rendered viz matches the source (no silently-dropped
+      log scale, data labels, `$`/`%` formats, or palette).
+
+## 3. Design-quality rubric (read AFTER the structural pass)
+
+> **Fidelity wins ties.** These checks make a *faithful* migration also look intentional rather
+> than generically AI-templated. They are tie-breakers for the converter's own **defaults** — never
+> a license to override the source. If the source dashboard deliberately uses equal-width tiles, a
+> flat KPI strip, or centered text, **keep it**; the source-fidelity rubric (§1) outranks polish.
+> Apply a design fix only where the converter picked a default and the source didn't dictate
+> otherwise. (Derived from the AI design anti-patterns catalog.)
+
+- [ ] **Focal point exists.** The page's signature element — the source's hero viz, or the primary
+      KPI — reads as the most important thing (larger span or stronger position), not one cell in a
+      uniform grid. *AI tell: every tile the same size and visual weight; "generic dashboard."*
+- [ ] **Proportion follows priority.** Two tiles share a row at equal width only when they're true
+      peers (a KPI strip, a real side-by-side comparison). A primary chart outweighs a supporting
+      one; a 50/50 split of unequal-priority content reads as indecisive. *AI tell: automatic
+      equal-width rows.*
+- [ ] **Pages don't all open the same way.** In a multi-page workbook, not every page leads with an
+      identical KPI band — each page opens with the thing it's actually for. *AI tell: every screen
+      starts with the same metric strip; feels templated.*
+- [ ] **Grid breaks where purpose changes.** Section layout shifts when the content's job shifts,
+      instead of repeating one 2–3-chart row down the whole page. *AI tell: "spreadsheet of cards."*
+- [ ] **Accent color is reserved, not sprayed.** Background tint / accent lives on the header band
+      and meaningful emphasis (state, the hero KPI) — not a pale wash on every container. When every
+      surface gets a touch of accent, nothing stands out. *AI tell: decorative accent overuse.*
+- [ ] **Status colors are tuned, not raw defaults.** Conditional-format / KPI semantic colors fit
+      the palette while preserving meaning; not unmodified saturated red/green badge defaults. *AI
+      tell: oversaturated framework-default status colors.*
+- [ ] **Typographic hierarchy.** Header → section title → KPI value → label form a clear scale (size,
+      weight, contrast); not every heading and number competing at the same visual volume. *AI tell:
+      flat typography; "feels like a form, not an application."*
+- [ ] **Alignment is intentional.** Left for text, natural for numbers; centering reserved for
+      genuine moments of emphasis, not applied to every section. *AI tell: centered text everywhere;
+      every section reads like a landing page.*
+- [ ] **Containers are for bands, not decoration.** No chart wrapped in its own card *inside* a band
+      container (card-in-card flattens hierarchy). Separate content levels with spacing, type, and
+      dividers before adding another container. *AI tell: nested cards.*
+
+## Building clean in the first place (so the gate rarely fails)
+
+Group every page into horizontal **band containers** — never a flat list of `<LayoutElement>`s:
+header band → control band → KPI band → chart rows → detail row. Verified container contract:
+
+- Spec side: a `kind: container` placeholder element per band.
+- Layout side: a `<GridContainer>` (NOT `<LayoutElement type="grid">`, which silently drops
+  children); child `gridRow`/`gridColumn` are **container-relative** (restart at 1);
+  `gridTemplateRows="auto"`; every `elementId` must match a real spec element (mismatch =
+  silent drop); GET before a layout PUT (POST reassigns ids; PUT preserves them).
+
+| Band | Container span | Children |
+|---|---|---|
+| Header | rows `1 / 4`, style `#0F172A` + `round` | full-width title text, inner `1 / 25` |
+| Control row | 3 rows | controls side-by-side, inner row `1 / 4` |
+| KPI row | ≥ 5 rows | N KPIs side-by-side, equal col spans (true peers → equal is correct here) |
+| Chart row | 11–12 rows | 2–3 charts side-by-side, identical inner row span, each ≥ 6 cols |
+| Detail table | content + summary (~4 rows + ~0.7/row) | never a fixed 20 (dead space) |
+
+**Design defaults that keep the render off the anti-pattern list** (apply only where the source
+doesn't dictate otherwise — §3 fidelity caveat):
+
+- **Give the hero its weight.** When a page has one signature viz (the source's largest/top viz, or
+  the primary trend), span it wider than its neighbors instead of forcing it into an equal split.
+  Equal col spans are right for a KPI strip and true comparisons — not for everything.
+- **Vary multi-page openings.** Don't auto-prepend an identical KPI band to every page; lead each
+  page with its own primary content.
+- **Reserve the accent.** Tint the header band and the hero KPI, not every container. Default the
+  rest to the neutral surface.
+- **Let type carry hierarchy.** Header title > section titles > KPI values > labels — don't flatten
+  everything to one size.
+
+## Known render caveats (not fixable via spec — keep titles short, drop redundant legends)
+
+- **point-map / region-map**: the element `name` and legend render *overlaid on the map canvas*;
+  a long title collides with legend chips. No legend/title-position knob in the OpenAPI.
+- KPI titles hide below ~5 grid rows. Container style knobs that round-trip: backgroundColor,
+  borderRadius, borderColor, borderWidth, padding (`borderColor/Width` incompatible with
+  `padding: none`).
+
+_Base patterns verified 2026-06-10 on tj-wells-1989 (workbooks bc24d476, 3e23b761, 9733fcd9)
+against a known-good native layout (Chart Zoo Enhanced v4, 39a8f826)._

--- a/quicksight-migration-skills/quicksight-to-sigma/refs/migration-results.md
+++ b/quicksight-migration-skills/quicksight-to-sigma/refs/migration-results.md
@@ -1,0 +1,101 @@
+# QuickSight → Sigma: 20-dashboard validation RESULTS
+
+> Run date: 2026-06-06 · Source account: AWS QuickSight **Enterprise**, acct `153722385948`,
+> us-east-1, profile `pivot` (20 graduated analyses D1–D20, all `CREATION_SUCCESSFUL`).
+> Sigma target: "QuickSight Migrations" folder (`59804d8b-fe7b-4de5-8f78-8d0cce07caa9`).
+> Companion: `refs/migration-test-slate.md` (the slate + 24-visual build catalog).
+
+## Summary
+The `quicksight-to-sigma` capability (converter MCP `convert_quicksight_to_sigma` + browser
+mirror, plus the skill's fixup/build/layout/parity scripts) was validated end-to-end against a
+graduated 20-dashboard slate on a **live QuickSight Enterprise account**. Every buildable
+dashboard reached **exact warehouse parity** (Sigma MCP query vs the same Snowflake source the
+QuickSight analysis reads): single-KPI, bar/line/pie, 2-way and 3-way joins, CustomSql,
+parameters/what-if, combo+scatter, gauge/funnel/treemap (approximated), data-prep transforms
+(incl. an applied 347-headcount row filter), multi-level pivots, and **maps** (region-map, exact
+parity). Hard cases degrade **gracefully and explicitly** — window/table-calc → `Null` + the
+original expression preserved in the column description; un-migratable visual kinds emit a per-visual
+`warnings.json` manifest — never a silent failure and never a broken POST. Five converter/skill
+gaps surfaced during the run were fixed at source (4 bugs) and the skill fixup was reconciled
+against the converter (1 task), with zero parity regression.
+
+## D1–D20 results
+
+URL form: `https://app.sigmacomputing.com/workbook/<urlId>`. **Every buildable dashboard
+(D1–D17, D19, D20) has a retained workbook in the "QuickSight Migrations" folder** — 19 workbooks
+in all. **D18 is the only entry with no workbook**: it is a reasoned (c)-tail (exotic chart zoo
+— 6 visuals with no Sigma chart kind, 0 chart elements), so the DM posts clean but no workbook is
+built. Where a D-number had more than one workbook from re-runs, the most-recent (`updatedAt`)
+copy is linked below. All URLs were verified against the live
+`GET /v2/files?typeFilters=workbook` list — none are invented.
+
+| # | QuickSight analysis | datasets | visual types | outcome | migrated vs dropped | Sigma workbook |
+|---|---|---|---|---|---|---|
+| D1 | D1-Single-KPI-Total-Revenue | 1 RelationalTable | KPI | ✅ exact-parity | KPI total 109116.5 ✓ | [2QQHnE2K6Uz3quHMY0i7dn](https://app.sigmacomputing.com/workbook/2QQHnE2K6Uz3quHMY0i7dn) |
+| D2 | D2-Bar-By-Region | 1 | bar | ✅ exact-parity | bar-by-region ✓ | [rXGEgUa3fKboJpYqFFg4V](https://app.sigmacomputing.com/workbook/rXGEgUa3fKboJpYqFFg4V) |
+| D3 | D3-Line-And-Pie | 1 | line, pie | ✅ exact-parity | line trend + pie mix ✓ | [uclsjO43ZtarimhRbGwfY](https://app.sigmacomputing.com/workbook/uclsjO43ZtarimhRbGwfY) |
+| D4 | D4-Exec-Summary | 3-way join | 4 KPI, bar, line, filter | ✅ exact-parity | all elements; West 38408.6 ✓ | [3UaM6oxiCV7bCcGRHrRhoD](https://app.sigmacomputing.com/workbook/3UaM6oxiCV7bCcGRHrRhoD) |
+| D5 | D5-CustomSql-Table | 1 CustomSql | bar, table | ✅ exact-parity | CustomSql element named; West 38408.6 ✓ | [c1huwfY97IBLi9vICJC4A](https://app.sigmacomputing.com/workbook/c1huwfY97IBLi9vICJC4A) |
+| D6 | D6-OrdersCustomers-Join | 2-way join | bar, KPI | ✅ exact-parity | join collapsed to 1 element; West 38408.6 ✓ | [63nDXy5wkxRYFOAT9xyzXp](https://app.sigmacomputing.com/workbook/63nDXy5wkxRYFOAT9xyzXp) |
+| D7 | D7-Orders-WhatIf | 1 + params | what-if + param controls | ✅ exact-parity | params→controls; slider→segmented control | [4HK9XIC3ani3j144K6Xa8g](https://app.sigmacomputing.com/workbook/4HK9XIC3ani3j144K6Xa8g) |
+| D8 | D8-Orders-Combo | 1 | combo (dual-axis), scatter | ✅ exact-parity | combo + scatter (size+color) ✓ | [ccnnkylCYSXO6pmTh2v30](https://app.sigmacomputing.com/workbook/ccnnkylCYSXO6pmTh2v30) |
+| D9 | D9-Orders-GaugeFunnelTree | 1 | gauge, funnel, treemap | ✅ exact-parity | gauge→kpi, funnel/treemap→bar (approximated) | [6hwkpX7v7L1Cnx8R3eHZu](https://app.sigmacomputing.com/workbook/6hwkpX7v7L1Cnx8R3eHZu) |
+| D10 | D10-Employees-Transforms | 1 + transforms | bar, KPI | ✅ exact-parity | Cast/Create/Rename + **row filter applied → 347 headcount** ✓ | [2hj8kEA4Uu8Xnv1Ksfq8FQ](https://app.sigmacomputing.com/workbook/2hj8kEA4Uu8Xnv1Ksfq8FQ) |
+| D11 | D11 Multi-Level Pivot | 1 | pivot (2 row, 1 col, 2 measures, subtotals) | ✅ exact-parity | pivot via rowsBy/columnsBy `{id}` arrays ✓ | [7KSVLawrB3JU3fM1xKqThH](https://app.sigmacomputing.com/workbook/7KSVLawrB3JU3fM1xKqThH) |
+| D12 | D12 Window Table-Calc | 1 | bar/line w/ window calcs | ⚠️ graceful | non-window exact (Online 60895.18 ✓); 4 window cols → `Null` + expr in description | [4yik4mvsIdKu5MLH1vAHY5](https://app.sigmacomputing.com/workbook/4yik4mvsIdKu5MLH1vAHY5) |
+| D13 | D13 Cascading Cross-Sheet Filters | 1 | filters across sheets | ⚠️ partial | data exact; FilterGroups dropped; multi-sheet → 1 page | [29L0Pyprn1tUxHEq8Q5Bpx](https://app.sigmacomputing.com/workbook/29L0Pyprn1tUxHEq8Q5Bpx) |
+| D14 | D14 Visual Actions | 1 | charts + actions | ⚠️ partial | data exact; visual actions (filter/nav/URL) dropped + warned | [dL4KSC5DEQM6TDOlkUGp7](https://app.sigmacomputing.com/workbook/dL4KSC5DEQM6TDOlkUGp7) |
+| D15 | D15 Free-Form Overlap | 1 | free-form + text + image | ✅ exact-parity | data exact; pixel overlap collision-resolved to stacked grid | [3AuNiEy2WWoOBxPW3L76sT](https://app.sigmacomputing.com/workbook/3AuNiEy2WWoOBxPW3L76sT) |
+| D16 | D16 Paginated Ticket Report | 1 | section-paginated + table | ⚠️ partial | table exact; sections (header/footer/page-break) flattened | [6vH3tPLylq8HPnMdU22OxD](https://app.sigmacomputing.com/workbook/6vH3tPLylq8HPnMdU22OxD) |
+| D17 | D17 Workforce Maps | 1 | filled choropleth + geo points | ✅ exact-parity | both → region-map; avg-salary-by-state matches Snowflake ✓ | [51HiaeigGh29ORZJbRIrR8](https://app.sigmacomputing.com/workbook/51HiaeigGh29ORZJbRIrR8) |
+| D18 | D18 Exotic Chart Zoo | 1 | waterfall/sankey/boxplot/histogram/wordcloud/radar | (c)-tail | DM posts clean (6 cols); 6 visuals have no Sigma kind → 6 explicit warnings | (c)-tail — no chart elements, no workbook |
+| D19 | D19 Secured Conditional Table | 1 | table + RLS/CLS + conditional fmt | ⚠️ partial | data exact; RLS/CLS + color rules/data bars dropped (live on dataset, not analysis) | [6yfSJ8sIMWI0Q6d1ac8ESZ](https://app.sigmacomputing.com/workbook/6yfSJ8sIMWI0Q6d1ac8ESZ) |
+| D20 | D20 Kitchen Sink | multi-join + params | bar/line/window + Insight/CustomContent/Plugin | ⚠️ partial | bar/line exact; window → `Null`; Insight/CustomContent/Plugin dropped + warned | [662gb4RxpVNfYQgsPo3GAz](https://app.sigmacomputing.com/workbook/662gb4RxpVNfYQgsPo3GAz) |
+
+Live cross-check: all 19 buildable D-series workbooks (D1–D17, D19, D20) confirmed present in the
+folder via `GET /v2/files?typeFilters=workbook&limit=500`; the `urlId`s above are the most-recent
+verified copy per D-number. **D18 is the only D-number with no workbook** — a reasoned (c)-tail
+(0 chart elements), not a missing or cleaned dashboard. URLs are not invented.
+
+## Gaps found & fixed (during the run)
+
+| Bead | Where fixed | One-line |
+|---|---|---|
+| `beads-sigma-vy4k` (P1 bug) | **converter** `src/quicksight.ts` + browser mirror | CustomSql/RelationalTable single-table elements were nameless → now named via `sigmaDisplayName`, cols emitted as `[Custom SQL/RAW_ALIAS]`; `dedupeElementNames` guarantees unique names. |
+| `beads-sigma-nc6g` (P0 bug) | **converter** + skill fixup/builder | Multi-table `JoinInstruction` (2-way + chained 3-way) — element naming/dedupe, transitive 2nd-hop resolution, paren sanitization, builder picks the element covering the charted cols (not `elements[0]`). |
+| `beads-sigma-woaa` (P0 bug) | **converter** (DM side) + skill builder | Window/table-calc was a comment-only `/* TODO */` → failed the all-or-nothing POST; now degrades to `formula:'Null'` + original expr in column description, on both DM and workbook sides. |
+| `beads-sigma-23xu` (P1 bug) | **converter** (cast) + skill (filter) | `CastColumnType` self-referenced its own display name → `error` col; now wraps resolved `[Custom SQL/RAW]`. `FilterOperation` surfaced to `dm-filters.json` and applied as a real element-level list filter (D10 → 347, was 369). |
+| `beads-sigma-dqyv` (P1 task) | **skill** `convert-model.rb --fixup` | Reconciled: slimmed fixup 397→303 lines, removed work the converter now does at source; kept only `synth_join_sql` collapse + `FilterOperation` surfacing + folderId/schemaVersion. Join strategy = keep `synth_join_sql` (uniform for both RelationalTable and CustomSql joins). Re-tested D1/D4/D5/D6/D10/D12 → zero regression. |
+
+## Known (c)-tail (NOT bugs — reasoned, warned, never "failed")
+
+Confirmed against the public Sigma OpenAPI element union (no matching Sigma element kind exists):
+- **histogram, heat-map, treemap*, waterfall, box-plot, radar, sankey, word-cloud** — no Sigma
+  chart kind. (*treemap is *approximated* to bar where charted as a TreeMapVisual; the bare kind
+  has no native equivalent.) Emitted as per-visual `warnings.json` entries.
+- **LayerMap** (multi-layer geospatial) — no Sigma kind. (Single-layer FilledMap / name- or
+  lat-long GeospatialMap DO build natively as region-map/point-map — no longer (c)-tail.)
+- **Insight (ML)** — forecast/anomaly/narrative ML; no equivalent.
+- **CustomContent** — arbitrary iframe/HTML; no equivalent.
+- **Plugin** — third-party visual (Highcharts etc.); no equivalent.
+- **Section-based pagination + free-form pixel overlap** — Sigma uses a 24-col responsive grid;
+  sections flatten, overlapping free-form elements collision-resolve to a stacked grid.
+- **RLS / CLS** (row/column security) — analysis-level constructs; in QuickSight these live on the
+  **dataset**, not the analysis definition, so they aren't in the migrated artifact.
+- **Window / table-calc functions** (~28: sumOver, runningSum, rank, periodOverPeriod, percentOfTotal,
+  percentile*Over, …) — degrade to `Null` + original expr in column description (graceful, not exact).
+- **FilterOperation row-filter on a warehouse-table DM element** — a true row filter cannot move
+  into a warehouse-table element; surfaced as a workbook/element filter or pushed to SQL WHERE
+  (handled for D10) — warned where it can't.
+- **Dataset-of-datasets** recursion — explicitly out of scope (negative test).
+
+## How to reproduce
+
+See `SKILL.md` — the proven 7-phase happy path:
+1. **AUTH** AWS CLI → QuickSight (Enterprise required); Sigma creds via `scripts/get-token.sh`.
+2. **DISCOVER** `describe-analysis-definition` + `describe-data-set(s)` + `describe-data-source(s)` → `quicksight-discover.py`.
+3. **CONVERT** `convert_quicksight_to_sigma` MCP (MCP gate) → Sigma DM JSON.
+4. **POST DM** `convert-model.rb --fixup` → validate → `POST /v2/dataModels/spec`.
+5. **WORKBOOK** master tables per DM element + chart elements mirroring the QS visuals → `POST /v2/workbooks/spec`.
+6. **LAYOUT** QS grid x,y,w,h → 24-col layout → `put-layout.rb` (do NOT skip).
+7. **VERIFY** sigma-mcp-v2 query each element + Phase 6 parity vs the QuickSight aggregation (hard gate).

--- a/quicksight-migration-skills/quicksight-to-sigma/refs/migration-test-slate.md
+++ b/quicksight-migration-skills/quicksight-to-sigma/refs/migration-test-slate.md
@@ -1,0 +1,101 @@
+# QuickSight → Sigma: complexity taxonomy + 20-dashboard test slate
+
+Reference for validating the quicksight-to-sigma skill against graduated complexity.
+Grounded in the QuickSight `describe-analysis-definition` schema and cross-referenced
+against this stack's known coverage + gaps.
+
+## Converter / builder coverage snapshot
+- **DM converter** (MCP `convert_quicksight_to_sigma`): handles RelationalTable, CustomSql,
+  JoinInstruction, DataTransforms (CreateColumns/Rename/Cast/Filter/Project), calc fields
+  (~40 functions; `ifelse`→If, `switch`→nested If). Params → Sigma controls.
+- **DM GAPS**: window/table-calc functions (~28+: sumOver, runningSum, rank, lag/lead via
+  periodOverPeriod*, percentOfTotal, window*, percentile*Over) → `/* TODO */` placeholder;
+  S3Source & SaaSTable → placeholder; analysis-level FilterGroups → skipped;
+  ColumnConfigurations (formatting) → skipped; dataset-of-datasets → out of scope.
+- **Workbook builder** recreates (native Sigma kind): KPI, bar, line, area, donut/pie,
+  combo, scatter, table, pivot, **region-map** (FilledMap + name-based GeospatialMap) and
+  **point-map** (GeospatialMap with real lat/long). Approximated (no native kind): gauge→kpi,
+  funnel/treemap→bar. NOT built — no Sigma element kind, emitted as a per-visual warning in
+  `<out>.warnings.json` + STDERR: histogram, heat-map, box-plot, waterfall, sankey, word-cloud,
+  radar, layer-map (multi-layer), insight (ML), customcontent, plugin, empty.
+  - **Sigma's real chart-kind universe** (confirmed against the public OpenAPI element union,
+    `/v2/workbooks/spec`, 2026-06-06): `kpi-chart`, `bar-chart`, `line-chart`, `area-chart`,
+    `pie-chart`, `donut-chart`, `scatter-chart`, `combo-chart`, `table`, `pivot-table`,
+    `point-map`, `region-map`, `geography-map` (+ non-chart `control`/`text`/`image`/`embed`/
+    `container`/`divider`). There is **no** histogram/heat-map/treemap/waterfall/box-plot/
+    radar/sankey/word-cloud kind — those names appear nowhere in the element union. `region-map`
+    persistence + query parity verified live (POST→readback→MCP query) on the D17 DM.
+
+## Visual catalog (API `Visual` union — 24 nodes) — per-node build status
+**BUILT (native Sigma kind):** `KPIVisual`→kpi-chart, `BarChartVisual`→bar-chart,
+`LineChartVisual`→line-chart, `PieChartVisual`→pie/donut-chart, `ComboChartVisual`→combo-chart,
+`ScatterPlotVisual`→scatter-chart, `TableVisual`→table, `PivotTableVisual`→pivot-table,
+`FilledMapVisual`→**region-map**, `GeospatialMapVisual`→**region-map** (name-based) or
+**point-map** (lat/long).
+**APPROXIMATED (no exact kind):** `GaugeChartVisual`→kpi-chart, `FunnelChartVisual`→bar-chart,
+`TreeMapVisual`→bar-chart.
+**(c)-TAIL — no Sigma element kind, dropped with a per-visual warning:** `HeatMapVisual`,
+`HistogramVisual` (re-author as binned bar), `BoxPlotVisual`, `WaterfallVisual`,
+`SankeyDiagramVisual`, `WordCloudVisual`, `RadarChartVisual`, `LayerMapVisual` (multi-layer),
+`InsightVisual` (ML), `CustomContentVisual`, `PluginVisual`, `EmptyVisual` (no-op).
+
+## Complexity axes (easy / medium / hard)
+- **A. Data topology**: 1 RelationalTable → CustomSql → multi-table JoinInstruction → dataset-of-datasets(out of scope). S3/SaaS sources = GAP.
+- **B. Data prep**: simple calc fields → transforms chain → window/table-calc funcs (GAP) / LAC.
+- **C. Visual types**: KPI/bar/line/pie → mid catalog (table/pivot/combo/…) → maps/sankey → insight/custom/plugin (un-migratable).
+- **D. Interactivity**: 1 filter control → param controls + relative-date → cascading/cross-sheet (FilterGroups GAP) → actions/drill (GAP).
+- **E. Layout**: single tiled grid → multi-sheet/fixed grid → free-form (pixel) / section-based (paginated). Free-form & section → approximate to Sigma grid.
+- **F. Governance/advanced**: text/images/themes → conditional formatting (GAP) → RLS/CLS → insight ML (un-migratable).
+
+## The 20-dashboard slate (low → high)
+**Tier 1 — trivial smoke (pass clean):**
+- D1 Single KPI (total revenue). baseline happy path.
+- D2 Bar by Region, simple `sum` calc.
+- D3 Line trend + Pie mix (multi-element grid).
+
+**Tier 2 — medium real-world:**
+- D4 Exec summary: 4 KPIs + bar + line + 1 filter control (sheet scope).
+- D5 CustomSql dataset → bar + **table** (table builder).
+- D6 Two-dataset **JoinInstruction** (orders⋈customers) → bar + KPI (cross-element ref form).
+- D7 **Parameters** + param controls (slider/dropdown) + what-if calc.
+- D8 **Combo** (dual-axis) + **Scatter** (size+color).
+- D9 **Gauge** + **Funnel** + **TreeMap**.
+- D10 Data-prep **transforms** chain (Create/Rename/Cast/Filter) → bar+KPI on derived cols.
+
+**Tier 3 — hard (hit gaps):**
+- D11 **Pivot table** multi-level (2 row dims, 1 col, 2 measures, subtotals) — rowsBy/columnsBy `{id}` arrays.
+- D12 **Window/table-calc** funcs (runningSum, percentOfTotal, rank, periodOverPeriod) → verify graceful `/* TODO */` degradation.
+- D13 **Cascading + cross-sheet filters** (FilterGroup AllSheets) — FilterGroups GAP.
+- D14 **Visual actions**: filter + navigation(+param) + URL — actions GAP (inventory/warn).
+- D15 **Free-form layout** w/ overlap + text box + image.
+- D16 **Section-based** paginated report (header/footer/page-break) + table.
+- D17 **Maps**: geospatial points + filled choropleth. **BUILT (2026-06-06):** both →
+  Sigma `region-map` (FilledMap STATE→us-state choropleth; GeospatialMap CITY→us-postal-place,
+  since the dataset carries geo NAMES not lat/long — point-map is auto-selected only when real
+  latitude+longitude fields are present). Live parity verified: avg-salary-by-state matches
+  Snowflake exactly. Was 0 chart elements → now 2.
+- D18 **Exotic zoo**: waterfall + sankey + boxplot + histogram + wordcloud + radar.
+  **(c)-TAIL — confirmed:** none of these six has a Sigma element kind (verified against the
+  OpenAPI element union). The builder now emits a per-visual warning manifest
+  (`wb-spec.warnings.json`) + STDERR for each instead of silently producing nothing. Was 0
+  chart elements / silent → now 0 chart elements + 6 explicit, reasoned warnings. DM still
+  posts clean (6 columns).
+
+**Tier 4 — very hard / governance + un-migratable:**
+- D19 **RLS + CLS** secured + conditional formatting (color rules, data bars) on a table.
+- D20 **Kitchen sink**: multi-dataset join + window calcs + cascading params + free-form + **InsightVisual (ML) + CustomContent + Plugin** — verify clean PARTIAL migration + full warning manifest.
+- (optional D21: dataset-of-datasets recursion — negative test for the out-of-scope case.)
+
+## Un-migratable → scope as known-(c)-tail, never "failed":
+`InsightVisual` ML (forecast/anomaly/narrative); `CustomContentVisual` (iframe/HTML); `PluginVisual`
+(Highcharts etc.); `SankeyDiagramVisual`, `RadarChartVisual`, `WordCloudVisual`, `BoxPlotVisual`,
+`WaterfallVisual`, `HistogramVisual`, `HeatMapVisual`, `LayerMapVisual` (each has NO Sigma element
+kind — confirmed against the OpenAPI element union, 2026-06-06); SectionBasedLayout + free-form
+pixel overlap; cascading filter *actions*; SPICE ingestion metadata; dataset-of-datasets recursion.
+The builder emits a structured `<out>.warnings.json` + STDERR line per dropped visual.
+**NOTE — the map family is NO LONGER (c)-tail:** `FilledMapVisual` and name/lat-long-based
+`GeospatialMapVisual` now build natively (Sigma `region-map`/`point-map`); only the multi-layer
+`LayerMapVisual` remains a warning.
+
+_Doc sources: QuickSight API_Visual, AnalysisDefinition, FilterGroup/FilterScopeConfiguration,
+LayoutConfiguration/GridLayoutConfiguration, custom-actions, table-calculation-functions, RLS/CLS, ML-insights._

--- a/quicksight-migration-skills/quicksight-to-sigma/refs/rca-arine-2026-06-17.md
+++ b/quicksight-migration-skills/quicksight-to-sigma/refs/rca-arine-2026-06-17.md
@@ -1,0 +1,101 @@
+# RCA — Arine "STD Elevate Operational / Task Log" migration (2026-06-17)
+
+First **real customer** QuickSight→Sigma run (customer-supplied code-only export; org `arine` on us-a.aws). Reached exact KPI parity vs the customer's screenshot (146,654 / 89,942 / 37 / 51,681 / 4,994) — but only after fixing **12 distinct gaps by hand**. This is the prioritized backlog to fold those fixes back into the skill so the next run is automatic.
+
+Severity: **P0** = silently-wrong numbers · **P1** = broken/empty element · **P2** = fidelity/polish · **P3** = process.
+
+---
+
+## P0 — Correctness (silently wrong, passes validation)
+
+### 1. Per-visual QuickSight FilterGroups are dropped → wrong aggregates
+`build-workbook-from-quicksight.rb`. The 5 KPIs (Open/In Progress/Closed/Deleted/Total Tasks) are identical `DISTINCT_COUNT(TASK_ID)` measures **distinguished only by a `TASK_STATUS` FilterGroup scoped to each visual** (`ScopeConfiguration.SelectedSheets.SheetVisualScopingConfigurations[].VisualIds`). The builder ignored these → all five rendered the same number (1.6 M). The dashboard *looked* done and POSTed clean.
+**Fix:** index `Definition.FilterGroups` by target VisualId; for each visual, translate its CategoryFilter(s) into either an element-level `filters[]` entry or fold into the measure (`CountDistinctIf(id, cond)`). This is the single highest-value fix — it's the difference between a demo and a wrong dashboard.
+
+### 2. `DISTINCT_COUNT` mapped to `Count()` not `CountDistinct()`
+`build-workbook-from-quicksight.rb` measure emitter. QS `CategoricalMeasureField.AggregationFunction = DISTINCT_COUNT` came out as `Count([…])`. Inflates every distinct-count measure.
+**Fix:** map the full QS `AggregationFunction` enum → Sigma (`DISTINCT_COUNT→CountDistinct`, `COUNT→Count`, `SUM→Sum`, `AVERAGE→Avg`, `MIN/MAX/STDEV/VAR/PERCENTILE…`). One lookup table, used by KPI + chart + pivot emitters.
+
+### 3. Boolean flags declared INTEGER in QS → `= 1` errors in Sigma
+QS `OutputColumns` typed `ALL_TASK_FLAG`/`CLOSED_TASK_FLAG` as `INTEGER`, but the Snowflake view is `BOOLEAN`. The converter's `distinct_countIf({flag}=1)` → `CountDistinctIf(..., [flag] = 1)` throws `Argument 2 invalid for function '='` at query time (not at validate/POST).
+**Fix:** don't trust QS-declared types for predicates. Either (a) verify type via `/v2/connections/tables/{inode}/columns` during fixup, or (b) emit boolean-safe predicates (`[flag]` / `[flag] = true`) when the underlying column is boolean. Add a converter note: QS `*_FLAG` INTEGER columns are frequently warehouse BOOLEAN.
+
+---
+
+## P1 — Structural (broken or empty elements)
+
+### 4. Single-master architecture breaks multi-dataset dashboards
+`build-workbook-from-quicksight.rb` picks ONE "best-covering" DM element as the sole `master` and points every visual at it. Task Log uses 2 datasets — the "Weekly Tasks" combo (TASK_AGGREGATION) got refs to columns that don't exist on the ops master, **and** contaminated the ops master with cross-dataset calc columns (`Tasks Closed`/`Generated` referencing absent flags).
+**Fix:** emit **one master per DM element** (one per QS DataSetIdentifier) on the Data page; route each visual to the master matching its `DataSetIdentifier`. Required for any multi-dataset analysis (the common case).
+
+### 5. Pivot tables built with no `rowsBy`/`columnsBy`/`values` shelves
+`PivotTableVisual` emitted dims as plain columns with no pivot structure → the daily pivot didn't aggregate and (combined with #6) rendered effectively empty.
+**Fix:** translate QS `PivotTableAggregatedFieldWells` Rows→`rowsBy`, Columns→`columnsBy`, Values→`values` (+ map the measure aggregation per #2). Mirror the `tables.md` pivot recipe.
+
+### 6. Date dimensions not truncated to QS `DateGranularity`
+QS `DateDimensionField.DateGranularity = DAY` was ignored; the raw DATETIME on the pivot Columns shelf exploded into one column per millisecond → blank-looking crosstab.
+**Fix:** wrap date dims in `DateTrunc`/`Date` per `DateGranularity` (DAY/WEEK/MONTH/…) **and** attach a strftime `format` (`%Y-%m-%d`). Applies to pivots, charts, and x-axes.
+
+---
+
+## P2 — Fidelity / polish
+
+### 7. Visual titles rendered as VisualId GUIDs
+Builder fell back to `VisualId` when the title is rich-text (`<visual-title>…`). Every element was named `52f9223d-…`.
+**Fix:** parse `Title.FormatText.PlainText`/`RichText` → strip tags, `html.unescape` (e.g. `Task Type &amp; Name` → `Task Type & Name`) → element name.
+
+### 8. Calc-col reference normalization (case/format + bare idents)
+Converter calc formulas referenced `[Hours to Close]` (actual display `Hours To Close`) and bare `LIS`/`DISABILITY` (display `Lis`/`Disability`) → `not a sibling column`. Some passed validate but would error live.
+**Fix:** normalize every column ref in a translated formula to the post-fixup display name; convert bare identifiers to bracketed display refs.
+
+### 9. Aggregate-level calc fields emitted as DM row-level columns
+Converter maps ALL `CalculatedFields` to DM calc columns; aggregate ones (`distinct_countIf`, `sum`, ratios of aggregates) can't be row-level — they error or silently collapse. It already *warns* ("→ Sigma metric") but still emits the broken column.
+**Fix:** when a calc field is aggregate-level, **skip it from the DM** (the workbook recreates it as a measure) or emit it as a proper Sigma metric — never as a row calc col. Also drop ratio cols whose operands are themselves aggregate measures.
+
+### 10. Default master name "Orders" leaked from fixtures
+`--master-name` defaults to `Orders` — wrong for any non-Orders dashboard.
+**Fix:** default the master name to the DM element / dataset name.
+
+### 11. Theme colors aren't in the export
+`describe-dashboard-definition` carries only the `ThemeArn`; categorical palette (donut slice colors) is absent. Only chrome hexes are inline (e.g. title `#1ed7ff`).
+**Fix:** discovery should also call `describe-theme <themeId>` and store the palette; apply the categorical colors to chart `color` axes. Also map inline chrome colors (title color, KPI/conditional colors) which *are* present.
+
+### 12. Insight / CustomNarrative visuals are reproducible, not hard drops
+The "Report Date" Insight (a single `MaximumMinimum` computation rendered via `CustomNarrative`) ports cleanly to a Sigma **text element with `{{formula | strftime}}`**.
+**Fix:** for simple single-computation narratives (MAX/MIN/COUNT/etc.), auto-emit a `text` element instead of dropping. Note: the text-template date format uses **strftime, unquoted** — `{{Max([El/Col]) | %B %-d, %Y}}` ("June 17, 2026"). Quoted formats and `DateFormat()` both render literally; `Date()` doesn't strip the time.
+
+---
+
+## P3 — Discovery / process / verification
+
+### 13. Database name absent from the export
+QS `RelationalTable` gives Schema+Name; the DB lives in the DataSource (the customer omitted `datasources/`). Recover via `POST /v2/connection/{connectionId}/lookup` (**singular** "connection") with `{"path":[DB,SCHEMA,TABLE]}` — probe candidate DBs until 200. Schema-not-granted (`REPORTING`) returns 404 even when the DB resolves.
+**Fix:** add a DB-resolution helper to the skill (probe the connection scope) and document the singular-`connection` lookup endpoint + the grant/index gotcha.
+
+### 14. `PUT /spec` wipes the applied layout
+Layout is applied separately by `put-layout.rb`; any later spec `PUT` drops it (broke the layout once mid-run).
+**Fix:** orchestrator must **always re-run `put-layout` after a spec PUT**; document the invariant prominently. Consider folding layout into the spec.
+
+### 15. FreeForm layout coordinates not parsed
+`build-quicksight-layout.rb` reads `GridLayout` ColumnIndex/RowIndex; this dashboard used **FreeFormLayout** with `XAxisLocation`/`YAxisLocation`/`Width`/`Height` in px → parser saw `None` → everything stacked full-width.
+**Fix:** parse FreeForm px coords and scale to the 24-col grid (canvas width ÷ 24). FreeForm is common for polished QS dashboards.
+
+### 16. Verification without a configured MCP
+Customer org isn't wired to `sigma-mcp-v2`, so the Phase-7 parity gate (which assumes that MCP) can't run. Verified instead via the **Export API**: `POST /v2/workbooks/{wb}/export {elementId, format:{type:csv}}` → poll `GET /v2/query/{queryId}/download`. Also sets control values for filtered parity.
+**Fix:** add an export-API parity path to `phase6-parity-quicksight.rb` for orgs lacking MCP. It's the only way we could prove the 5/5 KPI match.
+
+### 17. Parity needs the customer's control state + a rendered reference
+The customer's screenshot was filtered to `Organization = "Arine Demo Organization"` (a **runtime** selection — 0 occurrences in the definition, empty parameter default). Unfiltered, the dashboard correctly shows all orgs (~11× larger). Without the screenshot we'd have "verified" the wrong baseline.
+**Fix:** discovery should request (a) a screenshot/`get-dashboard` snapshot and (b) `describe-theme`; parity should record which control values are active in the reference.
+
+---
+
+## Suggested rollout order
+1. **#1 + #2** (P0 measure correctness) — biggest credibility risk; both in `build-workbook-from-quicksight.rb`.
+2. **#4** (multi-master) — unblocks every multi-dataset dashboard.
+3. **#5 + #6** (pivot shelves + date granularity).
+4. **#3, #8, #9** (converter type/ref/aggregate handling) — `quicksight.ts` + `convert-model.rb --fixup`.
+5. **#15** (FreeForm layout), **#7/#10** (titles/master name), **#12** (Insight→text).
+6. **#13/#14/#16/#17** (SKILL.md doc + orchestrator guardrails + export-API parity).
+
+Each P0/P1 should ship with a regression fixture derived from this Arine export (sanitized).

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/apply_sigma_rls.py
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/apply_sigma_rls.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Phase 1.5 (RLS decision gate) — apply a Looker RLS finding to Sigma, scripted.
+
+Sigma user attributes are FULLY API-supported (confirmed live 2026-06-10):
+  - GET  /v2/user-attributes            list (reuse-first)
+  - POST /v2/user-attributes            create
+  - POST /v2/user-attributes/{id}/users assign a value to a member
+And the Sigma RLS row-filter is fully spec-expressible (NOT UI-only): a boolean
+calc column `CurrentUserAttributeText("<attr>") = [<Field>]` on the base element
+plus an element `filters` entry `{kind:list, mode:include, values:[true]}`.
+
+This script does the whole flow, REUSE-FIRST and SAFE-BY-DEFAULT:
+  1. attribute   GET /v2/user-attributes → print a match if one already exists
+                 (by name, case-insensitive) before creating anything.
+  2. provision   --create  → POST /v2/user-attributes when nothing reusable exists.
+                 --assign   → POST /v2/user-attributes/{id}/users (needs --member-id
+                 + --value) to assign the attribute value to a member.
+  3. apply       --field <DisplayName> (+ --element-id/--dm-id) → print the RLS
+                 calc-column + element-filter spec snippet; with --apply, PATCH it
+                 into the DM element's spec (GET/PUT /v2/dataModels/{id}/spec).
+
+By default this only READS and PRINTS a plan — it mutates ONLY when you pass an
+explicit --create / --assign / --apply flag. Mirrors post_dm.py: reads
+$SIGMA_BASE_URL / $SIGMA_API_TOKEN from env (eval "$(scripts/get-token.sh)").
+Dependency-free (stdlib only).
+
+Live-validated: this exact flow produced exact 3-way parity (Looker-restricted ==
+Sigma-restricted == warehouse: $38,906.82 / 220 rows, region=West).
+
+Usage:
+  eval "$(scripts/get-token.sh)"
+  # reuse-first lookup only (default, read-only):
+  python3 apply_sigma_rls.py --attr region
+  # create the attribute if missing:
+  python3 apply_sigma_rls.py --attr region --value West --create
+  # assign a value to the querying member:
+  python3 apply_sigma_rls.py --attr region --value West --member-id <id> --assign
+  # print the RLS spec snippet for a DM element (plan only):
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid>
+  # ...and PATCH it into the DM element spec:
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid> \
+      --dm-id <dataModelId> --apply
+
+BATCH MODE (tool-agnostic) — ingest a converter's result.security[] (architecture B:
+the converter REPORTS RLS/CLS; this script provisions + applies). Handles RLS via
+user attribute / team (CurrentUserInTeam) / email, and CLS (columnSecurities):
+  # 1) convert + POST the model (converter injects NO RLS), capture dataModelId
+  # 2) write result.security to a JSON file, then:
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId>            # plan only
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId> --provision --apply
+Elements match by name (Sigma reassigns ids on POST); CLS columns match by normalized
+name. --provision creates missing attributes/teams (assign per-user values separately).
+Works for tableau/quicksight/powerbi/thoughtspot/qlik/lookml converter output alike.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+BASE = os.environ.get("SIGMA_BASE_URL")
+TOK = os.environ.get("SIGMA_API_TOKEN")
+
+
+def api(method, path, body=None):
+    if not BASE or not TOK:
+        sys.exit("SIGMA_BASE_URL / SIGMA_API_TOKEN unset — run: eval \"$(scripts/get-token.sh)\"")
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        BASE + path, data=data, method=method,
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+    except urllib.error.HTTPError as e:
+        print("HTTP", e.code, method, path, "->", e.read().decode()[:1000], file=sys.stderr)
+        raise
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw  # spec endpoints return YAML
+
+
+def _short_id(prefix="rls"):
+    """A short, deterministic-enough id for a calc column / filter."""
+    import hashlib
+    return prefix + "-" + hashlib.md5(prefix.encode() + os.urandom(4)).hexdigest()[:8]
+
+
+# --- 1. reuse-first attribute lookup --------------------------------------
+def find_attribute(name):
+    """Return the existing user-attribute entry matching `name` (case-insensitive), else None."""
+    res = api("GET", "/v2/user-attributes?limit=200")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+
+def list_attributes():
+    res = api("GET", "/v2/user-attributes?limit=200")
+    return res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+
+
+# --- 3. RLS spec snippet --------------------------------------------------
+def rls_spec_snippet(attr, field, element_id):
+    """The verified row-filter shape: a boolean calc column + an element list filter showing only True."""
+    col_id = _short_id("rlscol")
+    filt_id = _short_id("rlsf")
+    calc = {
+        "id": col_id,
+        "name": f"RLS {attr}",
+        "formula": f'CurrentUserAttributeText("{attr}") = [{field}]',
+    }
+    filt = {
+        "id": filt_id,
+        "columnId": col_id,
+        "kind": "list",
+        "mode": "include",
+        "values": [True],
+    }
+    return {
+        "elementId": element_id,
+        "calcColumn": calc,
+        "filter": filt,
+        "_note": (
+            f'Add calcColumn to element "{element_id}" columns, and `filter` to that '
+            f"element's filters[]. CurrentUserAttributeText(\"{attr}\") = [{field}] is the "
+            "user-attribute mode; team mode = CurrentUserInTeam([...]); email mode = "
+            "[Email] = CurrentUserEmail()."
+        ),
+    }
+
+
+def apply_to_dm(dm_id, element_id, calc, filt):
+    """PATCH the calc column + filter into the DM element's spec (GET → mutate → PUT)."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        # spec endpoints can return YAML; we can't safely mutate that here.
+        sys.exit("DM spec came back non-JSON (YAML) — cannot auto-PATCH; apply the snippet by hand.")
+    # The spec shape nests elements under the model; search for the element by id.
+    found = _inject(spec, element_id, calc, filt)
+    if not found:
+        sys.exit(f"element id {element_id} not found in DM {dm_id} spec — check --element-id")
+    res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+    print("PUT /v2/dataModels/%s/spec ->" % dm_id,
+          json.dumps(res)[:300] if isinstance(res, dict) else str(res)[:300])
+
+
+def _inject(node, element_id, calc, filt):
+    """Recursively find an element dict whose id == element_id; add calc col + filter. Returns True if injected."""
+    if isinstance(node, dict):
+        if node.get("id") == element_id and ("columns" in node or "kind" in node or "source" in node):
+            cols = node.setdefault("columns", [])
+            if not any(c.get("id") == calc["id"] for c in cols if isinstance(c, dict)):
+                cols.append(calc)
+            filters = node.setdefault("filters", [])
+            filters.append(filt)
+            return True
+        for v in node.values():
+            if _inject(v, element_id, calc, filt):
+                return True
+    elif isinstance(node, list):
+        for v in node:
+            if _inject(v, element_id, calc, filt):
+                return True
+    return False
+
+
+
+# --- shared engine: teams, element/column resolution, CLS, batch from result.security ---
+def find_team(name):
+    res = api("GET", "/v2/teams?limit=500")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+def ensure_team(name, do_create):
+    t = find_team(name)
+    if t:
+        print(f"  REUSE team '{name}' (id={t.get('teamId') or t.get('id')}).")
+        return t.get("teamId") or t.get("id")
+    if do_create:
+        res = api("POST", "/v2/teams", {"name": name})
+        tid = res.get("teamId") or res.get("id") if isinstance(res, dict) else None
+        print(f"  CREATED team '{name}' (id={tid}). NOTE: add members via POST /v2/teams/{tid}/members.")
+        return tid
+    print(f"  (plan: team '{name}' missing — pass --provision to create it, then add members.)")
+    return None
+
+def _walk_elements(node, out):
+    if isinstance(node, dict):
+        if node.get("id") and ("columns" in node or "kind" in node):
+            out.append(node)
+        for v in node.values():
+            _walk_elements(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            _walk_elements(v, out)
+    return out
+
+def _resolve_element(spec, element_id, element_name):
+    els = _walk_elements(spec, [])
+    for e in els:
+        if element_id and e.get("id") == element_id:
+            return e
+    for e in els:                                  # Sigma reassigns ids on POST → match by name
+        if element_name and (e.get("name") == element_name):
+            return e
+    # last resort: a path-tail match (warehouse-table element named by table)
+    for e in els:
+        path = (e.get("source") or {}).get("path") or []
+        if element_name and path and str(path[-1]).upper() == str(element_name).upper():
+            return e
+    return None
+
+def _norm(x):
+    """Normalize a column name for matching across raw/display forms (NET_PROFIT == Net Profit)."""
+    return __import__("re").sub(r"[^a-z0-9]", "", (x or "").lower())
+
+def _resolve_col_ids(element, names):
+    """Map raw-or-display column names -> live column ids (formula tail or name, normalized)."""
+    out = []
+    re = __import__("re")
+    for nm in (names or []):
+        cid = None
+        for c in (element.get("columns") or []):
+            cand = c.get("name") or ""
+            f = c.get("formula") or ""
+            m = re.match(r"^\[(?:[^\]/]+/)?([^\]]+)\]$", f)
+            if m:
+                cand = cand or m.group(1)
+                if _norm(m.group(1)) == _norm(nm): cid = c.get("id"); break
+            if _norm(cand) == _norm(nm): cid = c.get("id"); break
+        if cid: out.append(cid)
+        else: print(f"  WARN: CLS column '{nm}' not found on element — skipped.")
+    return out
+
+def apply_from_security(dm_id, security, do_apply, do_provision):
+    """Provision attrs/teams + apply RLS calc/filter and CLS for each result.security entry."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        sys.exit("DM spec came back non-JSON — cannot auto-apply.")
+    applied = 0
+    def _elname(e): return e.get('name') or ((e.get('source') or {}).get('path') or ['?'])[-1]
+    for rule in security:
+        el = _resolve_element(spec, rule.get("elementId"), rule.get("elementName"))
+        if not el:
+            print(f"⚠ {rule.get('kind')} on element '{rule.get('elementName')}' — not found in DM {dm_id}; skipped."); continue
+        if rule.get("kind") == "rls" and rule.get("rls"):
+            r = rule["rls"]
+            print(f"RLS → element '{_elname(el)}': {r['formula'][:80]}")
+            for attr in (r.get("userAttributes") or []):
+                ex = find_attribute(attr)
+                if ex: print(f"  REUSE attribute '{attr}'.")
+                elif do_provision:
+                    api("POST", "/v2/user-attributes", {"name": attr, "defaultValue": {"val": "", "type": "string"}})
+                    print(f"  CREATED attribute '{attr}'. NOTE: assign per-user values via POST /v2/user-attributes/{{id}}/users.")
+                else: print(f"  (plan: attribute '{attr}' — pass --provision to create; then assign per-user values.)")
+            for team in (r.get("teams") or []):
+                ensure_team(team, do_provision)
+            calc = {"id": _short_id("rlscol"), "name": r.get("name") or "RLS", "formula": r["formula"]}
+            filt = {"id": _short_id("rlsf"), "columnId": calc["id"], "kind": "list", "mode": "include", "values": [True]}
+            if do_apply:
+                el.setdefault("columns", []).append(calc)
+                el.setdefault("filters", []).append(filt); applied += 1
+        elif rule.get("kind") == "cls" and rule.get("cls"):
+            c = rule["cls"]
+            ids = _resolve_col_ids(el, c.get("restrictedColumnNames"))
+            print(f"CLS → element '{_elname(el)}': hide {c.get('restrictedColumnNames')}")
+            if do_apply and ids:
+                el.setdefault("columnSecurities", []).append({"id": _short_id("cls"), "criteria": c.get("criteria") or {"kind": "no-one-can-view"}, "restrictedColumns": ids}); applied += 1
+    if do_apply and applied:
+        res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+        print(f"PUT spec -> applied {applied} rule(s):", (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif not do_apply:
+        print("\n(plan only — pass --apply --dm-id <id> to PATCH these into the DM spec; --provision to create attributes/teams.)")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Apply a Looker RLS finding to Sigma (safe-by-default).")
+    ap.add_argument("--attr", help="Sigma user-attribute name (e.g. region)")
+    ap.add_argument("--value", help="attribute value (for --create defaultValue / --assign)")
+    ap.add_argument("--description", help="description when creating the attribute")
+    ap.add_argument("--member-id", help="Sigma memberId to assign the value to (with --assign)")
+    ap.add_argument("--field", help="DM column display name to filter on (e.g. Region) — for the RLS snippet")
+    ap.add_argument("--element-id", help="DM element id the RLS calc col + filter attach to")
+    ap.add_argument("--dm-id", help="dataModelId (with --apply, to PATCH the element spec)")
+    ap.add_argument("--create", action="store_true", help="create the user attribute if no reusable match")
+    ap.add_argument("--assign", action="store_true", help="assign --value to --member-id")
+    ap.add_argument("--apply", action="store_true", help="PATCH the RLS calc col + filter into the DM element spec")
+    ap.add_argument("--from-security", help="path to a converter result.security[] JSON (batch RLS+CLS apply)")
+    ap.add_argument("--provision", action="store_true", help="create missing user attributes / teams (with --from-security)")
+    a = ap.parse_args()
+
+    # Batch mode: ingest a converter's result.security[] and provision + apply all rules.
+    if a.from_security:
+        if not a.dm_id:
+            sys.exit("--from-security requires --dm-id (the posted data model).")
+        raw = json.load(open(a.from_security))
+        security = raw.get("security", raw) if isinstance(raw, dict) else raw
+        return apply_from_security(a.dm_id, security, a.apply, a.provision)
+
+    if not a.attr:
+        sys.exit("Provide --attr (single-rule mode) or --from-security <json> (batch mode).")
+    # --- 1. reuse-first --------------------------------------------------
+    existing = find_attribute(a.attr)
+    attr_id = None
+    if existing:
+        attr_id = existing.get("userAttributeId") or existing.get("id")
+        print(f"REUSE: user attribute '{a.attr}' already exists "
+              f"(id={attr_id}, default={existing.get('defaultValue')}) — reusing, NOT creating.")
+    else:
+        print(f"No existing Sigma user attribute named '{a.attr}'.")
+        if a.create:
+            body = {"name": a.attr}
+            if a.description:
+                body["description"] = a.description
+            if a.value is not None:
+                body["defaultValue"] = {"val": a.value, "type": "string"}
+            res = api("POST", "/v2/user-attributes", body)
+            attr_id = res.get("userAttributeId") or res.get("id") if isinstance(res, dict) else None
+            print(f"CREATED user attribute '{a.attr}' (id={attr_id}).")
+        else:
+            print("  (plan only — pass --create to create it.)")
+
+    # --- 2. assign -------------------------------------------------------
+    if a.assign:
+        if not attr_id:
+            sys.exit("--assign needs an attribute id — create/reuse it first (no id resolved).")
+        if not a.member_id or a.value is None:
+            sys.exit("--assign requires --member-id and --value.")
+        body = {"assignments": [{"userId": a.member_id, "value": {"val": a.value, "type": "string"}}]}
+        res = api("POST", f"/v2/user-attributes/{attr_id}/users", body)
+        print(f"ASSIGNED '{a.attr}'={a.value} to member {a.member_id}: "
+              + (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif a.value is not None and a.member_id:
+        print(f"  (plan: would assign '{a.attr}'={a.value} to member {a.member_id} — pass --assign.)")
+
+    # --- 3. RLS spec snippet --------------------------------------------
+    if a.field:
+        if not a.element_id:
+            print("\nNOTE: --field given without --element-id; printing the formula only.")
+            print(f'  calc column formula: CurrentUserAttributeText("{a.attr}") = [{a.field}]')
+        else:
+            snip = rls_spec_snippet(a.attr, a.field, a.element_id)
+            print("\nRLS spec snippet (verified shape — boolean calc col + element list filter on True):")
+            print(json.dumps(snip, indent=2))
+            if a.apply:
+                if not a.dm_id:
+                    sys.exit("--apply requires --dm-id.")
+                apply_to_dm(a.dm_id, a.element_id, snip["calcColumn"], snip["filter"])
+            else:
+                print("  (plan only — pass --apply --dm-id <id> to PATCH it into the DM element spec.)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,0 +1,554 @@
+#!/usr/bin/env ruby
+# Hard gate that proves a tableau-to-sigma conversion is actually complete.
+# The subagent MUST run this script before declaring GREEN. It checks seven
+# independent things — failing ANY of them blocks the GREEN declaration:
+#
+#   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
+#      → beads-sigma-4pm
+#   2. No orphan workbooks left in the customer's My Documents
+#      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
+#      cleanup ran with no failed deletes)  → beads-sigma-38a
+#   3. The live workbook's /columns endpoint shows no column with
+#      type=error (catches circular refs / runtime errors introduced
+#      AFTER the initial POST's column-type guard ran)  → beads-sigma-38a
+#   4. The workbook has a non-empty layout XML applied (catches the
+#      "elements just listed in a single column" regression where the
+#      agent forgot to PUT a layout)  → beads-sigma-bw3
+#   5. Tile census — parity-final.json's `tile_census` field (emitted by the
+#      converter's phase6 finalize when a dashboard zone tree is available)
+#      shows no unexplained dashboard zones without a matching chart in the
+#      parity plan. Catches the "empty view CSV silently dropped a tile and
+#      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
+#      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the GridContainer bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
+#   7. Control lint (scripts/lib/control_lint.rb, shared) — no dead controls
+#      (a control with no resolving `filters` target AND no [controlId]
+#      formula reference is furniture: the "Orders Overview (from Looker)"
+#      estate shipped three of them), no ghost filter targets, and no control
+#      whose source-closure misses same-page queryable elements (the PHASEE
+#      "Action(Region) -> Monthly Revenue Trend" escape). Honors the
+#      control-scope sidecar (<workdir>/control-scope.json or
+#      --control-scope) for source-signal coverage (zero controls built from
+#      an interactive source = FAIL, the Qlik class) and per-control
+#      scope:[...] allowlists (intentional single-chart switchers like grain
+#      controls). See the lib header CONTRACT.
+#
+# Usage:
+#   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
+#     [--workbook-id <id>]     # override; default = read from wb-ids.json
+#     [--min-pass-rate 1.0]    # default 1.0 (every chart must PASS)
+#     [--allow-extract]        # treat extract-mode as acceptable
+#     [--skip-column-check]    # skip the live /columns type=error scan
+#     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
+#                              # that genuinely want multiple workbooks)
+#     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--skip-control-lint]    # skip gate 7 (control-wiring lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--control-scope PATH]   # control-scope.json sidecar for gate 7
+#                              # (default: <workdir>/control-scope.json)
+#     [--min-layout-elements N] default 2 — single-page bare-element layouts
+#                              # often have just the page wrapper; require this
+#                              # many <LayoutElement> tags
+#     [--allow-missing-tiles N] default 0 — tolerate up to N unmatched dashboard
+#                              # zones in the tile census (for legitimately
+#                              # unbuildable zones; name them in your report)
+#
+# Exit codes:
+#   0  every gate passes — conversion is allowed to declare GREEN
+#   1  parity-final.json missing (Phase 6 skipped — the regression case)
+#   2  parity-final.json exists but status=FAIL / pass-rate below min /
+#      extract-mode without --allow-extract / charts_total==0
+#   3  parity-final.json malformed
+#   4  orphan workbooks left uncleaned (beads-sigma-38a)
+#   5  live workbook has column(s) with type=error (beads-sigma-38a)
+#   6  live workbook has no layout applied — single-column fallback
+#      (beads-sigma-bw3)
+#   7  tile census shows unexplained unmatched dashboard zones beyond
+#      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
+#   9  control lint violations — dead controls / ghost targets / partial
+#      reach / source filter signals with zero controls
+#      (gate 7; scripts/lib/control_lint.rb)
+#
+# Prints a per-gate summary to stdout regardless of exit code.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
+         allow_missing_tiles: 0 }
+OptionParser.new do |p|
+  p.on('--tableau DIR')              { |v| opts[:tab] = v }
+  p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
+  p.on('--workbook-id ID')           { |v| opts[:wb] = v }
+  p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--allow-extract')            { opts[:allow_extract] = true }
+  p.on('--skip-column-check')        { opts[:skip_column] = true }
+  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
+  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
+  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+  p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
+  p.on('--skip-parity-gate REASON', 'waive gate 1 (Phase 6 source-parity) — REQUIRED reason string. Use ONLY when source parity is genuinely unavailable (e.g. no source workspace/dataset/warehouse access). The reason MUST be named in your migration report.') { |v| opts[:skip_parity] = v }
+end.parse!
+abort('--workdir (or --tableau) required') unless opts[:tab]
+
+summary_path = File.join(opts[:tab], 'parity-final.json')
+
+if opts[:skip_parity]
+  puts "[SKIP] gate 1/7: Phase 6 source-parity WAIVED via --skip-parity-gate (#{opts[:skip_parity]})."
+  puts "       This waiver MUST be named in the migration report — the workbook was NOT numerically verified vs the source."
+else
+  unless File.exist?(summary_path)
+    warn "[FAIL] Phase 6 skipped — #{summary_path} does not exist."
+    warn "       Run: ruby scripts/phase6-parity.rb --tableau #{opts[:tab]} --workbook-id <id>"
+    warn "       then collect actuals via mcp__sigma-mcp-v2__query and re-run with --finalize."
+    warn "       See SKILL.md Phase 6. This is the hard gate (beads-sigma-4pm)."
+    warn "       If source parity is genuinely unavailable (no workspace/dataset/warehouse access), waive"
+    warn "       with --skip-parity-gate \"<reason>\" and name it in the report."
+    exit 1
+  end
+
+  begin
+    summary = JSON.parse(File.read(summary_path))
+  rescue JSON::ParserError => e
+    warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
+    exit 3
+  end
+
+  total = summary['charts_total'].to_i
+  passed = summary['charts_pass'].to_i
+  status = summary['status'].to_s
+  mode = summary['mode'].to_s
+
+  if total <= 0
+    warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
+    warn "       This usually means auto-parity-plan.rb matched zero Tableau views."
+    warn "       Phase 6 must verify at least one chart to declare GREEN."
+    exit 2
+  end
+
+  if mode == 'extract' && !opts[:allow_extract]
+    warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
+    warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
+    warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
+    exit 2
+  end
+
+  pass_rate = passed.to_f / total
+  # status=PASS requires 100% — when the caller explicitly accepts a lower
+  # pass-rate (--min-pass-rate, for honest NAMED divergences like LOD
+  # placeholders / cross-grain semantics), the rate is the gate, not the status.
+  rate_gate_only = opts[:min_pass_rate] < 1.0
+  if (rate_gate_only ? pass_rate < opts[:min_pass_rate] : (status != 'PASS' || pass_rate < opts[:min_pass_rate]))
+    warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
+    warn "       Required: #{rate_gate_only ? '' : 'status=PASS and '}pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
+    if (fail_names = summary['fail_names']) && !fail_names.empty?
+      warn "       Failing charts: #{fail_names.join(', ')}"
+    end
+    exit 2
+  end
+
+  if rate_gate_only && status != 'PASS'
+    puts "[OK] gate 1/7: Phase 6 ran — #{passed}/#{total} charts PASS (>= #{(opts[:min_pass_rate] * 100).to_i}% accepted); " \
+         "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
+  else
+    puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 2 — orphan workbooks (beads-sigma-38a)
+# ---------------------------------------------------------------------------
+unless opts[:skip_orphan]
+  log = File.join(opts[:tab], 'posted-workbooks.jsonl')
+  if File.exist?(log)
+    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    unique_ids = posted.map { |e| e['id'] }.uniq
+    if unique_ids.length > 1
+      marker_path = File.join(opts[:tab], 'cleanup-marker.json')
+      unless File.exist?(marker_path)
+        warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "       posted-workbooks.jsonl entries:"
+        unique_ids.each { |id| warn "         - #{id}" }
+        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        warn "       See beads-sigma-38a."
+        exit 4
+      end
+      marker = JSON.parse(File.read(marker_path)) rescue {}
+      if marker['failed'] && !marker['failed'].empty?
+        warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "       Orphan workbooks are still in the customer's My Documents:"
+        marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
+        exit 4
+      end
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+        exit 4
+      end
+      kept = marker['kept'] || '(unknown)'
+      deleted = (marker['deleted'] || []).length
+      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+    else
+      puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+    end
+  else
+    puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+  end
+else
+  puts "[SKIP] gate 2/7: --skip-orphan-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 3 — live /columns type=error scan (beads-sigma-38a)
+# Catches circular references and runtime errors that the initial post-and-
+# readback column-type guard missed because they were introduced by later
+# PUTs (layout updates, spec edits during error recovery).
+# ---------------------------------------------------------------------------
+unless opts[:skip_column]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 3/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        cols = (JSON.parse(res.body)['entries'] rescue []) || []
+        error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
+        if error_cols.any?
+          warn "[FAIL] gate 3/7: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
+          warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
+          error_cols.first(10).each do |c|
+            warn "         element=#{c['elementId']} col=#{c['columnId']} label=#{c['label'].inspect}"
+            warn "           formula: #{c['formula']}"
+          end
+          warn "       See beads-sigma-38a."
+          exit 5
+        end
+        puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+      else
+        warn "[SKIP] gate 3/7: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 3/7: --skip-column-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 4 — layout applied (beads-sigma-bw3)
+# Fetches the live workbook spec and confirms a non-empty top-level `layout`
+# XML is set, with at least --min-layout-elements <LayoutElement> tags.
+# Catches the "agent forgot to PUT a layout" regression where elements
+# render as a single-column stack instead of the dashboard grid.
+# ---------------------------------------------------------------------------
+unless opts[:skip_layout]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 4/7: no workbook ID resolvable for layout check"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 4/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        body = res.body.to_s
+        spec =
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+          end
+        layout_xml = spec['layout'].to_s
+        elem_count = layout_xml.scan(/<LayoutElement\b/).length
+
+        # Detect the Sigma "auto-generated single-column stack" layout that
+        # the server produces when a workbook is POSTed without a layout.
+        # Signature: every non-Data page has all its elements at the same
+        # gridColumn value (typically "1 / 13" — left half, vertically stacked).
+        # Note: per-page detection — a workbook with one element per content
+        # page is structurally fine (degenerate case, not a stack).
+        # Container-banded pages (<GridContainer> bands per layout-playbook.md)
+        # are exempt: full-width band containers (and single-chart rows inside
+        # them) legitimately share gridColumn="1 / 25" — that is deliberate
+        # banding, not the auto-stack regression.
+        non_data_stack_pages = []
+        # Walk one page at a time using the <Page id="..."> blocks
+        layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
+          next if page_id.to_s.downcase.include?('data')
+          next if page_body.include?('<GridContainer')
+          cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
+          elems_on_page = page_body.scan(/<LayoutElement\b/).length
+          if elems_on_page >= 2 && cols_on_page.length == 1
+            non_data_stack_pages << [page_id, cols_on_page.first, elems_on_page]
+          end
+        end
+
+        if layout_xml.empty?
+          warn "[FAIL] gate 4/7: live workbook #{wb_id} has NO top-level layout XML."
+          warn "       Elements render as a single-column stack instead of the"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
+          warn "       then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
+          warn "           --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        elsif elem_count < opts[:min_layout_elements]
+          warn "[FAIL] gate 4/7: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
+          warn "       The layout likely covers only the Data page — chart page is unstyled."
+          exit 6
+        elsif non_data_stack_pages.any?
+          warn "[FAIL] gate 4/7: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "       single-column stack layout (multiple elements at the same gridColumn"
+          warn "       on a non-Data page). This is what Sigma defaults to when you POST"
+          warn "       a workbook without a layout — exactly the CoCo regression."
+          non_data_stack_pages.each do |pid, col, n|
+            warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
+          end
+          warn "       Rebuild the layout with this skill's layout builder (see SKILL.md —"
+          warn "       layout phase) into #{opts[:tab]}/layout.xml, then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        else
+          puts "[OK] gate 4/7: layout XML applied with #{elem_count} positioned element(s)"
+        end
+      else
+        warn "[SKIP] gate 4/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 4/7: --skip-layout-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 5 — tile census (bead gjhe)
+# parity-final.json's `tile_census` field compares the source dashboard's
+# chart-zone count against the charts that made it into the parity plan.
+# Catches the empty-view-CSV escape where the builder silently emits N-1
+# charts and parity still reports PASS (every chart it knows about passes —
+# it just doesn't know about the dropped one).
+# ---------------------------------------------------------------------------
+census = summary && summary['tile_census']  # summary is nil when gate 1 was waived
+if census.nil?
+  puts "[SKIP] gate 5/7: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+else
+  zones     = census['zones_total'].to_i
+  built     = census['charts_built'].to_i
+  unmatched = census['zones_unmatched'].to_i
+  names     = Array(census['unmatched_zone_names'])
+  if unmatched > opts[:allow_missing_tiles]
+    warn "[FAIL] gate 5/7: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    names.each { |n| warn "         - #{n}" }
+    warn "       A zone that rendered in the source dashboard has NO matching chart in the"
+    warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
+    warn "       (re-fetch the view data and rebuild), or the tile was renamed without"
+    warn "       passing --rename to phase6-parity.rb / build-dashboard-layout.rb."
+    warn "       If #{unmatched} zone(s) are legitimately unbuildable, re-run with"
+    warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
+    exit 7
+  elsif unmatched > 0
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+  else
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/7: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/7: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/7: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts '[OK] gate 6/7: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
+      else
+        warn "[SKIP] gate 6/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7 — control-wiring lint (scripts/lib/control_lint.rb, shared)
+# A workbook can pass every gate above and still ship controls that do
+# NOTHING (dead controls: no resolving filter target, no [controlId] formula
+# reference — the "Orders Overview (from Looker)" estate escape) or controls
+# that silently skip same-page charts (the PHASEE "Action(Region) ->
+# Monthly Revenue Trend" escape). This gate mechanizes those checks on the
+# LIVE spec, plus source-signal coverage when a control-scope sidecar exists
+# (zero controls built from an interactive source = FAIL, the Qlik class).
+# ---------------------------------------------------------------------------
+if opts[:skip_control_lint]
+  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 7/7: no workbook ID resolvable for control lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 7/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/control_lint'
+    rescue LoadError
+      warn "[SKIP] gate 7/7: scripts/lib/control_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(ControlLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        scope_path = opts[:control_scope] || File.join(opts[:tab], 'control-scope.json')
+        scope = nil
+        if File.exist?(scope_path)
+          scope = JSON.parse(File.read(scope_path)) rescue nil
+          warn "[WARN] gate 7/7: #{scope_path} is not valid JSON — linting without source scope" if scope.nil?
+        end
+        violations = ControlLint.lint(spec, scope: scope)
+        if violations.any?
+          warn "[FAIL] gate 7/7: control lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the control wiring and re-PUT (dead controls -> add filters targets"
+          warn "       ({source:{elementId}, columnId}) or remove the control; partial reach ->"
+          warn "       wire the uncovered elements or annotate controlScope in control-scope.json;"
+          warn "       see scripts/lib/control_lint.rb CONTRACT), then re-run this gate."
+          warn "       Flip-test the wiring live with: ruby scripts/probe-controls.rb --workbook-id #{wb_id}"
+          warn "       Escape hatch (legacy workbooks only): --skip-control-lint."
+          exit 9
+        end
+        n_controls = ControlLint.controls_report(spec).length
+        puts "[OK] gate 7/7: control lint clean (#{n_controls} control(s); no dead controls, no ghost " \
+             "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
+      else
+        warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+puts "[OK] all gates pass — conversion may declare GREEN"
+exit 0

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/build-bookmark-workbooks.py
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/build-bookmark-workbooks.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""build-bookmark-workbooks.py — one Sigma workbook per saved view-state.
+
+VENDOR-NEUTRAL. Power BI bookmarks (extract-bookmarks.py) and Tableau custom
+views / story points (extract-custom-views.py) both normalize to the same
+state shape; this builds one Sigma workbook per state:
+
+  state = { name, displayName,
+            hidden:[visualId], spotlight:[visualId],   # show/hide  -> visible subset
+            filters: { "<column display name>": [values] } }  # filter state -> baked
+
+Per state:
+  - spotlight non-empty -> keep ONLY the spotlighted visuals (focus)
+  - else                -> all base visuals MINUS `hidden`
+  - filters             -> baked as a `list` filter on the Data-page MASTER
+                           element(s) carrying that column, so every chart that
+                           sources the master inherits it (page-filter semantics)
+
+The signals->workbook build is delegated to a vendor builder via --build-script
+(PBI: build-workbook-from-pbir.rb; Tableau: build-charts-from-signals.rb), so
+this orchestration is shared. Lives in tableau-to-sigma/scripts (the shared
+core); powerbi-to-sigma symlinks it.
+
+Usage:
+  python3 build-bookmark-workbooks.py --signals base/signals.json \
+    --bookmarks states.json --master-map mm.json --data-model <dmId> \
+    --folder-id <uuid> --name-prefix "<Report>" --out-dir /tmp/bm \
+    [--build-script /path/to/build-workbook-from-pbir.rb]
+"""
+import argparse, json, os, subprocess, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+def _bake_filters(spec, filters):
+    """Add `list` filters to the Data-page master element(s) holding each column."""
+    if not filters:
+        return 0
+    n = 0
+    masters = [el for pg in spec.get("pages", []) if pg.get("id") == "page-data"
+               for el in pg.get("elements", [])]
+    for col, vals in filters.items():
+        vlist = vals if isinstance(vals, list) else [vals]
+        for el in masters:
+            hit = next((c for c in el.get("columns", [])
+                        if (c.get("name") or "").lower() == str(col).lower()), None)
+            if not hit:
+                continue
+            el.setdefault("filters", []).append({
+                "id": f"bmf-{col}".replace(" ", "")[:20],
+                "columnId": hit["id"], "kind": "list", "mode": "include", "values": vlist})
+            n += 1
+    return n
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--signals", required=True); ap.add_argument("--bookmarks", required=True)
+    ap.add_argument("--master-map", required=True); ap.add_argument("--data-model", required=True)
+    ap.add_argument("--folder-id", required=True); ap.add_argument("--name-prefix", required=True)
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--build-script", default=os.path.join(HERE, "build-workbook-from-pbir.rb"),
+                    help="vendor signals->workbook builder (default: build-workbook-from-pbir.rb)")
+    a = ap.parse_args()
+    base = json.load(open(a.signals)); states = json.load(open(a.bookmarks))["bookmarks"]
+    os.makedirs(a.out_dir, exist_ok=True)
+    page = base["pages"][0]; all_vis = page["visuals"]; built = []
+    for b in states:
+        hidden, spot = set(b.get("hidden", [])), set(b.get("spotlight", []))
+        vis = ([v for v in all_vis if v["visual_id"] in spot] if spot
+               else [v for v in all_vis if v["visual_id"] not in hidden])
+        if not vis:
+            print(f"  [skip] {b['displayName']}: no visible visuals", file=sys.stderr); continue
+        d = os.path.join(a.out_dir, b["name"]); os.makedirs(d, exist_ok=True)
+        sigp = os.path.join(d, "signals.json")
+        json.dump(dict(base, pages=[dict(page, visuals=vis)]), open(sigp, "w"), indent=2)
+        spec = os.path.join(d, "workbook-spec.json"); lay = os.path.join(d, "layout.xml")
+        name = f"{a.name_prefix} — {b['displayName']} (from Power BI)"
+        r = subprocess.run(["ruby", a.build_script, "--signals", sigp, "--master-map", a.master_map,
+            "--data-model", a.data_model, "--name", name, "--folder-id", a.folder_id,
+            "--out", spec, "--layout-out", lay], capture_output=True, text=True)
+        if r.returncode != 0 or not os.path.exists(spec):
+            print(f"  ERR {b['displayName']}: {r.stderr[-200:]}", file=sys.stderr); continue
+        nf = 0
+        if b.get("filters"):                              # bake filter-state onto the master(s)
+            s = json.load(open(spec)); nf = _bake_filters(s, b["filters"]); json.dump(s, open(spec, "w"), indent=2)
+        print(f"  OK  {b['displayName']:22} {len(vis)} visual(s), {nf} filter(s) -> {spec}", file=sys.stderr)
+        built.append({"bookmark": b["name"], "name": name, "spec": spec, "layout": lay,
+                      "visuals": len(vis), "filters": nf})
+    json.dump({"built": built}, open(os.path.join(a.out_dir, "manifest.json"), "w"), indent=2)
+    print(f"[bookmark-workbooks] built {len(built)} -> {a.out_dir}/manifest.json", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/build-charts-from-signals.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/build-charts-from-signals.rb
@@ -1,0 +1,1533 @@
+#!/usr/bin/env ruby
+# Build Sigma chart-element specs from parse-twb-layout.rb output + view CSVs +
+# a master-column map.
+#
+# The agent's job is the data model + master table (deciding which DM columns
+# the master needs, naming them, wiring Lookup/Coalesce as needed). This
+# script's job is the chart layer: translating each Tableau chart zone into a
+# Sigma element using the new parser signals (chart_kind, sort, aggregations,
+# channels, filters) so chart kind / aggregator / sort match the source instead
+# of relying on agent defaults.
+#
+# Usage:
+#   ruby scripts/build-charts-from-signals.rb \
+#     --tableau-dir /tmp/<name> \
+#     --layout /tmp/<name>/dashboard-layout.json \
+#     --master-map /tmp/<name>/master-columns.json \
+#     --master-element-id master \
+#     --out /tmp/<name>/chart-specs.json
+#
+# Inputs:
+#   --tableau-dir       directory with get-workbook.json + views/<viewId>.csv
+#   --layout            parse-twb-layout.rb output (per-dashboard zone list)
+#   --master-map        JSON: regex-string → { id, name } mapping CSV header tokens
+#                       to master-table column IDs. Example:
+#                       { "(?i)region":      { "id": "m-region",  "name": "Region" },
+#                         "(?i)gross revenue": { "id": "m-gross-rev", "name": "Gross Revenue" } }
+#   --master-element-id ID of the master table in the workbook (default "master")
+#   --out               output JSON: array of chart-element specs ready to embed
+#                       in a workbook spec's pages[].elements[]
+#
+# Per chart zone, the script reads the matching view CSV's first two headers
+# (dim + measure). It then:
+#   - Maps each header to a master column using the regex map.
+#   - Picks the Sigma element `kind` from chart_kind (with `automatic` → bar
+#     fallback + a warning to verify against the PNG).
+#   - Reads zone.sort: emits xAxis.sort iff Tableau had a <sort>. Otherwise
+#     leaves xAxis unsorted (Sigma renders natural categorical / date order).
+#   - Reads zone.aggregations: applies the right Sigma aggregator. Tableau
+#     "Sum"→Sum, "Avg"→Avg, "Min"→Min, "Max"→Max, "Median"→Median,
+#     "CountD"→CountDistinct, "None"→raw column (no agg), "User"→already-
+#     aggregated calc field formula (use as-is via the master column).
+#   - Reads zone.channels.color: if present, build one yAxis per category in
+#     the master column's distinct values (best-effort — agent should fill in
+#     the real category list when they know it; we emit a TODO marker).
+#   - Skips action filters ("[Action (Foo)]") — those are cross-chart dashboard
+#     actions, not value filters.
+#
+# Output: array of element specs. Drop into pages[].elements[] in the workbook
+# spec and POST via post-and-readback.rb.
+
+require 'json'
+require 'csv'
+require 'date'
+require 'optparse'
+require_relative 'learned-rules'
+
+opts = { master_id: 'master' }
+OptionParser.new do |p|
+  p.on('--tableau-dir DIR')         { |v| opts[:tab] = v }
+  p.on('--layout PATH')             { |v| opts[:layout] = v }
+  p.on('--meta PATH', 'parse-twb-layout sister meta file (worksheets+shared_filters)') { |v| opts[:meta] = v }
+  p.on('--master-map PATH')         { |v| opts[:mmap] = v }
+  p.on('--master-element-id ID')    { |v| opts[:master_id] = v }
+  p.on('--controls PATH', 'JSON file: array of control specs to emit alongside the chart elements') { |v| opts[:controls] = v }
+  p.on('--title STR',     'Dashboard title text element to emit (e.g., "Orders Dashboard")')         { |v| opts[:title] = v }
+  p.on('--page-per-worksheet', 'Emit one Sigma page per Tableau worksheet (ignore dashboard layout)') { opts[:pages_mode] = :worksheet }
+  p.on('--auto-controls', 'Auto-emit Sigma controls from shared-view filters in --meta')              { opts[:auto_controls] = true }
+  p.on('--out PATH')                { |v| opts[:out] = v }
+end.parse!
+%i[tab layout mmap out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+# ---- chart_kind → Sigma element kind ----
+SIGMA_KIND = {
+  'bar'           => 'bar-chart',
+  'line'          => 'line-chart',
+  'area'          => 'area-chart',
+  'pie'           => 'pie-chart',
+  'scatter'       => 'scatter-chart',
+  'combo'         => 'combo-chart',
+  'map-region'    => 'region-map',
+  'map-point'     => 'point-map',
+  'pivot-table'   => 'pivot-table',
+  'table'         => 'table',
+  'kpi'           => 'kpi-chart',
+  'table-or-text' => 'table',         # legacy parser output — kept for back-compat
+  'automatic'     => 'bar-chart',     # fallback; agent verifies against PNG
+  'other'         => 'bar-chart'
+}.freeze
+
+# ---- Tableau derivation → Sigma aggregation function name ----
+SIGMA_AGG = {
+  'Sum'    => 'Sum',
+  'Avg'    => 'Avg',
+  'Min'    => 'Min',
+  'Max'    => 'Max',
+  'Median' => 'Median',
+  'CountD' => 'CountDistinct',
+  'Count'  => 'CountIf(IsNotNull(%s))',  # special — see render_agg below
+  'None'   => nil,                       # no aggregation; raw column ref
+  'User'   => nil                        # user-defined calc — already aggregated
+}.freeze
+
+# ---- Date truncation derivations ----
+DATE_TRUNC = {
+  'Year-Trunc'   => 'year',
+  'Quarter-Trunc'=> 'quarter',
+  'Month-Trunc'  => 'month',
+  'Week-Trunc'   => 'week',
+  'Day-Trunc'    => 'day',
+  'Hour-Trunc'   => 'hour'
+}.freeze
+
+# Tableau "this year/quarter/month" (relative-date first=0,last=0) → explicit
+# [startDate, endDate] bounds for the CURRENT period. Returns [nil, nil] for
+# periods we don't bound (caller falls back to a pass-through relative filter).
+#
+# Why bounds and not Sigma `mode: relative`/`current`: a relative/current date
+# filter only applies at UI render time — it does NOT filter the chart-data SQL
+# (Phase 6 parity showed every relative-date chart returning unfiltered data).
+# Hardcoded bounds apply at query time AND on the UI. Trade-off: the filter
+# "freezes" — it must be refreshed when the period rolls over.
+def current_period_bounds(period, now = Time.now)
+  case period.to_s.downcase
+  when 'year'
+    ["#{now.year}-01-01T00:00:00Z", "#{now.year}-12-31T23:59:59Z"]
+  when 'quarter'
+    q       = ((now.month - 1) / 3) + 1
+    start_m = (q - 1) * 3 + 1
+    end_m   = start_m + 2
+    end_day = Date.new(now.year, end_m, -1).day
+    ["#{now.year}-#{start_m.to_s.rjust(2, '0')}-01T00:00:00Z",
+     "#{now.year}-#{end_m.to_s.rjust(2, '0')}-#{end_day.to_s.rjust(2, '0')}T23:59:59Z"]
+  when 'month'
+    last = Date.new(now.year, now.month, -1).day
+    [now.strftime('%Y-%m-01T00:00:00Z'),
+     now.strftime("%Y-%m-#{last.to_s.rjust(2, '0')}T23:59:59Z")]
+  else
+    [nil, nil]
+  end
+end
+
+def render_agg(agg, master_col_ref)
+  return master_col_ref if agg.nil?
+  if agg.include?('%s')
+    agg.sub('%s', master_col_ref)
+  else
+    "#{agg}(#{master_col_ref})"
+  end
+end
+
+# Translate the Tableau column reference inside aggregations dict to a clean key
+# we can look up. Tableau uses internal IDs like "[33b6c718-9b55-3dc0-9698-…]"
+# OR friendly names like "[NET_REVENUE]". We strip the brackets for matching.
+def strip_brackets(s)
+  s.to_s.sub(/^\[/, '').sub(/\]$/, '')
+end
+
+# Match a CSV header (e.g., "Gross Revenue", "Distinct count of Order Id") to
+# a master-table column using regex map.
+def map_column(header, mmap)
+  # Strip leading/trailing whitespace from the header before matching. Tableau
+  # column captions sometimes carry trailing whitespace (e.g., "Order Date ")
+  # from the source .twb XML — `(?i)^order date$` won't match it without this.
+  h = header.to_s.strip
+  mmap.each do |pat, info|
+    return info if Regexp.new(pat).match?(h)
+  end
+  nil
+end
+
+# Pick the best aggregation for a header. CSV headers often hint at the
+# aggregation ("Sum of X" / "Distinct count of X" / etc.).
+def infer_csv_agg(header)
+  case header.to_s
+  when /^sum of /i        then 'Sum'
+  when /^avg of /i        then 'Avg'
+  when /^min of /i        then 'Min'
+  when /^max of /i        then 'Max'
+  when /^median of /i     then 'Median'
+  when /\bdistinct count\b/i then 'CountD'
+  when /\bcount\b/i       then 'Count'
+  else nil
+  end
+end
+
+# ---- Load inputs ----
+layout = JSON.parse(File.read(opts[:layout]))
+mmap   = JSON.parse(File.read(opts[:mmap]))
+meta   = opts[:meta] ? JSON.parse(File.read(opts[:meta])) : { 'worksheets' => {}, 'shared_filters' => [] }
+# Customer-learned rules (~/.tableau-to-sigma/learned-rules.yaml). Empty list
+# is normal for first-time customers — rules accumulate as the gap-scout
+# subagent validates translations.
+LEARNED_RULES = LearnedRules.load
+warn "loaded #{LEARNED_RULES.length} customer-learned rule(s) from #{LearnedRules.rules_path}" if LEARNED_RULES.any?
+gw     = JSON.parse(File.read(File.join(opts[:tab], 'get-workbook.json')))
+views  = gw.dig('views', 'view') || []
+views  = [views] unless views.is_a?(Array)
+view_by_name = views.each_with_object({}) { |v, h| h[v['name']] = v }
+
+# Translate a Tableau format-value string (already parsed by the parser's
+# translate_format) into a Sigma format hash. Done here so we don't fork the
+# parser logic — we just call into it via a duplicated minimal translator.
+def tableau_format_to_sigma(s)
+  return nil if s.nil? || s.empty?
+  segments = s.split(';')
+  pos = segments[0] || s
+  neg = segments[1]
+  prefix = (neg && neg.include?('(') && neg.include?(')')) ? '(' : ''
+  if (m = pos.match(/^p\d*(?:\.(\d+))?%$/i))
+    decimals = (m[1] || '').length
+    return { 'kind' => 'number', 'formatString' => "#{prefix},.#{decimals}%" }
+  end
+  if (m = pos.match(/^C\d+(?:\.(\d+))?%?$/))
+    decimals = (m[1] || '').length
+    return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{decimals}f", 'currencySymbol' => '$' }
+  end
+  if pos =~ /^c?["\\]*\$/ || pos.start_with?('$')
+    decimals = (pos.match(/\.(0+)/) || [])[1].to_s.length
+    return { 'kind' => 'number', 'formatString' => "#{prefix}$,.#{decimals}f", 'currencySymbol' => '$' }
+  end
+  if pos =~ /^[#,0]+(?:\.(0+))?$/
+    decimals = ($1 || '').length
+    return { 'kind' => 'number', 'formatString' => "#{prefix},.#{decimals}f" }
+  end
+  if s =~ /yyyy|MMM|MM|dd|HH/
+    f = s.gsub('yyyy','%Y').gsub('yy','%y').gsub('MMMM','%B').gsub('MMM','%b').gsub('MM','%m')
+         .gsub('dd','%d').gsub('HH','%H').gsub('mm','%M').gsub('ss','%S')
+    return { 'kind' => 'datetime', 'formatString' => f }
+  end
+  nil
+end
+
+# Sigma formulas reference controls by `controlId` in brackets, NOT by display
+# name. This helper computes the controlId the auto-controls block will emit
+# for a given parameter caption so the translated Switch/If formulas match.
+def param_control_ref(caption)
+  "[ctl-param-#{caption.downcase.gsub(/\W+/, '-').sub(/-$/, '')}]"
+end
+
+# ---- Tableau table-calc translators ---------------------------------------
+# Translate Tableau table-calculation functions to their Sigma equivalents.
+# Returns the translated formula, plus a hint about Sigma-specific caveats
+# (e.g., "window functions silently error in grouping-table charts — add to a
+# non-grouping context or Custom SQL DM element").
+#
+# Function mappings (Sigma names):
+#   INDEX()                  → RowNumber()
+#   LOOKUP(expr, n)          → Lag(expr, n)  (positive n) / Lead(expr, -n) (neg)
+#   LOOKUP(expr, 0)          → expr  (zero offset is identity)
+#   RANK(expr [, 'desc'])    → Rank(expr [, "desc"])
+#   RANK_DENSE(expr)         → RankDense(expr)
+#   RANK_UNIQUE(expr)        → RowNumber() within ranked partition
+#   RANK_PERCENTILE(expr)    → RankPercentile(expr)
+#   TOTAL(SUM(x))            → Sum(x)  (Sigma metric on master without dim group)
+#   SIZE()                   → Count(*) OVER ()  — no direct Sigma fn; warn
+#   FIRST()                  → RowNumber() - 1   (Tableau FIRST returns 0-indexed)
+#   LAST()                   → no direct equiv; needs Count-RowNumber pattern
+#   ZN(x)                    → Coalesce(x, 0)
+#   COUNTD(x)                → CountDistinct(x)
+#   IIF(c, t, e)             → If(c, t, e)
+#   IFNULL(x, y)             → Coalesce(x, y)
+def translate_tableau_tc(formula)
+  return [nil, nil] if formula.nil? || formula.empty?
+  s = formula.dup
+  hints = []
+  changed = false
+
+  # Order matters — apply table-calc translations BEFORE simple renames so the
+  # match patterns (LOOKUP / TOTAL(COUNTD()) etc.) see the original Tableau
+  # syntax.
+
+  # INDEX() → RowNumber()
+  if s.gsub!(/\bINDEX\s*\(\s*\)/, 'RowNumber()')
+    hints << 'INDEX()→RowNumber()'; changed = true
+  end
+
+  # LOOKUP(expr, 0) — drop the wrapper. Use a balanced-paren match.
+  while s =~ /\bLOOKUP\s*\(\s*((?:[^,()]|\([^()]*\)|\([^()]*\([^()]*\)[^()]*\))+?)\s*,\s*0\s*\)/
+    s = s.sub($~[0], $1)
+    hints << 'LOOKUP(x, 0)→x'; changed = true
+  end
+  # LOOKUP(expr, -n) → Lead(expr, n)
+  while s =~ /\bLOOKUP\s*\(\s*((?:[^,()]|\([^()]*\)|\([^()]*\([^()]*\)[^()]*\))+?)\s*,\s*-(\d+)\s*\)/
+    s = s.sub($~[0], "Lead(#{$1}, #{$2})")
+    hints << 'LOOKUP(x, -n)→Lead(x, n)'; changed = true
+  end
+  # LOOKUP(expr, n) where n >= 1 → Lag(expr, n)
+  while s =~ /\bLOOKUP\s*\(\s*((?:[^,()]|\([^()]*\)|\([^()]*\([^()]*\)[^()]*\))+?)\s*,\s*(\d+)\s*\)/
+    s = s.sub($~[0], "Lag(#{$1}, #{$2})")
+    hints << 'LOOKUP(x, n)→Lag(x, n)'; changed = true
+  end
+
+  # TOTAL(SUM(x)) → Sum(x); TOTAL(COUNTD(x)) → CountDistinct(x); TOTAL(AVG(x))
+  if s.gsub!(/\bTOTAL\s*\(\s*SUM\s*\(((?:[^()]|\([^()]*\))+)\)\s*\)/, 'Sum(\1)')
+    hints << 'TOTAL(SUM(x))→Sum(x) (non-grouping context)'; changed = true
+  end
+  if s.gsub!(/\bTOTAL\s*\(\s*COUNTD\s*\(((?:[^()]|\([^()]*\))+)\)\s*\)/, 'CountDistinct(\1)')
+    hints << 'TOTAL(COUNTD(x))→CountDistinct(x) (non-grouping context)'; changed = true
+  end
+  if s.gsub!(/\bTOTAL\s*\(\s*AVG\s*\(((?:[^()]|\([^()]*\))+)\)\s*\)/, 'Avg(\1)')
+    hints << 'TOTAL(AVG(x))→Avg(x) (non-grouping context)'; changed = true
+  end
+
+  # RANK([col], 'desc') / RANK([col]) / RANK_DENSE / RANK_PERCENTILE
+  if s.gsub!(/\bRANK\s*\(\s*((?:[^,()]|\([^()]*\))+?)\s*,\s*'(asc|desc)'\s*\)/, 'Rank(\1, "\2")')
+    hints << "RANK→Rank"; changed = true
+  end
+  if s.gsub!(/\bRANK\s*\(\s*((?:[^,()]|\([^()]*\))+?)\s*\)/, 'Rank(\1)')
+    hints << "RANK→Rank"
+    changed = true
+  end
+  if s.gsub!(/\bRANK_DENSE\s*\(\s*((?:[^,()]|\([^()]*\))+?)\s*\)/, 'RankDense(\1)')
+    hints << "RANK_DENSE→RankDense"; changed = true
+  end
+  if s.gsub!(/\bRANK_PERCENTILE\s*\(\s*((?:[^,()]|\([^()]*\))+?)\s*\)/, 'RankPercentile(\1)')
+    hints << "RANK_PERCENTILE→RankPercentile"; changed = true
+  end
+
+  # Simple renames done AFTER table-calc rewrites so the table-calc patterns
+  # match the original Tableau spelling.
+  if s.gsub!(/\bZN\s*\(/, 'Coalesce(')
+    # ZN takes one arg; pair the matching close-paren and append `, 0`. Walk
+    # the string and balance parens to find the right `)`.
+    out = String.new
+    i = 0
+    while i < s.length
+      if s[i, 9] == 'Coalesce(' && (i == 0 || s[i - 1] !~ /\w/)
+        out << 'Coalesce('
+        depth = 1
+        j = i + 9
+        while j < s.length && depth > 0
+          depth += 1 if s[j] == '('
+          depth -= 1 if s[j] == ')'
+          break if depth == 0
+          j += 1
+        end
+        out << s[i + 9...j] << ', 0)'
+        i = j + 1
+      else
+        out << s[i]
+        i += 1
+      end
+    end
+    s = out
+    changed = true
+  end
+  if s.gsub!(/\bIIF\s*\(/, 'If(')
+    changed = true
+  end
+  if s.gsub!(/\bIFNULL\s*\(/, 'Coalesce(')
+    changed = true
+  end
+  if s.gsub!(/\bCOUNTD\s*\(/, 'CountDistinct(')
+    changed = true
+  end
+
+  # SIZE() — no direct Sigma equivalent for partition size at the formula level.
+  # Leave as-is and warn so the agent rewrites manually (commonly Count(*)+OVER).
+  if s.include?('SIZE()')
+    hints << 'SIZE() has no direct Sigma equivalent — rewrite as Count(*) in a non-grouping context or Custom SQL'
+  end
+
+  # FIRST() / LAST() — special.
+  if s.include?('FIRST()')
+    hints << 'FIRST() → RowNumber() - 1 (Tableau FIRST is 0-indexed first row)'
+  end
+  if s.include?('LAST()')
+    hints << 'LAST() → no direct Sigma equivalent — use a Count() - RowNumber() pattern or Custom SQL'
+  end
+
+  # LOD calcs — Tableau's `{FIXED [dim] : AGG([m])}` family.
+  # Translation strategy (Sigma):
+  #   {FIXED [dim] : SUM([m])}    → workbook metric `Sum([m])` grouped by [dim]
+  #                                 OR Custom SQL `SUM(m) OVER (PARTITION BY dim)`
+  #   {FIXED : SUM([m])}          → unscoped `Sum([m])` (workbook-level scalar)
+  #   {INCLUDE [dim] : SUM([m])}  → add [dim] to chart grouping and just use Sum
+  #   {EXCLUDE [dim] : SUM([m])}  → remove [dim] from chart grouping, use Sum
+  # The full translation needs context (chart's grouping cols), so we surface
+  # the suggested Sigma expression as a hint rather than auto-emitting.
+  if s =~ /\{\s*FIXED\s+\[([^\]]+)\]\s*:\s*(SUM|AVG|MIN|MAX|COUNT|COUNTD)\s*\(\[([^\]]+)\]\)\s*\}/i
+    dim, agg, m = $1, $2.upcase, $3
+    sigma_agg = { 'SUM' => 'Sum', 'AVG' => 'Avg', 'MIN' => 'Min', 'MAX' => 'Max',
+                  'COUNT' => 'Count', 'COUNTD' => 'CountDistinct' }[agg]
+    sigma_expr = "#{sigma_agg}([Master/#{m}]) over the partition of [Master/#{dim}]"
+    hints << "FIXED LOD → #{sigma_expr}; OR Custom SQL DM element with #{agg}(#{m}) OVER (PARTITION BY #{dim})"
+    changed = true
+  end
+  if s =~ /\{\s*FIXED\s*:\s*(SUM|AVG|MIN|MAX|COUNT|COUNTD)\s*\(\[([^\]]+)\]\)\s*\}/i
+    agg, m = $1.upcase, $2
+    sigma_agg = { 'SUM' => 'Sum', 'AVG' => 'Avg', 'MIN' => 'Min', 'MAX' => 'Max',
+                  'COUNT' => 'Count', 'COUNTD' => 'CountDistinct' }[agg]
+    hints << "FIXED-no-dim LOD → workbook scalar metric #{sigma_agg}([Master/#{m}]) (no group by)"
+    changed = true
+  end
+  if s =~ /\{\s*INCLUDE\s+\[([^\]]+)\]\s*:\s*(SUM|AVG)\s*\(\[([^\]]+)\]\)\s*\}/i
+    dim, agg, m = $1, $2.upcase, $3
+    hints << "INCLUDE LOD on [#{dim}] → add [Master/#{dim}] to chart grouping, use plain #{agg}([Master/#{m}])"
+    changed = true
+  end
+  if s =~ /\{\s*EXCLUDE\s+\[([^\]]+)\]\s*:\s*(SUM|AVG)\s*\(\[([^\]]+)\]\)\s*\}/i
+    dim, agg, m = $1, $2.upcase, $3
+    hints << "EXCLUDE LOD on [#{dim}] → remove [Master/#{dim}] from chart grouping, use plain #{agg}([Master/#{m}])"
+    changed = true
+  end
+
+  return [nil, nil] unless changed
+  hints.uniq!
+  hints << 'NOTE: Sigma window functions (Rank/Lag/Lead/Cumulative*) silently error in grouping-table charts and DM-element calc cols — add to a workbook-master non-grouping context OR a Custom SQL DM element' if hints.any? { |h| h =~ /Rank|Lag|Lead|RowNumber/ }
+  [s, hints.join('; ')]
+end
+
+# ---- Parameter / CASE translator ------------------------------------------
+# Tableau CASE-on-parameter:
+#   CASE [Parameters].[Analysis Type]
+#     WHEN "Customer Type" THEN [CUSTOMER_TYPE]
+#     WHEN "Overall"       THEN "Overall"
+#     WHEN "Region"        THEN [REGION_NAME]
+#     ELSE "Country"
+#   END
+# Sigma:
+#   Switch([Analysis Type], "Customer Type", [Customer Type], "Overall",
+#          "Overall", "Region", [Region Name], "Country")
+#
+# We accept the slightly-loose form Tableau uses (`Case` token-case insensitive,
+# bracket refs for parameter and for dim columns, mixed quoted strings).
+def translate_case_on_param(formula, param_captions)
+  return nil unless formula =~ /\bCASE\b/i
+  # Strip newlines + collapse spaces
+  s = formula.gsub(/\s+/, ' ').strip
+  m = s.match(/\bCASE\b\s+(.*?)\s+(WHEN\b.*?)\s+\bEND\b/i)
+  return nil unless m
+  param_ref = m[1].strip   # the value being switched, e.g. [Parameters].[X] or [X]
+  body = m[2]
+  # Pull WHEN ... THEN ... pairs + optional ELSE
+  pairs = body.scan(/WHEN\s+(.+?)\s+THEN\s+(.+?)(?=\s+WHEN\b|\s+ELSE\b|\z)/i).map { |a, b| [a.strip, b.strip] }
+  else_match = body.match(/\bELSE\b\s+(.+)\z/i)
+  else_expr = else_match && else_match[1].strip
+  return nil if pairs.empty?
+  # Normalise parameter reference: prefer the human caption when we know it,
+  # otherwise strip [Parameters].[...] wrapping.
+  param_caption = nil
+  if (mm = param_ref.match(/\[Parameters?(?:\s*\([^)]*\))?\]\s*\.\s*\[([^\]]+)\]/i))
+    param_caption = mm[1]
+  elsif (mm = param_ref.match(/\[([^\]]+)\]/))
+    param_caption = mm[1] if param_captions.include?(mm[1])
+  end
+  return nil unless param_caption
+  parts = [param_control_ref(param_caption)]
+  pairs.each { |when_val, then_val| parts << when_val; parts << then_val }
+  parts << else_expr if else_expr
+  "Switch(#{parts.join(', ')})"
+end
+
+# Translate IF/ELSEIF chains on a parameter ref:
+#   IF [Param] = "A" THEN x ELSEIF [Param] = "B" THEN y ELSE z END
+# → Switch([Param], "A", x, "B", y, z)
+def translate_if_chain_on_param(formula, param_captions)
+  s = formula.gsub(/\s+/, ' ').strip
+  return nil unless s =~ /\bIF\b.*\bEND\b/i
+  return nil unless param_captions.any? { |cap| s.include?("[#{cap}]") }
+  m = s.match(/\bIF\b\s+(.+?)\s+\bEND\b/i)
+  return nil unless m
+  body = m[1]
+  # Pull `<cond> THEN <result>` segments delimited by ELSEIF
+  segs = body.scan(/(.+?)\s+THEN\s+(.+?)(?=\s+ELSEIF\b|\s+ELSE\b|\z)/i).map { |c, r| [c.strip, r.strip] }
+  else_match = body.match(/\bELSE\b\s+(.+)\z/i)
+  else_expr = else_match && else_match[1].strip
+  return nil if segs.empty?
+  # All conditions must be `[Param] = "..."` for the same parameter
+  param_caption = nil
+  cases = []
+  segs.each do |cond, result|
+    cm = cond.match(/\[([^\]]+)\]\s*=\s*("[^"]*"|'[^']*'|\S+)/)
+    return nil unless cm
+    p_cap = cm[1]
+    return nil unless param_captions.include?(p_cap)
+    param_caption ||= p_cap
+    return nil unless p_cap == param_caption
+    val = cm[2]
+    val = val.gsub("'", '"') if val.start_with?("'")
+    cases << val << result
+  end
+  parts = [param_control_ref(param_caption)] + cases
+  parts << else_expr if else_expr
+  "Switch(#{parts.join(', ')})"
+end
+
+# Pick the Tableau format for a given header against a worksheet's formats dict.
+# Match by best-effort: field ref contains a column GUID OR a friendly name
+# fragment that overlaps with the header.
+def pick_tableau_format(formats, header)
+  return nil if formats.nil? || formats.empty?
+  hkey = header.to_s.downcase.gsub(/\W+/, '')
+  formats.each do |field, val|
+    body = field.to_s.downcase
+    # Friendly-name match: format key looks like `[usr:Return Rate:qk]`. Pull
+    # the human chunk and compare to header.
+    inner = body.scan(/\[([^\]]+)\]/).flatten.last.to_s
+    parts = inner.split(':')
+    friendly = parts.length >= 3 ? parts[1].to_s.gsub(/\W+/, '') : ''
+    if !friendly.empty? && (friendly == hkey || hkey.include?(friendly) || friendly.include?(hkey))
+      sigma = tableau_format_to_sigma(val)
+      return sigma if sigma
+    end
+  end
+  nil
+end
+
+# ---- Pivot-table emission --------------------------------------------------
+# Tableau crosstab worksheets (mark=Text or mark=Square with dims on both
+# Rows AND Cols shelves, OR the Measure Names crosstab pattern) translate to
+# a Sigma `pivot-table` element with `rowsBy` / `columnsBy` / `values` arrays,
+# NOT a plain `table`. Without this, parse-twb-layout's `pivot-table` chart_kind
+# would fall through to the default table builder and lose the pivot shape.
+#
+# Resolves shelf fields via the parser's columns_by_guid lookup + the master-
+# column regex map. Returns the element hash, or nil if shelf info is unusable
+# (caller falls back to the standard table/chart flow with a warning).
+SHELF_AGG_FOR_PREFIX = {
+  'sum' => 'Sum', 'avg' => 'Avg', 'min' => 'Min', 'max' => 'Max',
+  'median' => 'Median', 'count' => 'CountIf(IsNotNull(%s))',
+  'countd' => 'CountDistinct', 'cntd' => 'CountDistinct'
+}.freeze
+SHELF_TRUNC_FOR_PREFIX = {
+  'yr' => 'year', 'qr' => 'quarter', 'mn' => 'month',
+  'wk' => 'week', 'dy' => 'day', 'hr' => 'hour'
+}.freeze
+
+def resolve_shelf_field(field, meta, mmap)
+  guid = field['guid']
+  cap_for_field = nil
+  if guid
+    info = (meta['columns_by_guid'] || {})[guid]
+    cap_for_field = info && info['caption']
+  end
+  cap_for_field ||= field['raw'].to_s
+                                 .sub(/^\[[^\]]+\]\./, '')
+                                 .gsub(/^\[|\]$/, '')
+                                 .sub(/^[a-z]+:/i, '')
+                                 .sub(/:[a-z]+$/i, '')
+  m = map_column(cap_for_field, mmap)
+  m ||= { 'id' => "m-#{cap_for_field.downcase.gsub(/\W+/, '-')}", 'name' => cap_for_field }
+  [m, cap_for_field]
+end
+
+def build_pivot_element(z, meta, mmap, opts, warnings)
+  cap = z['caption']
+  el_id = "el-#{cap.downcase.gsub(/\W+/, '-')[0..40]}".sub(/-$/, '')
+  rows_shelf = z['rows_shelf'] || {}
+  cols_shelf = z['cols_shelf'] || {}
+
+  cols_array = []
+  rows_by    = []
+  cols_by    = []
+  values_arr = []
+  seen_ids   = {}
+
+  add_col = lambda do |field, target|
+    m, _cap = resolve_shelf_field(field, meta, mmap)
+    base = "p-#{el_id}-#{target}-#{(m['name'] || 'x').downcase.gsub(/\W+/, '-')}"
+    col_id = base
+    n = 1
+    while seen_ids[col_id]
+      col_id = "#{base}-#{n}"
+      n += 1
+    end
+    seen_ids[col_id] = true
+
+    deriv = field['derivation'].to_s.downcase
+    formula =
+      if field['role'] == 'measure'
+        agg = SHELF_AGG_FOR_PREFIX[deriv] || 'Sum'
+        if agg.include?('%s')
+          agg.sub('%s', "[Master/#{m['name']}]")
+        else
+          "#{agg}([Master/#{m['name']}])"
+        end
+      elsif field['role'] == 'dim' && SHELF_TRUNC_FOR_PREFIX[deriv]
+        %(DateTrunc("#{SHELF_TRUNC_FOR_PREFIX[deriv]}", [Master/#{m['name']}]))
+      else
+        "[Master/#{m['name']}]"
+      end
+
+    col_obj = { 'id' => col_id, 'name' => m['name'], 'formula' => formula }
+    if field['role'] == 'measure'
+      tab_fmt = pick_tableau_format(z['formats'], m['name'])
+      col_obj['format'] = tab_fmt if tab_fmt
+      col_obj['format'] ||= m['format'] if m['format'].is_a?(Hash)
+      col_obj['format'] ||= { 'kind' => 'number', 'formatString' => ',.0f' }
+    elsif SHELF_TRUNC_FOR_PREFIX[deriv]
+      col_obj['format'] = { 'kind' => 'datetime', 'formatString' => '%b %Y' }
+    end
+    cols_array << col_obj
+    case target
+    when :row   then rows_by    << { 'id' => col_id }
+    when :col   then cols_by    << { 'id' => col_id }
+    when :value then values_arr << col_id
+    end
+  end
+
+  (rows_shelf['fields'] || []).each do |f|
+    add_col.call(f, :row)   if f['role'] == 'dim'
+    add_col.call(f, :value) if f['role'] == 'measure'
+  end
+  (cols_shelf['fields'] || []).each do |f|
+    add_col.call(f, :col)   if f['role'] == 'dim'
+    add_col.call(f, :value) if f['role'] == 'measure'
+  end
+
+  # Measure-Names pattern: shelves carry the placeholder but the actual
+  # measures live in z['measures']. Materialize them here.
+  if values_arr.empty? && (z['measures'] || []).any?
+    z['measures'].each do |m|
+      add_col.call({
+        'role'       => 'measure',
+        'derivation' => (m['derivation'] || 'Sum').to_s.downcase,
+        'raw'        => m['column'],
+        'guid'       => guid_from_text(m['column'].to_s)
+      }, :value)
+    end
+  end
+
+  if values_arr.empty? || (rows_by.empty? && cols_by.empty?)
+    warnings << "'#{cap}' is flagged as a Tableau crosstab but shelves did not yield rows+cols+values — falling back to flat table"
+    return nil
+  end
+
+  {
+    'id'        => el_id,
+    'kind'      => 'pivot-table',
+    'name'      => cap,
+    'source'    => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+    'columns'   => cols_array,
+    'values'    => values_arr,
+    'rowsBy'    => rows_by,
+    'columnsBy' => cols_by
+  }
+end
+
+# Minimal GUID-from-text helper for shelf measures whose `column` reads like
+# `[federated.X].[sum:GUID:qk]` or just `[GUID]`. Mirrors the parser helper.
+def guid_from_text(s)
+  return nil if s.nil? || s.empty?
+  m = s.match(/\[(?:[a-z\-]+:)?([0-9a-f\-]{36})(?::[a-z]+)?\]/i)
+  m && m[1]
+end
+
+# ---- KPI emission ---------------------------------------------------------
+# Tableau "scorecard" / "big number" tiles — mark=Text or mark=Square with a
+# single measure and no dimensions — translate to a Sigma kpi-chart element.
+# Without this, the chart_kind=kpi worksheet would fall through to the
+# CSV-driven flat-table flow and quietly produce nothing usable.
+# See beads-sigma-bw3.
+def build_kpi_element(z, meta, mmap, opts, warnings)
+  cap = z['caption']
+  el_id = "el-kpi-#{cap.downcase.gsub(/\W+/, '-')[0..38]}".sub(/-$/, '')
+
+  rows_shelf = z['rows_shelf'] || {}
+  cols_shelf = z['cols_shelf'] || {}
+
+  # Find the KPI's measure: first from shelves (preferred — explicit derivation),
+  # then fall back to the worksheet's `measures` array (when the measure is on
+  # the Marks card via Text/Color/Size encoding rather than a shelf).
+  measure_field = nil
+  (rows_shelf['fields'] || []).each { |f| measure_field ||= f if f['role'] == 'measure' }
+  (cols_shelf['fields'] || []).each { |f| measure_field ||= f if f['role'] == 'measure' }
+  if measure_field.nil? && (z['measures'] || []).any?
+    m = z['measures'].first
+    measure_field = {
+      'role'       => 'measure',
+      'derivation' => (m['derivation'] || 'Sum').to_s.downcase,
+      'raw'        => m['column'],
+      'guid'       => guid_from_text(m['column'].to_s)
+    }
+  end
+
+  if measure_field.nil?
+    warnings << "'#{cap}' is flagged as KPI but no measure resolved from shelves or worksheet — skipping"
+    return nil
+  end
+
+  master, _cap = resolve_shelf_field(measure_field, meta, mmap)
+  deriv = measure_field['derivation'].to_s.downcase
+  agg_template = SHELF_AGG_FOR_PREFIX[deriv] || 'Sum'
+  formula =
+    if agg_template.include?('%s')
+      agg_template.sub('%s', "[Master/#{master['name']}]")
+    else
+      "#{agg_template}([Master/#{master['name']}])"
+    end
+
+  measure_col_id = "k-#{el_id}"
+  measure_col = {
+    'id'      => measure_col_id,
+    'name'    => master['name'],
+    'formula' => formula
+  }
+
+  # Format: prefer Tableau format string for this measure, then master-map
+  # format, then heuristic by name.
+  tab_fmt = pick_tableau_format(z['formats'], master['name'])
+  measure_col['format'] = tab_fmt if tab_fmt
+  measure_col['format'] ||= master['format'] if master['format'].is_a?(Hash)
+  measure_col['format'] ||=
+    case master['name'].downcase
+    when /(revenue|profit|cost|sales|amount|spend)/
+      { 'kind' => 'number', 'formatString' => '$,.0f', 'currencySymbol' => '$' }
+    when /(rate|margin|pct|percent|ratio)/
+      { 'kind' => 'number', 'formatString' => ',.1%' }
+    else
+      { 'kind' => 'number', 'formatString' => ',.0f' }
+    end
+
+  element = {
+    'id'      => el_id,
+    'kind'    => 'kpi-chart',
+    'name'    => cap,
+    'source'  => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+    'columns' => [measure_col],
+    'value'   => { 'columnId' => measure_col_id }
+  }
+
+  # If the Tableau worksheet had Show Mark Labels on (typical for KPIs since
+  # the number IS the chart), we don't need a separate dataLabel — kpi-chart
+  # always renders the value. No-op.
+
+  element
+end
+
+# A workbook may have multiple dashboards; iterate all and concatenate elements.
+# Drop the chart_kind=automatic warnings to stderr so the caller can act on them.
+elements = []
+warnings = []
+
+layout.each do |dash|
+  dash['zones'].each do |z|
+    next unless z['kind'] == 'chart'
+    cap = z['caption']
+    next if cap.nil? || cap.empty?
+
+    # Pivot-table fast path: Tableau crosstabs (chart_kind=pivot-table from
+    # parse-twb-layout) emit a Sigma pivot-table element with rowsBy/columnsBy/
+    # values derived from shelf info — independent of the view CSV shape.
+    # Falls through to the CSV-driven flat-table path if shelves can't be
+    # resolved cleanly (logged via warnings).
+    if z['chart_kind'] == 'pivot-table'
+      pivot_el = build_pivot_element(z, meta, mmap, opts, warnings)
+      if pivot_el
+        elements << pivot_el
+        warnings << "'#{cap}' auto-emitted as Sigma pivot-table from Tableau crosstab (rows/cols shelves) — verify dim placement"
+        next
+      end
+      # else: fall through to flat-table flow
+    end
+
+    # KPI fast path: Tableau scorecards (chart_kind=kpi) emit a Sigma kpi-chart
+    # with a single measure as value. Without this, the worksheet would fall
+    # into the CSV-driven 2-column flow which requires headers.length >= 2 and
+    # silently drops single-measure tiles. beads-sigma-bw3.
+    if z['chart_kind'] == 'kpi'
+      kpi_el = build_kpi_element(z, meta, mmap, opts, warnings)
+      if kpi_el
+        elements << kpi_el
+        warnings << "'#{cap}' auto-emitted as Sigma kpi-chart from Tableau scorecard (Text mark + single measure) — verify value formula"
+        next
+      end
+      # else: fall through with the warning already logged
+    end
+
+    view = view_by_name[cap]
+    if view.nil?
+      warnings << "no Tableau view matched '#{cap}'"
+      next
+    end
+    csv_path = File.join(opts[:tab], 'views', "#{view['id']}.csv")
+    unless File.exist?(csv_path)
+      warnings << "missing CSV for '#{cap}' at #{csv_path}"
+      next
+    end
+    rows = CSV.read(csv_path)
+    next if rows.empty?
+    headers = rows.shift
+    next unless headers.length >= 2
+
+    dim_hdr  = headers[0]
+    meas_hdr = headers[1]
+    dim  = map_column(dim_hdr,  mmap)
+    meas = map_column(meas_hdr, mmap)
+    if dim.nil?
+      warnings << "no master column matched dim header '#{dim_hdr}' for '#{cap}' — falling back to raw header"
+      dim  = { 'id' => "m-#{dim_hdr.downcase.gsub(/\W+/,'-')}", 'name' => dim_hdr }
+    end
+    if meas.nil?
+      warnings << "no master column matched measure header '#{meas_hdr}' for '#{cap}'"
+      meas = { 'id' => "m-#{meas_hdr.downcase.gsub(/\W+/,'-')}", 'name' => meas_hdr }
+    end
+
+    # Decide the Sigma aggregator. Priority:
+    #   1. parse-twb-layout.rb's aggregations dict (most authoritative — comes
+    #      from Tableau's column-instance derivation)
+    #   2. CSV header naming heuristic ("Sum of X" → Sum)
+    #   3. Default Sum for numeric, no-agg for text
+    agg_label = nil
+    (z['aggregations'] || {}).each do |col_ref, deriv|
+      stripped = strip_brackets(col_ref)
+      if stripped.casecmp(meas['name']).zero? ||
+         stripped.casecmp(meas_hdr).zero? ||
+         meas_hdr.downcase.include?(stripped.downcase[0..15])
+        agg_label = deriv
+        break
+      end
+    end
+    agg_label ||= infer_csv_agg(meas_hdr)
+    agg_label ||= 'Sum'
+    sigma_agg = SIGMA_AGG[agg_label] || 'Sum'
+
+    # Decide if the dimension is a date that needs DateTrunc. The parser's
+    # aggregations dict surfaces Month-Trunc / Year-Trunc / etc. on the date col.
+    dim_trunc = nil
+    (z['aggregations'] || {}).each do |col_ref, deriv|
+      stripped = strip_brackets(col_ref)
+      if DATE_TRUNC.key?(deriv) &&
+         (stripped.casecmp(dim['name']).zero? || dim_hdr.downcase.include?('date'))
+        dim_trunc = DATE_TRUNC[deriv]
+        break
+      end
+    end
+
+    el_id = "el-#{cap.downcase.gsub(/\W+/, '-')[0..40]}".sub(/-$/, '')
+
+    # If the dim column is aliased in Tableau (raw → display mapping), wrap the
+    # master ref in a Switch() so the chart displays the friendly labels.
+    aliases_for_dim = (meta['column_aliases'] || {})[dim['name']] ||
+                      (meta['column_aliases'] || {})[dim_hdr]
+    dim_formula = if dim['formula']                     # explicit formula override
+                    dim['formula']
+                  elsif aliases_for_dim && !aliases_for_dim.empty?
+                    parts = ["[Master/#{dim['name']}]"]
+                    aliases_for_dim.each { |a| parts << a['key'].inspect; parts << a['value'].inspect }
+                    parts << "[Master/#{dim['name']}]"  # default: pass through raw value
+                    "Switch(#{parts.join(', ')})"
+                  elsif dim_trunc
+                    %(DateTrunc("#{dim_trunc}", [Master/#{dim['name']}]))
+                  else
+                    "[Master/#{dim['name']}]"
+                  end
+    # If the measure mapping carries a `formula` key, that's a workbook-level
+    # calc like Return Rate = Sum(...)/Count(...). Use it verbatim. Otherwise
+    # wrap the master-table column with the Sigma aggregator picked above.
+    measure_formula = if meas['formula']
+                        meas['formula']
+                      else
+                        render_agg(sigma_agg, "[Master/#{meas['name']}]")
+                      end
+
+    dim_col_obj = { 'id' => "x-#{el_id}", 'name' => dim['name'], 'formula' => dim_formula }
+    dim_col_obj['format'] = { 'kind' => 'datetime', 'formatString' => '%b %Y' } if dim_trunc
+    meas_col_obj = { 'id' => "y-#{el_id}", 'name' => meas['name'], 'formula' => measure_formula }
+    # Format priority:
+    #   1. explicit `format` on the master-map entry
+    #   2. Tableau's own format string for this measure (zone.formats — only set
+    #      when --meta was provided)
+    #   3. heuristic by header name
+    meas_col_obj['format'] = meas['format'] if meas['format'].is_a?(Hash)
+    if meas_col_obj['format'].nil?
+      tab_fmt = pick_tableau_format(z['formats'], meas_hdr) ||
+                pick_tableau_format(z['formats'], meas['name'])
+      meas_col_obj['format'] = tab_fmt if tab_fmt
+    end
+    if meas_col_obj['format'].nil?
+      meas_col_obj['format'] =
+        case meas['name'].downcase
+        when /(revenue|profit|cost|sales|amount|spend)/
+          { 'kind' => 'number', 'formatString' => '$,.0f', 'currencySymbol' => '$' }
+        when /(rate|margin|pct|percent|ratio)/
+          { 'kind' => 'number', 'formatString' => ',.1%' }
+        else
+          { 'kind' => 'number', 'formatString' => ',.0f' }
+        end
+    end
+    # Allow `format` on map entries to be either a Sigma format object OR a
+    # bare formatString string for convenience.
+    if meas['format'].is_a?(String)
+      meas_col_obj['format'] = { 'kind' => 'number', 'formatString' => meas['format'] }
+    end
+
+    kind = SIGMA_KIND[z['chart_kind']] || 'bar-chart'
+    if z['chart_kind'] == 'automatic'
+      warnings << "'#{cap}' has chart_kind=automatic — defaulted to bar-chart; verify against PNG"
+    end
+
+    # Dual-axis / combo detection: if Tableau marked this worksheet as
+    # synchronized-axes OR there are 2+ measures in the pane AND the view CSV
+    # has a second measure column, emit a combo-chart with two yAxis groups.
+    extra_meas_col = nil
+    if z['dual_axis'] && headers.length >= 3
+      meas2_hdr = headers[2]
+      meas2 = map_column(meas2_hdr, mmap) ||
+              { 'id' => "m-#{meas2_hdr.downcase.gsub(/\W+/,'-')}", 'name' => meas2_hdr }
+      meas2_formula = meas2['formula'] || render_agg(sigma_agg, "[Master/#{meas2['name']}]")
+      extra_meas_col = {
+        'id'      => "y2-#{el_id}",
+        'name'    => meas2['name'],
+        'formula' => meas2_formula,
+        'format'  => meas2['format'].is_a?(Hash) ? meas2['format'] :
+                     ({ 'kind' => 'number', 'formatString' => ',.0f' })
+      }
+      kind = 'combo-chart' unless %w[pie-chart donut-chart].include?(kind)
+      # Sigma combo-chart dual-axis IS persisted in the spec — the secondary
+      # axis is implied by yAxis.columnIds entries in object form
+      # (`{columnId, type}`) vs bare-string form. Bare strings go to the
+      # primary (left) axis; object-form entries go to the secondary (right)
+      # axis with the specified mark type. Verified 2026-05-22 against
+      # UI-built workbook readback (workbookUrlId 5xKqmuAXGooHxRgFrdk6VY).
+      # The right axis is auto-scaled by default; custom right-axis scale
+      # configuration (log/min/max/zero) is unverified — yAxis.format only
+      # governs the left axis.
+      warnings << "'#{cap}' detected as dual-axis (synchronized=true or 2+ measures) — emitted as combo-chart with secondary measure on right axis (yAxis.columnIds object form). Right axis is auto-scaled; if Tableau had a custom right-axis range, configure manually in the Sigma editor."
+    end
+
+    element = {
+      'id'      => el_id,
+      'kind'    => kind,
+      'name'    => cap,
+      'source'  => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+      'columns' => [dim_col_obj, meas_col_obj]
+    }
+    element['columns'] << extra_meas_col if extra_meas_col
+
+    # Reference lines / bands / trendlines from Tableau → Sigma `refMarks`.
+    # Verified shape (from a UI-built workbook readback, 2026-05-21):
+    #   refMarks:
+    #     - type: line | band
+    #       axis: series | series2 | axis
+    #       value:
+    #         { type: constant, value: <number> }     # constant threshold
+    #         { type: formula,  formula: "<expr>" }   # any Sigma formula
+    #       label:
+    #         { visibility: shown|hidden, text?: "..." }
+    #
+    # Docs (charts.md) suggested bare numbers / strings for `value` but the
+    # live API only accepts the wrapped object form. `value.type: column` is
+    # also rejected — use `formula` with a column ref instead.
+    ref_emit, trend_emit, ref_skip = [], [], []
+    if z['ref_marks'] && !z['ref_marks'].empty? && %w[bar-chart line-chart area-chart combo-chart scatter-chart].include?(kind)
+      meas_name = meas_col_obj['name']
+      tab_to_sigma_agg = { 'average' => 'Avg', 'median' => 'Median', 'max' => 'Max', 'min' => 'Min', 'sum' => 'Sum', 'count' => 'Count' }
+      # Trendline shape verified 2026-05-22 against a UI-built workbook
+      # (workbookUrlId 5xKqmuAXGooHxRgFrdk6VY). Only `linear` is canonically
+      # verified; other Tableau model-types are passed through under the same
+      # name (Sigma docs list logarithmic/exponential/polynomial/quadratic/power)
+      # and will surface a per-element WARN to verify visually.
+      tab_to_sigma_model = {
+        'linear'      => 'linear',
+        'logarithmic' => 'logarithmic',
+        'exponential' => 'exponential',
+        'polynomial'  => 'polynomial',
+        'power'       => 'power'
+      }
+      z['ref_marks'].each do |rm|
+        case rm['kind']
+        when 'line'
+          # Skip band-styled lines (fill/percentage bands) — they need the band shape, not line.
+          if rm['band_values'] || rm['fill_below'] == 'true' || rm['fill_above'] == 'true' || rm['percentage_bands'] == 'true'
+            ref_skip << rm
+            next
+          end
+          fagg = tab_to_sigma_agg[rm['formula']]
+          if fagg
+            label_text = rm['label_type'] == 'custom' ? rm['label'] : "#{fagg} #{meas_name}"
+            ref_emit << {
+              'type'  => 'line',
+              'axis'  => 'series',
+              'value' => { 'type' => 'formula', 'formula' => "#{fagg}([Master/#{meas_name}])" },
+              'label' => { 'visibility' => 'shown', 'text' => label_text }.compact
+            }
+          else
+            ref_skip << rm
+          end
+        when 'trendline'
+          model = tab_to_sigma_model[rm['model'].to_s] || 'linear'
+          trend_emit << {
+            'columnId' => meas_col_obj['id'],
+            'model'    => model,
+            'label'    => { 'visibility' => 'shown' },
+            'value'    => { 'visibility' => 'shown' }
+          }
+        when 'band', 'distribution'
+          # Bands need the {type:band} variant which we haven't verified.
+          ref_skip << rm
+        end
+      end
+      element['refMarks']   = ref_emit   unless ref_emit.empty?
+      element['trendlines'] = trend_emit unless trend_emit.empty?
+      if !ref_skip.empty?
+        skip_counts = ref_skip.each_with_object(Hash.new(0)) { |r, h| h[r['kind']] += 1 }
+        skip_kinds = skip_counts.map { |k, n| "#{n}× #{k}" }.join(', ')
+        warnings << "'#{cap}' has #{ref_skip.size} Tableau reference mark(s) not auto-emitted (#{skip_kinds}) — bands/distributions need manual review (beads-sigma-7ak)"
+      end
+      if !ref_emit.empty?
+        warnings << "'#{cap}' auto-emitted #{ref_emit.size} Sigma refMarks from Tableau reference marks — verify visual fidelity"
+      end
+      if !trend_emit.empty?
+        models_used = trend_emit.map { |t| t['model'] }.uniq
+        non_linear = models_used - ['linear']
+        msg = "'#{cap}' auto-emitted #{trend_emit.size} Sigma trendline(s) (model: #{models_used.join(', ')})"
+        msg += " — only `linear` is canonically verified; visually verify #{non_linear.join('/')} fits" unless non_linear.empty?
+        warnings << msg
+      end
+    end
+
+    if kind == 'pie-chart' || kind == 'donut-chart'
+      element['color'] = { 'id' => dim_col_obj['id'] }
+      element['value'] = { 'id' => meas_col_obj['id'] }
+    else
+      # Breaking-change-2026-05-21: xAxis takes singular `columnId` (string),
+      # yAxis takes plural `columnIds` (array on the object — NOT array of
+      # objects). The old `xAxis: {id: ...}` / `yAxis: [{id: ...}]` shape
+      # is rejected by the live API on new POSTs.
+      x_axis = { 'columnId' => dim_col_obj['id'] }
+      # Sort: only set when Tableau explicitly sorted. parse-twb-layout emits
+      # nil when there's no <sort> on the worksheet — leave Sigma's xAxis
+      # unsorted in that case (natural order matches Tableau's default).
+      if z['sort']
+        dir = z.dig('sort', 'direction').to_s
+        sigma_dir = (dir =~ /desc/i) ? 'descending' : 'ascending'
+        x_axis['sort'] = { 'by' => meas_col_obj['id'], 'direction' => sigma_dir }
+      end
+      element['xAxis'] = x_axis
+      # Combo-chart: yAxis.columnIds is a mixed array — bare strings default to
+      # bar; { columnId, type: 'line' } objects override the series type.
+      # For non-combo: just bare strings.
+      y_column_ids = [meas_col_obj['id']]
+      if extra_meas_col
+        y_column_ids << (kind == 'combo-chart' ?
+          { 'columnId' => extra_meas_col['id'], 'type' => 'line' } :
+          extra_meas_col['id'])
+      end
+      element['yAxis'] = { 'columnIds' => y_column_ids }
+
+      # Axis format (log scale, fixed min/max). parse-twb-layout extracts these
+      # from Tableau's <style-rule element='axis'><encoding attr='space' ...>
+      # nodes per worksheet. Sigma side shape verified 2026-05-22:
+      #   format: { scale: { type: log | linear, domain: {min, max}, zero } }
+      # Tableau→Sigma scope mapping: rows→yAxis, cols→xAxis. class='0' is
+      # primary, class='1' is secondary (dual-axis right side, currently
+      # unverified from Sigma side — emit primary only for now).
+      (z['axis_formats'] || []).each do |af|
+        next unless af['class'].to_s == '0'  # primary only
+        target = af['scope'] == 'rows' ? 'yAxis' : 'xAxis'
+        scale = {}
+        scale['type']   = 'log' if af['scale'] == 'log'
+        if af['range_type'] == 'fixed' && af['min'] && af['max']
+          scale['domain'] = { 'min' => af['min'], 'max' => af['max'] }
+        end
+        next if scale.empty?
+        element[target] ||= {}
+        element[target]['format'] ||= {}
+        element[target]['format']['scale'] = scale
+        warnings << "'#{cap}' auto-emitted #{target}.format.scale from Tableau axis override (scale=#{af['scale']}, range=#{af['range_type']}) — verify visual fidelity"
+      end
+    end
+
+    # Surface action filters (they get skipped — these are cross-chart actions,
+    # not value filters)
+    action_filters = (z['filters'] || []).select { |f|
+      f['column'].to_s.include?('[Action (') || f['column'].to_s.start_with?('[Action ')
+    }
+    if action_filters.any?
+      warnings << "'#{cap}' has #{action_filters.size} Tableau action filter(s) — skipped (cross-chart actions, not value filters)"
+    end
+
+    # If channels.color is set, that's a multi-series signal. Emit a TODO note
+    # so the agent can fan-out the yAxis with one If() per category. We don't
+    # auto-fan because we don't have a reliable categorical-values list here.
+    if z.dig('channels', 'color', 'column')
+      warnings << "'#{cap}' has a color channel on #{z['channels']['color']['column']} — chart is single-series; agent should fan-out yAxis with one If() per category (see refs/workbook-layout.md \"Multi-series chart patterns\")"
+    end
+
+    # Data labels — verified canonical shape 2026-05-22 against UI-built workbook
+    # (workbookUrlId 5xKqmuAXGooHxRgFrdk6VY): minimum required is just
+    #   dataLabel: { labels: shown }
+    # Two Tableau signals trigger this:
+    #   1. Label or Text encoding channel on the worksheet (drag-to-shelf)
+    #   2. Worksheet-level "Show Mark Labels" toggle, surfaced by parse-twb-layout
+    #      from <pane><style><style-rule element='mark'>
+    #             <format attr='mark-labels-show' value='true'/>
+    #      (verified against "Orders Conversion Test" workbook, 2026-05-22)
+    if %w[bar-chart line-chart area-chart combo-chart scatter-chart pie-chart donut-chart].include?(kind)
+      has_label_channel = z.dig('channels', 'label', 'column') || z.dig('channels', 'text', 'column')
+      has_mark_labels   = z['mark_labels_show'] == true
+      if has_label_channel || has_mark_labels
+        element['dataLabel'] = { 'labels' => 'shown' }
+        src = has_label_channel ? 'Label/Text encoding' : 'worksheet "Show Mark Labels" toggle'
+        warnings << "'#{cap}' auto-emitted dataLabel:{labels:shown} from Tableau #{src} — verify formatting (Sigma defaults are minimal)"
+      end
+    end
+
+    # Per-chart value filters (skip action filters — already warned above).
+    # Translate each non-action filter into a Sigma element-level filter spec
+    # using the parser's normalized fields (column_caption, kind, members,
+    # period_type, etc.). We map the caption → master column via the same
+    # regex map used for dim/measure.
+    value_filters = (z['filters'] || []).reject { |f| f['is_action'] }
+    el_filters = []
+    value_filters.each do |f|
+      fcap = f['column_caption'] || f['raw_param']
+      m = fcap ? map_column(fcap, mmap) : nil
+      if m.nil?
+        warnings << "value filter on '#{cap}' targets '#{fcap}' — no master column matched, skipping"
+        next
+      end
+      case f['kind']
+      when 'list'
+        el_filters << {
+          'columnId' => m['id'],
+          'kind' => 'list', 'mode' => 'include', 'selectionMode' => 'multiple',
+          'values' => (f['members'] || []), 'includeNulls' => 'never'
+        }
+      when 'relative-date'
+        # Tableau first-period=0, last-period=0 + period-type=year means
+        # "this <period>". Emit explicit current-period bounds — `mode: relative`
+        # does NOT filter the chart-data SQL (same lesson the shared-filter path
+        # learned; see current_period_bounds). Falls back to pass-through
+        # relative for periods we don't bound (week/day).
+        period = (f['period_type'] || 'year').downcase
+        start_d, end_d = current_period_bounds(period)
+        if start_d
+          el_filters << {
+            'columnId' => m['id'], 'kind' => 'date-range', 'mode' => 'between',
+            'startDate' => start_d, 'endDate' => end_d,
+            'includeNulls' => (f['include_null'].to_s == 'true' ? 'always' : 'never')
+          }
+          warnings << "'#{cap}' relative-date '#{period}' → element filter mode:between current-#{period} (#{start_d[0..9]}..#{end_d[0..9]}); re-run next #{period} to refresh"
+        else
+          el_filters << {
+            'columnId' => m['id'], 'kind' => 'date-range', 'mode' => 'relative',
+            'unit' => period, 'count' => 1,
+            'includeNulls' => (f['include_null'].to_s == 'true' ? 'always' : 'never')
+          }
+          warnings << "'#{cap}' relative-date '#{period}' kept as mode:relative (no current-period bounds for '#{period}') — verify it filters the SQL"
+        end
+      when 'number-range'
+        el_filters << {
+          'columnId' => m['id'], 'kind' => 'number-range', 'mode' => 'between',
+          'min' => f['min'], 'max' => f['max'], 'includeNulls' => 'never'
+        }
+      end
+    end
+    # Every element filter needs a unique `id` (the live /v2/workbooks/.../spec
+    # readback shows `id: flt-<element>-<n>`); the API rejects filters without it.
+    el_filters.each_with_index { |nf, i| nf['id'] = "flt-#{el_id}-#{i}" }
+    element['filters'] = el_filters unless el_filters.empty?
+
+    # Surface Tableau-side calculated fields the worksheet uses, and auto-
+    # translate the ones we know how to handle (parameter-driven Switch).
+    # Otherwise emit a translation hint so the agent can wire it up by hand.
+    param_caps = (meta['parameters'] || []).map { |p| p['caption'] }.compact
+    (z['calculations'] || []).each do |c|
+      formula = c['formula'].to_s
+      next if formula.empty?
+      next if formula =~ /\A\s*(SUM|COUNT|AVG|MIN|MAX)\(\[[^\]]+\]\)\s*\z/
+      next if formula =~ /\A\s*\[[^\]]+\]\s*\z/
+
+      # Try parameter-driven translations first (CASE / IF chain on param).
+      translated = translate_case_on_param(formula, param_caps) ||
+                   translate_if_chain_on_param(formula, param_caps)
+      if translated
+        # Drop the calc onto the chart element as an inline calc column. The
+        # column id is derived from the calc name (strip brackets) so it's
+        # stable across re-runs.
+        calc_name = c['name'].to_s.gsub(/^\[|\]$/, '')
+        calc_id   = "calc-#{calc_name.downcase.gsub(/\W+/, '-')[0..40]}".sub(/-$/, '')
+        element['columns'] << {
+          'id'      => calc_id,
+          'name'    => calc_name,
+          'formula' => translated
+        }
+        warnings << "'#{cap}' parameter-driven calc #{c['name']} → translated to Switch: #{translated[0..120]}"
+        next
+      end
+
+      # Try customer-learned rules FIRST — these are translations the scout
+      # subagent has validated against this customer's Sigma site. Anything
+      # here is known-to-work in their context, so it wins over built-in
+      # heuristics. Source: ~/.tableau-to-sigma/learned-rules.yaml (user home,
+      # never clobbered by skill updates).
+      lr_translated, lr_hint = LearnedRules.apply(LEARNED_RULES, formula)
+      if lr_translated
+        warnings << "'#{cap}' learned-rule applied to #{c['name']} → Sigma:  #{lr_translated[0..160]}  [#{lr_hint}]"
+        next
+      end
+
+      # Try table-calc / common-fn translations (INDEX/LOOKUP/TOTAL/RANK/ZN/etc.).
+      tc_translated, tc_hint = translate_tableau_tc(formula)
+      if tc_translated
+        warnings << "'#{cap}' Tableau table-calc #{c['name']} → Sigma:  #{tc_translated[0..160]}  [#{tc_hint}]"
+        next
+      end
+
+      hint = if formula =~ /\bIIF\(.*=.*0.*,\s*SUM.*\/\s*SUM/
+               'ratio calc — translate as `Sum(num) / NullIf(Sum(den), 0)` on master OR via Custom SQL'
+             elsif formula =~ /\bIF\b.*\bELSEIF\b.*\bEND\b/i
+               'IF/ELSEIF chain — translate to nested Sigma If(...) or Switch(...) on master'
+             elsif formula =~ /\bCASE\b/i
+               'CASE statement — translate to Sigma Switch(value, when1, then1, ...) on master'
+             elsif formula =~ /\bSUM\(.*\)\s*\/\s*COUNT\(/i
+               'ratio calc — translate as `Sum(...) / Count(...)` (or CountIf for NotNull) on master'
+             elsif formula =~ /\[Parameters?\]\.|\[Parameters?\s+\(/
+               'parameter-driven calc — translate to Sigma control + Switch()/If() formula'
+             else
+               'calc — translate to Sigma formula and add as a master column or workbook calc'
+             end
+      warnings << "'#{cap}' uses Tableau calc #{c['name']}: #{hint}. Formula: #{formula[0..120]}"
+    end
+
+    # Stamp with worksheet name so the page-per-worksheet emitter can group.
+    element['_worksheet'] = cap
+    elements << element
+  end
+end
+
+# ---- Title text element ----
+# If --title given, emit a text element. If --title omitted AND the parser
+# found a title/text zone, infer the dashboard name from the parser output.
+auto_title = nil
+if opts[:title].nil?
+  layout.each do |dash|
+    next unless dash['zones'].any? { |z| %w[title text].include?(z['kind']) && (z['y_pct'] || 100) < 10 }
+    auto_title = dash['dashboard']
+    break
+  end
+end
+title_text = opts[:title] || auto_title
+
+extras = []
+if title_text
+  extras << {
+    'id'   => 'title-text',
+    'kind' => 'text',
+    'body' => "## #{title_text}"
+  }
+end
+
+# ---- Auto-generated parameter controls (--auto-controls) ------------------
+# Tableau parameters become Sigma controls. The control's name matches the
+# parameter caption so any translated `Switch([Param Caption], ...)` formula
+# resolves to this control.
+param_controls = []
+if opts[:auto_controls]
+  # Determine which parameter captions are actually referenced by any worksheet
+  # calc. Tableau workbooks often define orphan parameters (defined but not used
+  # by any calc field) — emitting controls for those clutters the dashboard
+  # with widgets that filter nothing. Skip them.
+  referenced_caps = (meta['worksheets'] || {}).values
+    .flat_map { |w| (w['calculations'] || []).flat_map { |c| c['parameter_refs'] || [] } }
+    .uniq
+  (meta['parameters'] || []).each_with_index do |p, i|
+    cap = p['caption'].to_s.strip
+    next if cap.empty?
+    unless referenced_caps.include?(cap)
+      warnings << "parameter '#{cap}' is defined in Tableau but not referenced by any worksheet calc — skipped auto-control (orphan parameter)"
+      next
+    end
+    slug = cap.downcase.gsub(/\W+/, '-').sub(/-$/, '')
+    spec = {
+      'id'        => "el-param-#{slug}",
+      'kind'      => 'control',
+      'controlId' => "ctl-param-#{slug}",
+      'name'      => cap,
+      'includeNulls' => 'when-no-value-is-selected'
+    }
+    if p['param_domain'] == 'list'
+      spec['controlType']   = 'segmented'
+      spec['source'] = {
+        'kind' => 'manual', 'valueType' => 'text',
+        'values' => p['members'] || [], 'labels' => []
+      }
+      spec['value'] = p['default_value']
+    elsif p['param_domain'] == 'range' && %w[integer real].include?(p['datatype'])
+      # Numeric range parameter → Sigma `number-range` control (discovered by
+      # gap-scout 2026-05-20, beads-sigma-ebw). Two-handle slider; the single-
+      # value Tableau parameter is rendered as a range with handles initially
+      # collapsed to the default. `mode` and `values` don't round-trip on
+      # readback but the workbook renders correctly (known Sigma quirk).
+      spec['controlType'] = 'number-range'
+      spec['mode']        = 'between'
+      min = p['min'] ? (p['datatype'] == 'real' ? p['min'].to_f : p['min'].to_i) : nil
+      max = p['max'] ? (p['datatype'] == 'real' ? p['max'].to_f : p['max'].to_i) : nil
+      spec['values']      = [min, max].compact if min && max
+      warnings << "parameter '#{cap}' is a numeric range — emitted as number-range control (Sigma 2-handle slider; Tableau's single-handle UX needs manual post-publish tweak)"
+    elsif p['param_domain'] == 'range' && %w[date datetime].include?(p['datatype'])
+      spec['controlType'] = 'date-range'
+      spec['mode'] = 'between'
+    else
+      # Generic fallback — text input
+      spec['controlType'] = 'text'
+      spec['value'] = p['default_value']
+    end
+    param_controls << spec
+  end
+end
+
+# ---- Auto-generated controls from shared-view filters (--auto-controls) ----
+auto_controls = []
+if opts[:auto_controls]
+  (meta['shared_filters'] || []).each_with_index do |f, i|
+    next if f['is_action']
+    cap = f['column_caption']
+    if cap.nil?
+      warnings << "shared filter ##{i} has no resolvable column_caption (raw_param=#{f['raw_param']}) — skipping auto-control"
+      next
+    end
+    m = map_column(cap, mmap)
+    if m.nil?
+      warnings << "shared filter on '#{cap}' has no master-map entry — add a regex to master-columns.json"
+      next
+    end
+    slug = cap.downcase.gsub(/\W+/, '-').sub(/-$/, '')
+    spec = {
+      'id'           => "el-ctl-#{slug}",
+      'kind'         => 'control',
+      'controlId'    => "ctl-#{slug}",
+      'name'         => cap.strip,
+      'includeNulls' => 'when-no-value-is-selected'
+    }
+    case f['kind']
+    when 'list'
+      spec['controlType']   = 'list'
+      spec['mode']          = 'include'
+      spec['selectionMode'] = 'multiple'
+      spec['values']        = []  # default to all; user adjusts in UI
+      spec['source'] = {
+        'kind'     => 'source',
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => m['id']
+      }
+      spec['filters'] = [{
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => m['id']
+      }]
+    when 'relative-date'
+      # Tableau "this year" / "this month" / "this quarter" → translate to
+      # Sigma `mode: between` with hardcoded startDate/endDate. The previously-
+      # tried `mode: current, unit: <period>` only applies at UI render time —
+      # it does NOT filter Sigma's chart-data SQL queries (Phase 6 parity
+      # showed every relative-date chart returning unfiltered data). Hardcoded
+      # dates apply at query time AND on the UI. Trade-off: filter "freezes"
+      # — next year someone must update it manually. The mirror of v4's
+      # reference workbook.
+      spec['controlType'] = 'date-range'
+      spec['mode']        = 'between'
+      period = (f['period_type'] || 'year').downcase
+      start_d, end_d = current_period_bounds(period)
+      unless start_d
+        # Fallback: pass-through current+unit; agent updates manually
+        spec['mode'] = 'current'
+        spec['unit'] = period
+        spec['filters'] = [{
+          'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+          'columnId' => m['id']
+        }]
+        next
+      end
+      spec['startDate'] = start_d
+      spec['endDate']   = end_d
+      spec['filters'] = [{
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => m['id']
+      }]
+      warnings << "shared filter '#{cap}' relative-date '#{period}' → emitted as mode:between with hardcoded current-#{period} dates (#{start_d[0..9]}..#{end_d[0..9]}). Re-run next #{period} to refresh."
+    when 'number-range'
+      spec['controlType'] = 'range-slider'
+      spec['filters'] = [{
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => m['id']
+      }]
+    end
+    auto_controls << spec
+  end
+end
+
+# ---- Filter controls ----
+# Caller supplies the column targets explicitly via --controls. We don't try
+# to infer the column from filter zone metadata because the Tableau filter
+# shelf doesn't reliably tell us which dimension it filters in this XML.
+if opts[:controls]
+  controls = JSON.parse(File.read(opts[:controls]))
+  controls.each_with_index do |c, i|
+    spec = {
+      'id'          => "el-ctl-#{c['name'] ? c['name'].downcase.gsub(/\W+/, '-') : "f#{i}"}",
+      'kind'        => 'control',
+      'controlId'   => "ctl-#{c['name'] ? c['name'].downcase.gsub(/\W+/, '-') : "f#{i}"}",
+      'name'        => c['name'] || "Filter #{i + 1}",
+      'controlType' => c['type'] || 'list',
+      'includeNulls' => 'when-no-value-is-selected',
+      'filters' => [
+        {
+          'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+          'columnId' => c['column']
+        }
+      ]
+    }
+    case spec['controlType']
+    when 'list'
+      spec['mode'] = c['mode'] || 'include'
+      spec['selectionMode'] = c['selectionMode'] || 'multiple'
+      spec['values'] = c['values'] || []
+      spec['source'] = {
+        'kind'     => 'source',
+        'source'   => { 'kind' => 'table', 'elementId' => opts[:master_id] },
+        'columnId' => c['column']
+      }
+    when 'date-range'
+      spec['mode'] = c['mode'] || 'between'
+      if c['default']
+        d = c['default']
+        spec['startDate'] = d['startDate'] if d['startDate']
+        spec['endDate']   = d['endDate']   if d['endDate']
+        spec['unit']      = d['unit']      if d['unit']
+        spec['mode']      = d['mode']      if d['mode']
+      end
+    when 'segmented'
+      spec['source'] = c['source'] || {
+        'kind' => 'manual', 'valueType' => 'text', 'values' => c['values'] || [], 'labels' => []
+      }
+      spec['value'] = c['value']
+    end
+    extras << spec
+  end
+end
+
+all_extras = extras + param_controls + auto_controls
+
+# ---- Output mode ----
+#   Default       → flat array of elements (legacy behaviour). Extras first.
+#   --page-per-worksheet → emit { pages: [{name, elements:[]}] }. One page per
+#                          worksheet that has a chart, with the shared-filter
+#                          auto-controls AND a title text duplicated onto each
+#                          page so the customer sees the same filter set on
+#                          every page (Tableau dashboard-level filter semantics).
+if opts[:pages_mode] == :worksheet
+  pages = []
+  by_ws = elements.group_by { |e| e['_worksheet'] }
+  by_ws.each do |ws_name, els|
+    els.each { |e| e.delete('_worksheet') }
+    page_extras = []
+    if title_text
+      page_extras << {
+        'id'   => "title-text-#{ws_name.downcase.gsub(/\W+/,'-')[0..30]}".sub(/-$/, ''),
+        'kind' => 'text',
+        'body' => "## #{ws_name}"
+      }
+    end
+    # Auto-controls duplicated per page. Both `id` and `controlId` need to be
+    # workbook-globally unique (Sigma rejects duplicates). We track per-page
+    # controlId rewrites so any param-driven Switch() formula on this page's
+    # charts can be rewritten to reference the suffixed controlId.
+    ws_slug = ws_name.downcase.gsub(/\W+/, '-')[0..20]
+    ctl_rewrites = {}
+    (param_controls + auto_controls).each do |c|
+      dup = JSON.parse(c.to_json)
+      original_cid = dup['controlId']
+      dup['id']        = "#{dup['id']}-#{ws_slug}"
+      dup['controlId'] = "#{dup['controlId']}-#{ws_slug}"
+      ctl_rewrites[original_cid] = dup['controlId']
+      page_extras << dup
+    end
+    # Rewrite Switch / If formulas on this page's chart calc columns.
+    els.each do |el|
+      (el['columns'] || []).each do |col|
+        f = col['formula'].to_s
+        ctl_rewrites.each do |from, to|
+          f = f.gsub("[#{from}]", "[#{to}]")
+        end
+        col['formula'] = f
+      end
+    end
+    pages << {
+      'name'     => ws_name,
+      'elements' => page_extras + els
+    }
+  end
+  File.write(opts[:out], JSON.pretty_generate({ 'pages' => pages }))
+  warn "wrote #{opts[:out]} (page-per-worksheet: #{pages.size} pages, #{auto_controls.size} auto-controls per page)"
+else
+  elements.each { |e| e.delete('_worksheet') }
+  all_elements = all_extras + elements
+  File.write(opts[:out], JSON.pretty_generate(all_elements))
+  warn "wrote #{opts[:out]}  (#{all_elements.size} elements: #{all_extras.size} controls/text + #{elements.size} charts)"
+end
+warnings.each { |w| warn "  WARN  #{w}" }
+
+# ---- Tableau dashboard actions companion file -----------------------------
+# Action filters were translated into element-level filters when possible; the
+# leftover Tableau-internal action wiring (which source-tile filters which
+# target-tile set) is non-translatable without Sigma's cross-element wiring
+# API. Emit a companion actions.md so the agent (or customer) can replicate
+# the cross-chart interactivity by hand post-publish.
+actions = []
+(layout || []).each do |dash|
+  (dash['zones'] || []).each do |z|
+    next unless z['kind'] == 'chart'
+    (z['filters'] || []).select { |f| f['is_action'] }.each do |af|
+      # Tableau's action filter column looks like
+      #   [federated.<id>].[Action (Region)]
+      # Pull "Region" out as the dim that the action filters on.
+      raw = (af['raw_param'] || af['column'] || '').to_s
+      dim = (raw[/\[Action \(([^)]+)\)\]/, 1] || raw)
+      actions << {
+        'target'  => z['caption'],
+        'source'  => dim,
+        'column'  => dim
+      }
+    end
+  end
+end
+unless actions.empty?
+  actions_md_path = opts[:out].sub(/\.json$/, '-actions.md')
+  md = String.new
+  md << "# Tableau dashboard actions — post-publish setup\n\n"
+  md << "Sigma cross-chart filtering replaces Tableau's filter actions. For each\n"
+  md << "row below, in the published Sigma workbook: select the source element,\n"
+  md << "open Actions → Add filter action, target the listed element on the named\n"
+  md << "column.\n\n"
+  md << "| Source dim | Target chart | Filter column |\n"
+  md << "|---|---|---|\n"
+  actions.uniq.each do |a|
+    md << "| #{a['source']} | #{a['target']} | #{a['column']} |\n"
+  end
+  File.write(actions_md_path, md)
+  warn "wrote #{actions_md_path} (#{actions.size} action entries)"
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/build-quicksight-layout.rb
@@ -1,0 +1,237 @@
+#!/usr/bin/env ruby
+# build-quicksight-layout.rb
+# Emit a Sigma layout XML for a QuickSight-derived workbook, faithfully mapping the
+# QuickSight sheet layout to Sigma's 24-col grid (1-based grid lines).
+#
+# Handles:
+#   - GridLayout (TILED) with explicit ColumnIndex/RowIndex/ColumnSpan/RowSpan (36-col grid)
+#   - GridLayout auto-flow (spans only, no indices) → flow left-to-right, wrap by span
+#   - FreeFormLayout (pixel X/Y/W/H) → normalized to the bounding box
+#   - fallback: 2-per-row flow when no layout info is present
+#
+# Usage:
+#   ruby scripts/build-quicksight-layout.rb --analysis DISCOVER_DIR/analysis.json \
+#        --map /tmp/wb-spec.map.json --out /tmp/layout.xml
+require 'json'
+require 'optparse'
+require 'set'
+require_relative 'lib/layout'
+include SigmaLayout
+
+opts = {}
+OptionParser.new do |o|
+  o.on('--analysis F') { |v| opts[:an] = v }
+  o.on('--map F') { |v| opts[:map] = v }
+  o.on('--out F') { |v| opts[:out] = v }
+end.parse!
+%i[an map out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+defn = JSON.parse(File.read(opts[:an]))['Definition']
+map = JSON.parse(File.read(opts[:map]))
+v2e = map['visualToElement']             # QS VisualId -> Sigma element id
+GRID = 36.0                              # QuickSight max grid width (fallback only)
+SIG = 24                                 # Sigma grid width
+
+# QuickSight does NOT use a fixed 36-column grid when indices are EXPLICIT. A sheet's
+# effective grid width is whatever the widest row of tiles adds up to — commonly 12,
+# 18, 24, or 36 depending on how the author sized things. Scaling every layout by a
+# hardcoded 36 squeezes a 12-wide D4 into the left third of the Sigma page. Infer the
+# real width as the max row edge (ColumnIndex + ColumnSpan — i.e. the per-row span sum
+# of the widest row) across the sheet's elements, so relative widths + the overall
+# span are preserved when we scale to Sigma's 24 columns.
+#
+# SPANS-ONLY layouts (auto-flow GridLayout: ColumnSpan but no ColumnIndex) are a
+# DIFFERENT case: QS auto-flows those on its full 36-column canvas, so the canvas IS
+# 36. Taking max(span) as the width here collapsed a uniform-18-span sheet (2-up on
+# the QS canvas) into a full-width single-column stack (every 18-span tile scaled to
+# 18/18 = full width) — beads-sigma-vvus. Spans-only callers must pass
+# spans_only: true to get the fixed 36 canvas.
+def infer_grid_width(els, spans_only: false)
+  return GRID if spans_only
+  edges = els.map { |e| (e['ColumnIndex'] || 0) + (e['ColumnSpan'] || 0) }
+  w = edges.compact.max.to_f
+  w >= 1 ? w : GRID
+end
+
+def num(s) # "120px" / "50%" / 120 -> float
+  s.to_s.gsub(/[^0-9.\-]/, '').to_f
+end
+
+def scale_cols(x, w, canvas)
+  c0 = (x.to_f / canvas * SIG).round + 1
+  c1 = ((x.to_f + w.to_f) / canvas * SIG).round + 1
+  c0 = 1 if c0 < 1
+  c1 = c0 + 1 if c1 <= c0
+  c1 = SIG + 1 if c1 > SIG + 1
+  [c0, c1]
+end
+
+
+# Collision guard helper (D15 free-form overlap -> Sigma rejects "Element collisions").
+# Two elements collide when their column AND row ranges both overlap.
+def collides?(a, b)
+  _, ac0, ac1, ar0, ar1 = a
+  _, bc0, bc1, br0, br1 = b
+  (ac0 < bc1 && bc0 < ac1) && (ar0 < br1 && br0 < ar1)
+end
+
+# Lay out ONE QuickSight sheet onto a Sigma grid. Returns [[elId, c0, c1, r0, r1], ...]
+# using ONLY the element ids that belong to this sheet (eids_for_sheet) so a multi-sheet
+# analysis lays out each page from its OWN sheet's QS layout (no cross-sheet bleed).
+def layout_sheet(sheet, v2e, eids_for_sheet)
+  cfg = (sheet['Layouts'] || [{}])[0].fetch('Configuration', {})
+  placed = []
+  if (g = cfg['GridLayout'])
+    els = g['Elements'] || []
+    explicit = els.any? { |e| !e['ColumnIndex'].nil? }
+    if explicit
+      grid_w = infer_grid_width(els)
+      els.each do |e|
+        eid = v2e[e['ElementId']]; next unless eid && eids_for_sheet.include?(eid)
+        c0, c1 = scale_cols(e['ColumnIndex'] || 0, e['ColumnSpan'] || (grid_w / 2), grid_w)
+        r0 = (e['RowIndex'] || 0) + 1
+        r1 = r0 + (e['RowSpan'] || 8)
+        placed << [eid, c0, c1, r0, r1]
+      end
+    else
+      grid_w = infer_grid_width(els, spans_only: true); grid_w = GRID if grid_w <= 0
+      col = 0; row = 1; row_h = 0
+      els.each do |e|
+        eid = v2e[e['ElementId']]; next unless eid && eids_for_sheet.include?(eid)
+        span = e['ColumnSpan'] || (grid_w / 2)
+        col = 0 if col + span > grid_w
+        row += row_h if col.zero? && row_h.positive?
+        c0, c1 = scale_cols(col, span, grid_w)
+        h = (e['RowSpan'] || 12)
+        placed << [eid, c0, c1, row, row + h]
+        col += span; row_h = [row_h, h].max
+        if col >= grid_w
+          col = 0; row += row_h; row_h = 0
+        end
+      end
+    end
+  elsif (sb = cfg['SectionBasedLayout'])
+    # QuickSight paginated/section layout (header/body/footer). Sigma has no page-section
+    # concept; flatten every section's free-form sub-elements into a single stacked column
+    # in document order so the report's vertical sequence is preserved. (D16 paginated)
+    sects = []
+    sects.concat(sb['HeaderSections'] || [])
+    sects.concat(sb['BodySections'] || [])
+    sects.concat(sb['FooterSections'] || [])
+    row = 1
+    sects.each do |sec|
+      sec_els = (sec.dig('Content', 'Layout', 'FreeFormLayout', 'Elements') || sec['Elements'] || [])
+      cw = sec_els.map { |e| num(e['XAxisLocation']) + num(e['Width']) }.max
+      cw = 1.0 if cw.nil? || cw <= 0
+      sec_els.each do |e|
+        eid = v2e[e['ElementId']]; next unless eid && eids_for_sheet.include?(eid)
+        c0, c1 = scale_cols(num(e['XAxisLocation']), num(e['Width']), cw)
+        h = [(num(e['Height']) / 40.0).round, 4].max
+        placed << [eid, c0, c1, row, row + h]
+        row += h
+      end
+    end
+  elsif (f = cfg['FreeFormLayout'])
+    els = f['Elements'] || []
+    cw = els.map { |e| num(e['XAxisLocation']) + num(e['Width']) }.max || 1.0
+    ch_unit = 40.0 # ~px per Sigma row
+    els.each do |e|
+      eid = v2e[e['ElementId']]; next unless eid && eids_for_sheet.include?(eid)
+      c0, c1 = scale_cols(num(e['XAxisLocation']), num(e['Width']), cw <= 0 ? 1 : cw)
+      r0 = (num(e['YAxisLocation']) / ch_unit).round + 1
+      r1 = r0 + [(num(e['Height']) / ch_unit).round, 4].max
+      placed << [eid, c0, c1, r0, r1]
+    end
+  end
+
+  # fallback: 2-per-row flow over this sheet's mapped elements (preserving sheet order)
+  if placed.empty?
+    sheet_eids = (sheet['Visuals'] || []).map { |v| _t, inner = v.first; v2e[inner['VisualId']] }
+                                          .compact.select { |eid| eids_for_sheet.include?(eid) }
+    col = 1; row = 1
+    sheet_eids.each do |eid|
+      if col > 13
+        col = 1; row += 12
+      end
+      placed << [eid, col, col + 12, row, row + 12]
+      col += 12
+    end
+  end
+
+  # NOTE: do NOT crudely collapse to full-width stacked rows on any overlap (RCA #7,
+  # bead 3goo.7). The px->grid rounding of a FreeFormLayout produces spurious overlaps;
+  # collapsing here destroyed the entire geometry (KPI row, pie row, etc.) and forced
+  # the whole dashboard into a single stacked column. banded_page() downstream clusters
+  # items into row-bands and runs decollide_bands(), which preserves collision-free bands
+  # exactly and only tiles WITHIN a band that genuinely overlaps — the right granularity.
+  [placed, cfg.keys.first || 'flow-fallback']
+end
+
+# ----- assemble: one Sigma page per QS sheet (plus the shared Data page) -----
+# The map's sheetPages (written by build-workbook-from-quicksight.rb) tells us which
+# Sigma page each QS sheet maps to. Fall back to the legacy single dashPageId when an
+# older map (no sheetPages) is supplied.
+sheet_pages = map['sheetPages']
+sheets = defn['Sheets'] || []
+pages_xml = []
+sidecar = {}   # pageId -> container/header spec elements (put-layout.rb injects)
+total_placed = 0
+
+# Sigma control elements per page (built from QS sheet FilterControls/ParameterControls).
+# They have no QS visual-grid coords, so we LIFT them into a clean full-width band at the
+# top of the page (qlik-to-sigma parity): the chart bands keep their QS geometry below.
+control_eids = map['controlElementIds'] || {}
+
+# Prepend a controls band: tile the page's control eids edge-to-edge across the full grid
+# at the top (rows 1..3), then shift all chart items DOWN by that band's height so nothing
+# overlaps. Returns the augmented `placed`.
+def lift_controls(placed, ctl_ids)
+  return placed if ctl_ids.nil? || ctl_ids.empty?
+  band_h = 3
+  shift = placed.map { |i| i[3] }.min.to_i
+  shift = 1 if shift.zero?
+  charts = placed.map { |eid, c0, c1, r0, r1| [eid, c0, c1, r0 - shift + 1 + band_h, r1 - shift + 1 + band_h] }
+  n = ctl_ids.size
+  ctl_band = ctl_ids.each_with_index.map do |eid, j|
+    c0 = 1 + (24 * j / n.to_f).round
+    c1 = 1 + (24 * (j + 1) / n.to_f).round
+    [eid, c0, c1, 1, 1 + band_h]
+  end
+  ctl_band + charts
+end
+
+if sheet_pages && !sheet_pages.empty?
+  sheet_pages.each do |sp|
+    idx = sp['sheetIndex']
+    sheet = sheets[idx] || {}
+    # element ids that belong to THIS sheet = the elements for this sheet's visuals
+    eids_for_sheet = (sheet['Visuals'] || []).map { |v| _t, inner = v.first; v2e[inner['VisualId']] }.compact.to_set
+    placed, src = layout_sheet(sheet, v2e, eids_for_sheet)
+    placed = lift_controls(placed, control_eids[sp['pageId']])
+    total_placed += placed.size
+    next if placed.empty?
+    # Container-banded page (layout-playbook.md): header band with the QS sheet
+    # name, then one full-width GridContainer per row band — the QS 36-col row
+    # geometry is preserved INSIDE each band (container-relative coordinates).
+    xml, extra = banded_page(sp['pageId'], placed, title: sp['name'] || sheet['Name'])
+    pages_xml << xml
+    sidecar[sp['pageId']] = extra
+    STDERR.puts "layout: page \"#{sp['name']}\" (#{sp['pageId']}) <- QS sheet[#{idx}] #{src}: #{placed.size} element(s), #{extra.size - 2} chart band(s) + header"
+    placed.each { |eid, c0, c1, r0, r1| STDERR.puts "  #{eid}  col #{c0}-#{c1}  row #{r0}-#{r1}" }
+  end
+else
+  # legacy single-page path (old map without sheetPages)
+  all_eids = v2e.values.to_set
+  placed, src = layout_sheet(sheets[0] || {}, v2e, all_eids)
+  placed = lift_controls(placed, control_eids[map['dashPageId']])
+  total_placed += placed.size
+  xml, extra = banded_page(map['dashPageId'], placed, title: (sheets[0] || {})['Name'] || 'Dashboard')
+  pages_xml << xml
+  sidecar[map['dashPageId']] = extra
+  STDERR.puts "layout: #{placed.size} elements mapped from QuickSight #{src} (legacy single-page; container bands)"
+end
+
+data_page = page_xml('page-data', le(map['masterElementId'], 1, 25, 1, 15))
+File.write(opts[:out], assemble(data_page, *pages_xml))
+File.write("#{opts[:out]}.elements.json", JSON.pretty_generate(sidecar))
+STDERR.puts "layout: #{total_placed} elements across #{pages_xml.size} page(s) -> #{opts[:out]} (+ .elements.json sidecar)"

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/build-workbook-from-quicksight.rb
@@ -1,0 +1,1466 @@
+#!/usr/bin/env ruby
+# build-workbook-from-quicksight.rb
+# Build a Sigma workbook that mirrors a QuickSight analysis, bound to the
+# data model produced by the convert phase.
+#
+# Architecture (matches the Qlik/PowerBI builders):
+#   - a master "table" element on a Data page, source = {dataModelId, elementId, kind:"data-model"},
+#     surfacing the columns the dashboard needs via [Custom SQL/RAW] (or a translated calc-field expr);
+#   - one dashboard page whose chart elements source the master via {elementId, kind:"table"}
+#     and reference master columns as [<MasterName>/<Col>] with the QuickSight aggregation.
+#
+# Key behaviours (beads-sigma-nc6g / woaa / 23xu):
+#   - the master sources the DM element whose columns COVER the charted columns (the
+#     denormalized join element), NOT a hardcoded pages[0].elements[0];
+#   - QuickSight window/table-calc functions (runningSum/percentOfTotal/rank/difference/…)
+#     are NOT passed through as live Sigma formulas — they are neutralized to Null (the
+#     original expr goes into the column description);
+#   - a dataset FilterOperation surfaced by convert-model (dm-filters.json) is APPLIED as a
+#     real element-level list filter on the master, so downstream aggregates honor it;
+#   - GaugeChartVisual -> kpi-chart, FunnelChartVisual -> bar-chart, TreeMapVisual -> bar-chart
+#     (Sigma has no native gauge/funnel/treemap kind; this mirrors the PBI builder's mapping).
+#
+# Usage:
+#   ruby scripts/build-workbook-from-quicksight.rb \
+#     --analysis DISCOVER_DIR/analysis.json --dm-readback /tmp/dm-readback.json \
+#     [--dm-spec /tmp/dm-spec.json] [--filters /tmp/dm-filters.json] \
+#     --folder-id ID --out /tmp/wb-spec.json
+require 'json'
+require 'optparse'
+require 'securerandom'
+require 'set'
+
+opts = {}
+OptionParser.new do |o|
+  o.on('--analysis F') { |v| opts[:an] = v }
+  o.on('--dm-readback F') { |v| opts[:rb] = v }
+  o.on('--dm-spec F') { |v| opts[:dmspec] = v }
+  o.on('--filters F') { |v| opts[:filters] = v }
+  o.on('--folder-id ID') { |v| opts[:folder] = v }
+  o.on('--master-name NAME') { |v| opts[:mname] = v }
+  o.on('--discover-dir D') { |v| opts[:discover] = v }   # datasets/*.json -> BOOLEAN_COLS (RCA #3)
+  o.on('--out F') { |v| opts[:out] = v }
+end.parse!
+%i[an rb out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+an = JSON.parse(File.read(opts[:an]))
+defn = an['Definition']
+# QuickSight what-if PARAMETERS (Decimal/Integer/String/DateTime ParameterDeclaration).
+# A calc field references a parameter as ${ParamName}. Sigma has no 1:1 parameter inside a
+# data-model formula, so for parity we inline the parameter's DEFAULT value as a constant
+# (the default-view value the QS dashboard shows on load). This is recorded as a warning so
+# the (interactive) what-if control is understood to be a manual re-author in Sigma.
+PARAM_DEFAULTS = {}
+(defn['ParameterDeclarations'] || []).each do |pd|
+  decl = pd.values.first
+  next unless decl.is_a?(Hash) && decl['Name']
+  dv = (decl.dig('DefaultValues', 'StaticValues') || [])[0]
+  PARAM_DEFAULTS[decl['Name']] = dv unless dv.nil?
+end
+rb = JSON.parse(File.read(opts[:rb]))
+dm_id = rb['dataModelId']
+
+def disp(raw); raw.to_s.gsub(/[_.]/, ' ').split.map { |w| w[0..0].upcase + w[1..-1].to_s.downcase }.join(' '); end
+
+# Boolean columns (display names), derived from the discovery datasets' PhysicalTable
+# InputColumns where Type==BOOLEAN. QS OutputColumns coerce booleans to INTEGER, so a
+# calc-field predicate `{FLAG}=1` would emit `[Flag] = 1` and throw at query time on the
+# real boolean column. qs_expr_to_sigma uses this set to rewrite the predicate to the
+# bare boolean (RCA #3, bead 3goo.3). Empty (no --discover-dir) => no rewrite, no change.
+BOOLEAN_COLS = Set.new
+if opts[:discover]
+  Dir[File.join(opts[:discover], 'datasets', '*.json')].sort.each do |f|
+    j = JSON.parse(File.read(f)) rescue next
+    ds = j['DataSet'] || j
+    (ds['PhysicalTableMap'] || {}).each_value do |pt|
+      rt = pt['RelationalTable'] || pt['CustomSql'] || {}
+      (rt['InputColumns'] || []).each { |c| BOOLEAN_COLS << disp(c['Name']) if c['Type'].to_s.upcase == 'BOOLEAN' }
+    end
+  end
+  STDERR.puts "boolean-cols: #{BOOLEAN_COLS.size} BOOLEAN column(s) detected from discovery datasets" unless BOOLEAN_COLS.empty?
+end
+
+# ---- derive the columns the dashboard actually references (raw col names) ----
+def visual_cols(inner)
+  out = []
+  walk = lambda do |o|
+    if o.is_a?(Hash)
+      if (c = o['Column']) && c.is_a?(Hash) && c['ColumnName']
+        out << c['ColumnName']
+      end
+      o.each_value { |v| walk.call(v) }
+    elsif o.is_a?(Array)
+      o.each { |v| walk.call(v) }
+    end
+  end
+  walk.call(inner['ChartConfiguration'] || {})
+  out
+end
+
+calc_names = {}
+(defn['CalculatedFields'] || []).each { |c| calc_names[c['Name']] = c['Expression'] }
+
+needed_raw = []
+defn['Sheets'].each do |sh|
+  (sh['Visuals'] || []).each do |v|
+    _, inner = v.first
+    needed_raw.concat(visual_cols(inner))
+  end
+end
+needed_raw.uniq!
+# calc fields resolve to raw columns inside their expressions; expand
+needed_resolved = needed_raw.flat_map do |n|
+  if calc_names.key?(n)
+    calc_names[n].to_s.scan(/\{([^}]+)\}/).flatten.map(&:strip)
+  else
+    [n]
+  end
+end.uniq
+
+# ---- pick the DM element whose columns COVER the charted columns ----
+# Use the dm-spec (has column display names) to score coverage; fall back to the
+# dm-readback element list when no dm-spec is provided. (beads-sigma-nc6g point 4)
+dm_spec = opts[:dmspec] && File.exist?(opts[:dmspec]) ? JSON.parse(File.read(opts[:dmspec])) : nil
+needed_disp = needed_resolved.map { |c| disp(c) }.to_set
+
+best = nil
+best_idx = nil
+if dm_spec
+  spec_els = (dm_spec['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+  scored = spec_els.each_with_index.map do |el, i|
+    names = (el['columns'] || []).map { |c| c['name'] }.compact.to_set
+    cover = needed_disp.count { |d| names.include?(d) }
+    [cover, (el['columns'] || []).size, el['name'], i]
+  end
+  # most coverage; tie-break on more columns (the denormalized view wins)
+  top = scored.max_by { |cover, ncols, _name, _i| [cover, ncols] }
+  best = top && top[2]
+  best_idx = top && top[3]
+end
+
+rb_els = (rb['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+dm_el_obj =
+  if best
+    # DM element names can COLLIDE (e.g. two "D20 Kitchen Sink" elements: a source +
+    # the denormalized join). Selecting by name alone would grab the first match and
+    # miss the join element that actually covers the charted columns. The dm-spec and
+    # dm-readback element lists are in the same order, so prefer the readback element at
+    # the winning spec index; fall back to name match, then first.
+    (best_idx && rb_els[best_idx]) || rb_els.find { |e| e['name'] == best } || rb_els.first
+  elsif rb_els.any? { |e| (e['columns'] || []).any? }
+    # No dm-spec, but the readback carries column names: score coverage directly off the
+    # readback so we pick the element that actually COVERS the charted columns (handles
+    # name-collision + arbitrary element ordering — beads D20). Tie-break on more columns
+    # (the denormalized join wins).
+    scored_rb = rb_els.map do |el|
+      names = (el['columns'] || []).map { |c| c['name'] }.compact.to_set
+      cover = needed_disp.count { |d| names.include?(d) }
+      [cover, (el['columns'] || []).size, el]
+    end
+    top = scored_rb.max_by { |cover, ncols, _| [cover, ncols] }
+    (top && top[2]) || rb_els.first
+  else
+    # no dm-spec and no readback columns: prefer the last (synthesized join element is
+    # appended last) else first.
+    rb_els.last || rb_els.first
+  end
+abort 'no DM elements in readback' unless dm_el_obj
+dm_el = dm_el_obj['id']
+DMEL = dm_el_obj['name'] || 'Custom SQL'   # DM element name — master refs cols as [DMEL/Col]
+# Master element name (used in [M/Col] refs from charts). Default to the DM element's
+# own name — not the fixture leftover 'Orders', which is wrong for any non-Orders
+# dashboard and confused the Arine healthcare migration (RCA #10, bead 3goo.13).
+M = opts[:mname] || DMEL
+
+def nid(p = 'el'); "#{p}-" + SecureRandom.hex(5); end
+NUM = ->(fs) { { 'kind' => 'number', 'formatString' => fs } }
+AGG = { 'SUM' => 'Sum', 'AVERAGE' => 'Avg', 'MIN' => 'Min', 'MAX' => 'Max',
+        'COUNT' => 'Count', 'DISTINCT_COUNT' => 'CountDistinct', 'MEDIAN' => 'Median' }
+
+# QuickSight window / table-calc function names (must match convert-model.rb). A
+# calc field using any of these can't be a live Sigma formula — neutralize to Null.
+QS_WINDOW_FUNCS = %w[
+  runningSum runningAvg runningCount runningMax runningMin
+  percentOfTotal percentDifference difference
+  rank denseRank percentileRank
+  lag lead firstValue lastValue
+  windowSum windowAvg windowCount windowMax windowMin
+  movingSum movingAverage
+].freeze
+def qs_window_func?(expr)
+  e = expr.to_s
+  QS_WINDOW_FUNCS.any? { |fn| e =~ /(?<![A-Za-z0-9_])#{Regexp.escape(fn)}\s*\(/ }
+end
+
+# minimal QuickSight-expr → Sigma-formula translator for calc fields referenced by visuals
+# QuickSight/moment date-format tokens -> Sigma strftime (RCA #11). Longest-first.
+def qs_datefmt_to_strftime(fmt)
+  return nil if fmt.nil? || fmt.to_s.strip.empty?
+  s = fmt.dup
+  [%w[MMMM %B], %w[MMM %b], %w[MM %m], ['DD', '%d'], ['D', '%-d'],
+   %w[YYYY %Y], %w[YY %y], %w[HH %H], %w[mm %M], %w[ss %S]].each { |q, c| s = s.gsub(q, c) }
+  s
+end
+
+def qs_expr_to_sigma(expr, dmel, params = {})
+  s = expr.to_s.dup
+  # ${Param} -> inlined default constant (what-if parameters have no DM-formula equivalent).
+  s = s.gsub(/\$\{([^}]+)\}/) do
+    nm = Regexp.last_match(1).strip
+    v = params[nm]
+    v.nil? ? '0' : (v.is_a?(String) ? "\"#{v}\"" : v.to_s)
+  end
+  s = s.gsub(/\{([^}]+)\}/) { "[#{dmel}/#{disp(Regexp.last_match(1).strip)}]" }
+  s = s.gsub('<>', '!=')
+  s = s.gsub(/\bifelse\s*\(/i, 'If(')
+  # QS aggregate/scalar function names -> Sigma. Substituted column refs ([dmel/Col]) are
+  # already in place, so this only rewrites function-call heads. Longest-first so
+  # distinct_countIf matches before distinct_count and *If before the base. The negative
+  # lookbehind + required '(' avoids touching identifiers/column names (RCA #9/#10).
+  [%w[distinct_countIf CountDistinctIf], %w[distinct_count CountDistinct],
+   %w[countIf CountIf], %w[sumIf SumIf], %w[avgIf AvgIf], %w[minIf MinIf], %w[maxIf MaxIf],
+   %w[percentOfTotal PercentOfTotal], %w[count Count], %w[sum Sum], %w[avg Avg],
+   %w[min Min], %w[max Max]].each do |qs, sig|
+    s = s.gsub(/(?<![A-Za-z0-9_.\/])#{Regexp.escape(qs)}\s*\(/i, "#{sig}(")
+  end
+  # Boolean-flag predicates: a warehouse BOOLEAN column compared `= 1`/`= 0` (QS's idiom
+  # for a flag it coerced to INTEGER) throws at query time in Sigma. Rewrite to the bare
+  # boolean / Not() for columns known boolean (RCA #3, bead 3goo.3).
+  if defined?(BOOLEAN_COLS) && !BOOLEAN_COLS.empty?
+    s = s.gsub(/\[([^\]]+)\]\s*(=|!=)\s*(1|0|true|false)\b/i) do
+      ref = Regexp.last_match(1); op = Regexp.last_match(2); val = Regexp.last_match(3).downcase
+      if BOOLEAN_COLS.include?(ref.split('/').last)
+        truthy = %w[1 true].include?(val)
+        truthy = !truthy if op == '!='
+        truthy ? "[#{ref}]" : "Not([#{ref}])"
+      else
+        Regexp.last_match(0)
+      end
+    end
+  end
+  s = s.gsub(/'([^']*)'/) { "\"#{Regexp.last_match(1)}\"" }
+  s
+end
+
+calc = {}
+(defn['CalculatedFields'] || []).each { |c| calc[c['Name']] = c['Expression'] }
+
+# A QS visual title may be plain (`Title.FormatText.PlainText`) OR rich text
+# (`Title.FormatText.RichText` = `<visual-title>Weekly Tasks</visual-title>` / inline
+# styling spans). The builder previously read PlainText only, so every rich-text title
+# fell back to the raw VisualId GUID as the element name (RCA #8, bead 3goo.8). Parse
+# both, strip tags, unescape entities.
+def qs_visual_title(inner, vtype)
+  ft = (inner['Title'] || {})['FormatText'] || {}
+  raw = ft['PlainText'] || ft['RichText']
+  if raw && !raw.to_s.strip.empty?
+    s = raw.gsub(/<[^>]+>/, '')
+    { '&amp;' => '&', '&lt;' => '<', '&gt;' => '>', '&nbsp;' => ' ',
+      '&#39;' => "'", '&quot;' => '"', " " => ' ' }.each { |k, val| s = s.gsub(k, val) }
+    s = s.strip
+    return s unless s.empty?
+  end
+  (inner.is_a?(Hash) ? inner['VisualId'] : nil) || vtype
+end
+
+# QS BarsArrangement -> Sigma bar `stacking`. Sigma defaults bars to STACKED, so an
+# unspecified or CLUSTERED QS arrangement must be set to 'none' to render side-by-side
+# (the QS spec + screenshot show clustered bars — RCA).
+def qs_bars_stacking(inner)
+  case inner.dig('ChartConfiguration', 'BarsArrangement').to_s.upcase
+  when 'STACKED' then 'stacked'
+  when 'STACKED_PERCENT' then 'normalized'
+  else 'none'
+  end
+end
+
+def field_role(f)
+  if (mf = f['NumericalMeasureField'])
+    [:meas, mf['Column']['ColumnName'], (mf.dig('AggregationFunction', 'SimpleNumericalAggregation') || 'SUM')]
+  elsif (mf = f['CategoricalMeasureField'])
+    # AggregationFunction here is a PLAIN STRING ('DISTINCT_COUNT' / 'COUNT'), not the
+    # nested SimpleNumericalAggregation shape. Honor it — hardcoding COUNT silently turned
+    # every QS DISTINCT_COUNT(TASK_ID) KPI into a non-distinct Count (RCA #2, bead 3goo.2).
+    [:meas, mf['Column']['ColumnName'], (mf['AggregationFunction'] || 'COUNT').to_s.upcase]
+  elsif (df = f['CategoricalDimensionField'])
+    [:dim, df['Column']['ColumnName'], nil]
+  elsif (df = f['DateDimensionField'])
+    # 4th tuple slot carries the QS DateGranularity (YEAR/QUARTER/MONTH/WEEK/DAY/...)
+    # so a date x-axis can be truncated to that grain (D20 line-chart monthly).
+    # QS frequently omits DateGranularity on a date dim but still renders it at DAY
+    # grain; absent a default, a raw DATETIME on a pivot Columns shelf explodes into one
+    # column per millisecond (RCA #6, bead 3goo.6). Default to DAY.
+    [:dim, df['Column']['ColumnName'], nil, (df['DateGranularity'] || 'DAY')]
+  end
+end
+
+# Generic field-well flattener for the D18 fallback path. The unsupported QS visual
+# types use non-standard well names (Categories / Source / Destination / Weight /
+# GroupBy / Size / Color / ...), so the named-well lambda in the dispatch cannot find
+# them. This walks EVERY well in the field-well object, in document order, and returns
+# [dims, measures] (each an array of field_role tuples). Used only for fallbacks.
+def all_field_roles(w)
+  dims = []; meas = []
+  (w || {}).each do |_well, fields|
+    next unless fields.is_a?(Array)
+    fields.each do |f|
+      r = field_role(f); next unless r
+      (r[0] == :dim ? dims : meas) << r
+    end
+  end
+  [dims, meas]
+end
+
+# The QuickSight FieldId of a single field-well entry (e.g. "f_cnt"). Needed to map a
+# ConditionalFormatting rule (keyed by FieldId) back to the Sigma column we built.
+def field_id(f)
+  return nil unless f.is_a?(Hash)
+  (f['NumericalMeasureField'] || f['CategoricalMeasureField'] ||
+   f['CategoricalDimensionField'] || f['DateDimensionField'] || {})['FieldId']
+end
+
+# ---- QS SortConfiguration -> Sigma sort (beads-sigma-xvjl) -------------------
+# QuickSight sorts live under ChartConfiguration.SortConfiguration, e.g.
+#   { "CategorySort": [ { "FieldSort":  { "FieldId": "...", "Direction": "DESC" } },
+#                       { "ColumnSort": { "SortBy": { "Column": { "ColumnName": ... } },
+#                                         "Direction": "ASC", "AggregationFunction": {...} } } ] }
+# (bar/line/pie use CategorySort; TableVisual uses RowSort.) Resolve the sorted field
+# to the Sigma column built for the visual and emit the verified Sigma shapes:
+#   bar/line/area/combo/scatter : xAxis.sort  = { by: <colId>, direction: }
+#   pie/donut                   : color.sort  = { by: <colId>, direction: }
+#   table                       : sort        = [{ columnId:, direction: }]
+# (pivot-table columnsBy/rowsBy sorts are NOT spec-supported — skipped with a warning.)
+
+# Every FieldId -> raw ColumnName mapping in the visual's field wells.
+def fid_to_colname(field_wells)
+  map = {}
+  walk = lambda do |o|
+    if o.is_a?(Hash)
+      if o['FieldId'] && (cn = o.dig('Column', 'ColumnName'))
+        map[o['FieldId']] = cn
+      end
+      o.each_value { |v| walk.call(v) }
+    elsif o.is_a?(Array)
+      o.each { |v| walk.call(v) }
+    end
+  end
+  walk.call(field_wells || {})
+  map
+end
+
+# Apply a visual's SortConfiguration to the built Sigma element (mutates el).
+def apply_qs_sorts(el, inner, kind, title, warnings)
+  cc = inner['ChartConfiguration'] || {}
+  sc = cc['SortConfiguration']
+  return unless sc.is_a?(Hash) && !sc.empty?
+  entries = sc.values.find { |v| v.is_a?(Array) && !v.empty? } # CategorySort / RowSort / ...
+  return unless entries
+  if kind == 'pivot-table'
+    warnings << { 'visual' => title, 'type' => 'SortConfiguration',
+                  'reason' => 'pivot-table sorts are not spec-expressible in Sigma (columnsBy/rowsBy sort rejected) — set in the UI' }
+    return
+  end
+  fidmap = fid_to_colname(cc['FieldWells'])
+  entries.each_with_index do |entry, i|
+    fs = entry['FieldSort']; cs = entry['ColumnSort']
+    raw = fs ? fidmap[fs['FieldId']] : cs&.dig('SortBy', 'Column', 'ColumnName')
+    dir = ((fs || cs || {})['Direction'].to_s.upcase == 'DESC') ? 'descending' : 'ascending'
+    next unless raw
+    # column names on the element: calc fields keep the raw name, physical cols are disp()'d
+    col = (el['columns'] || []).find { |c| c['name'] == disp(raw) || c['name'] == raw }
+    unless col
+      warnings << { 'visual' => title, 'type' => 'SortConfiguration',
+                    'reason' => "sort field '#{raw}' is not among the visual's Sigma columns — sort skipped" }
+      next
+    end
+    case kind
+    when 'bar-chart', 'line-chart', 'area-chart', 'combo-chart', 'scatter-chart'
+      (el['xAxis'] ||= {})['sort'] = { 'by' => col['id'], 'direction' => dir } if i.zero?
+    when 'pie-chart', 'donut-chart'
+      (el['color'] ||= {})['sort'] = { 'by' => col['id'], 'direction' => dir } if i.zero?
+    when 'table'
+      (el['sort'] ||= []) << { 'columnId' => col['id'], 'direction' => dir }
+    end
+  end
+end
+
+# ---- QS ReferenceLines -> Sigma refMarks (B-gap: reference lines) ------------
+# QuickSight reference lines live at ChartConfiguration.ReferenceLines[] on the
+# cartesian visuals (bar/line/area/combo/scatter). Each entry:
+#   { "Status": "ENABLED",
+#     "DataConfiguration": {
+#       "AxisBinding": "PRIMARY_YAXIS",          # PRIMARY_YAXIS|SECONDARY_YAXIS = series; *_XAXIS = axis
+#       "StaticConfiguration": { "Value": 0.45 } # a constant; OR
+#       "DynamicConfiguration": { "Calculation": {"SimpleNumericalAggregation":"AVERAGE"},
+#                                 "MeasureAggregationFunction": {...}, "Column": {...} } },
+#     "LabelConfiguration": { "CustomLabelConfiguration": { "CustomLabel": "Target" },
+#                             "FontColor": "#ef4444" },
+#     "StyleConfiguration": { "Color": "#ef4444", "Pattern": "DASHED" } }
+# Sigma refMarks (verified shape, qlik_refmarks() parity, 2026-06-15): the value
+# MUST be the wrapped { type:"formula", formula:"<expr>" } form (a bare number 400s);
+# label.visibility must be "shown". A static value -> the literal; a dynamic
+# (aggregation over a column) -> the Sigma aggregate formula over the master, so the
+# line tracks the data. X-axis bindings -> axis "axis"; Y/measure bindings -> "series".
+def qs_reference_lines(inner, calc, master_cols, dmel, m, title, warnings)
+  cc = inner['ChartConfiguration'] || {}
+  lines = cc['ReferenceLines']
+  return [] unless lines.is_a?(Array) && !lines.empty?
+  out = []
+  lines.each do |rl|
+    next if rl['Status'].to_s.upcase == 'DISABLED'
+    dc = rl['DataConfiguration'] || {}
+    axis = dc['AxisBinding'].to_s.upcase.include?('XAXIS') ? 'axis' : 'series'
+    formula = nil
+    if (sc = dc['StaticConfiguration']) && !sc['Value'].nil?
+      formula = sc['Value'].to_s
+    elsif (dyn = dc['DynamicConfiguration'])
+      # aggregation over a column -> Agg([Master/Col]); the line follows the data.
+      col = dyn.dig('Column', 'ColumnName') || dyn.dig('MeasureAggregationFunction', 'Column', 'ColumnName')
+      aggk = (dyn.dig('Calculation', 'SimpleNumericalAggregation') ||
+              dyn.dig('MeasureAggregationFunction', 'SimpleNumericalAggregation') || 'AVERAGE').to_s.upcase
+      if col
+        ref = master_ref(col, calc, master_cols, dmel)
+        formula = "#{AGG[aggk] || 'Avg'}([#{m}/#{ref['name']}])"
+      end
+    end
+    if formula.nil? || formula.empty?
+      warnings << { 'visual' => title, 'type' => 'ReferenceLine',
+                    'reason' => 'reference line has neither a static value nor a resolvable dynamic column — skipped' }
+      next
+    end
+    color = rl.dig('StyleConfiguration', 'Color') || rl.dig('LabelConfiguration', 'FontColor') || '#ef4444'
+    rm = { 'type' => 'line', 'axis' => axis,
+           'value' => { 'type' => 'formula', 'formula' => formula },
+           'line' => { 'color' => color, 'width' => 2 } }
+    lbl = rl.dig('LabelConfiguration', 'CustomLabelConfiguration', 'CustomLabel')
+    rm['label'] = { 'visibility' => 'shown', 'text' => lbl } if lbl && !lbl.to_s.empty?
+    out << rm
+  end
+  out
+end
+
+# ---- QS chart color encoding -> Sigma `color` channel (B-gap: by-measure / by-dimension)
+# QuickSight encodes series color two ways inside the aggregated field wells:
+#   * by DIMENSION — a `Colors` well holding a CategoricalDimensionField (the chart is
+#     split into one colored series per dimension value). -> Sigma color:{by:category}
+#     on that dimension's Sigma column (added to the element if not already present).
+#   * by MEASURE — a `ColorScale` (ColorFillType + Colors[] gradient stops) under the
+#     visual's ColorScale/ScalarColors config, coloring marks along a measure's value.
+#     A Sigma column can't sit on both yAxis and color, so (qlik_color() parity) we add
+#     a DUPLICATE of the first measure column and put color:{by:scale, scheme} on it.
+# Returns the color hash (and MUTATES el['columns'] for the by-scale dup / by-category
+# dim) or nil. `wells` is the inner aggregated-field-wells hash; dim_ids/m_ids are the
+# Sigma column ids already built for this element.
+def qs_color(inner, wells, el, dim_ids, m_ids, calc, master_cols, dmel, m)
+  cc = inner['ChartConfiguration'] || {}
+  # by-dimension: a Colors well with a categorical dimension
+  color_roles = (wells['Colors'] || []).map { |f| field_role(f) }.compact
+  cdim = color_roles.find { |r| r[0] == :dim }
+  if cdim
+    # reuse the dim column if it's already on the element, else add it
+    existing = (el['columns'] || []).find { |c| c['name'] == disp(cdim[1]) || c['name'] == cdim[1] }
+    if existing
+      return { 'by' => 'category', 'column' => existing['id'] }
+    end
+    dc, did = dim_col(cdim, calc, master_cols, dmel, m)
+    (el['columns'] ||= []) << dc
+    return { 'by' => 'category', 'column' => did }
+  end
+  # by-measure: a ColorScale gradient (ColorFillType + Colors[] stops). QS nests it
+  # under the aggregated field-wells (Color/ColorScale) OR ChartConfiguration.ColorScale.
+  cs = wells['ColorScale'] || cc['ColorScale']
+  if cs.is_a?(Hash) && !m_ids.empty?
+    stops = (cs['Colors'] || []).map { |st| st.is_a?(Hash) ? st['Color'] : st }.compact
+    scheme = stops.size >= 2 ? stops : ['#ffffcc', '#fd8d3c', '#bd0026']
+    base = (el['columns'] || []).find { |c| c['id'] == m_ids[0] }
+    return nil unless base
+    cid = "clr-#{SecureRandom.hex(4)}"
+    dup = { 'id' => cid, 'formula' => base['formula'], 'name' => "#{base['name']} (color)" }
+    dup['format'] = base['format'] if base['format']
+    (el['columns'] ||= []) << dup
+    return { 'by' => 'scale', 'column' => cid, 'scheme' => scheme }
+  end
+  nil
+end
+
+# Translate a QuickSight TableVisual ConditionalFormatting block into Sigma
+# `conditionalFormats` (D19). Supported QS -> Sigma mappings (verified spec-expressible
+# + round-tripping via /v2/workbooks/spec, 2026-06-06):
+#   - TextFormat.BackgroundColor.Gradient  -> type:"backgroundScale" (gradient on cell bg)
+#   - TextFormat.TextColor.Gradient        -> type:"fontScale"
+#   - DataBars                             -> type:"dataBars"
+# The gradient Color.Stops (offset/color) become the Sigma `scheme` color-stop array.
+# fieldmap maps QS FieldId -> Sigma column id (only measure cells are colored).
+def qs_conditional_formats(cf_block, fieldmap)
+  out = []
+  (cf_block['ConditionalFormattingOptions'] || []).each do |opt|
+    cell = opt['Cell'] || opt['Row'] || {}
+    fid  = cell['FieldId']
+    colid = fieldmap[fid]
+    next unless colid
+    tf = cell['TextFormat'] || {}
+    if (grad = tf.dig('BackgroundColor', 'Gradient'))
+      scheme = (grad.dig('Color', 'Stops') || []).map { |st| st['Color'] }.compact
+      scheme = ['#FFFFFF', '#D13212'] if scheme.size < 2
+      out << { 'type' => 'backgroundScale', 'columnIds' => [colid], 'scheme' => scheme }
+    elsif (grad = tf.dig('TextColor', 'Gradient'))
+      scheme = (grad.dig('Color', 'Stops') || []).map { |st| st['Color'] }.compact
+      scheme = ['#FFFFFF', '#D13212'] if scheme.size < 2
+      out << { 'type' => 'fontScale', 'columnIds' => [colid], 'scheme' => scheme }
+    elsif cell['DataBars']
+      db = cell['DataBars']
+      pos = db['PositiveColor'] || '#1f77b4'
+      out << { 'type' => 'dataBars', 'columnIds' => [colid], 'scheme' => [pos] }
+    end
+  end
+  out
+end
+
+# QuickSight visual type -> Sigma element kind.
+#
+# Sigma's REAL workbook chart kinds (confirmed against the public OpenAPI element
+# union — /v2/workbooks/spec): kpi-chart, bar-chart, line-chart, area-chart,
+# pie-chart, donut-chart, scatter-chart, combo-chart, table, pivot-table, AND the
+# three geographic kinds point-map / region-map / geography-map. There is NO native
+# histogram, heat-map, treemap, waterfall, box-plot, radar, sankey, or word-cloud
+# kind (verified: those names do not appear anywhere in the element union).
+#
+# Approximations (no native kind, mirror the PBI builder, beads-sigma-1zh9):
+#   gauge -> kpi-chart (single value); funnel/treemap -> bar-chart (category+measure).
+# Geographic (NEW — region-map shape verified to round-trip via live POST+readback
+# + MCP query parity on the D17 DM, 2026-06-06): QuickSight FilledMapVisual and
+# GeospatialMapVisual both map to Sigma region-map when their geo field is a region
+# NAME (state/country/city/zip); GeospatialMapVisual maps to point-map only when it
+# carries real latitude+longitude fields (handled in the dispatch). LayerMapVisual
+# (multi-layer) has no clean single-element equivalent -> dropped with a warning.
+KIND = { 'KPIVisual' => 'kpi-chart', 'BarChartVisual' => 'bar-chart',
+         'LineChartVisual' => 'line-chart', 'PieChartVisual' => 'pie-chart',
+         'ComboChartVisual' => 'combo-chart', 'ScatterPlotVisual' => 'scatter-chart',
+         'TableVisual' => 'table', 'PivotTableVisual' => 'pivot-table',
+         'GaugeChartVisual' => 'kpi-chart', 'FunnelChartVisual' => 'bar-chart',
+         'TreeMapVisual' => 'bar-chart',
+         'FilledMapVisual' => 'region-map', 'GeospatialMapVisual' => 'region-map' }
+
+# QuickSight visual types Sigma has NO native equivalent for. Rather than dropping
+# them (which left whole dashboards empty - beads D18), we DATA-MIGRATE each one as a
+# Sigma fallback element built from the visual\'s underlying dims + measures, so the
+# query/data still migrates with parity. A clear per-visual warning is still recorded
+# (the chart KIND is the (c)-tail, not the data).
+#
+#   QS_FALLBACK maps the type -> the Sigma kind to approximate it with:
+#     - \'bar-chart\'  where a single category+measure shape reads sensibly as bars
+#       (waterfall: a running category total; histogram: a binned distribution that
+#       we approximate as a per-value bar - true auto-binning is still (c)-tail).
+#     - \'table\'      for everything multi-dimensional or non-cartesian (sankey: a
+#       source->dest->weight table; box-plot/word-cloud/radar/heat-map: the underlying
+#       grouped measure table). A table is always data-complete + query-parity.
+# Reason text is surfaced to STDERR + a sidecar warnings file either way.
+QS_UNSUPPORTED = {
+  'HeatMapVisual'       => 'Sigma has no heat-map element kind; migrated as a grouped table of the underlying measure',
+  'HistogramVisual'     => 'Sigma has no histogram element kind (auto-binning); approximated as a bar-chart of the measure (true binning is manual in Sigma)',
+  'BoxPlotVisual'       => 'Sigma has no box-plot element kind; migrated as a grouped table of the underlying values',
+  'WaterfallVisual'     => 'Sigma has no waterfall element kind; approximated as a bar-chart of the category totals',
+  'SankeyDiagramVisual' => 'Sigma has no sankey element kind; migrated as a source/destination/weight table',
+  'WordCloudVisual'     => 'Sigma has no word-cloud element kind; migrated as a grouped table of the term counts',
+  'RadarChartVisual'    => 'Sigma has no radar/spider element kind; migrated as a grouped table of the measure',
+  'LayerMapVisual'      => 'Sigma has no multi-layer map element kind (single-layer point/region-map only)',
+  'InsightVisual'       => 'QuickSight ML insight (forecast/anomaly/narrative) - no Sigma equivalent',
+  'CustomContentVisual' => 'QuickSight custom content (iframe/HTML/image embed) - re-author as a Sigma image/embed element',
+  'PluginVisual'        => 'QuickSight third-party plugin visual (e.g. Highcharts) - no Sigma equivalent',
+  'EmptyVisual'         => 'QuickSight placeholder (no chart configured) - nothing to build'
+}.freeze
+
+# Fallback Sigma kind for each unsupported QS type (D18 data-migration). Types absent
+# here (Insight / CustomContent / Plugin / Empty / LayerMap) have no underlying
+# dim+measure field-well to migrate, so they remain genuine drops with a warning.
+QS_FALLBACK = {
+  'WaterfallVisual'     => 'bar-chart',
+  'HistogramVisual'     => 'bar-chart',
+  'HeatMapVisual'       => 'table',
+  'BoxPlotVisual'       => 'table',
+  'SankeyDiagramVisual' => 'table',
+  'WordCloudVisual'     => 'table',
+  'RadarChartVisual'    => 'table'
+}.freeze
+build_warnings = []
+# Hidden GROUPED source tables emitted for scatter-charts (one row per point dim),
+# appended to the Data page next to the master. See the scatter branch below
+# (ported from the live-verified qlik-to-sigma builder, bead ry0n): Sigma's scatter
+# axis is a GROUPING axis, so an aggregate (Sum(...)) over the UNGROUPED master
+# collapses every point to one x. The scatter must instead bind to a hidden grouped
+# source whose groupBy is the point dimension.
+scatter_sources = []
+
+master_cols = {}   # colname(raw or calc) -> {id, formula, name}  (PRIMARY master's columns)
+
+# ---- Multi-master routing (RCA #4, bead 3goo.4) ----------------------------
+# A QS analysis can bind visuals to DIFFERENT datasets -> different DM elements. The old
+# single-master design pointed EVERY visual at one master, so a visual on a second dataset
+# got broken column refs AND contaminated the master with that dataset's calc fields.
+# We register one Sigma master per DM element and route each visual to the master whose DM
+# element COVERS its columns. A SINGLE-dataset analysis (the common case) routes every
+# visual to the primary master, so its output is byte-identical to the prior behavior.
+rb_label_set = ->(el) { ((el['columnLabels'] || []) + (el['columns'] || []).map { |c| c['name'] }).compact.to_set }
+MASTERS = {}   # dm_el_id -> { sid, name, dmel, dm_el_id, cols(hash), labels(Set) }
+MASTERS[dm_el] = { sid: 'master', name: M, dmel: DMEL, dm_el_id: dm_el,
+                   cols: master_cols, labels: rb_label_set.call(dm_el_obj) }
+PRIMARY_MASTER = MASTERS[dm_el]
+visual_needed_disp = lambda do |inner|
+  raw = visual_cols(inner)
+  resolved = raw.flat_map { |n| calc.key?(n) ? calc[n].to_s.scan(/\{([^}]+)\}/).flatten.map(&:strip) : [n] }
+  resolved.map { |c| disp(c) }.to_set
+end
+route_master = lambda do |inner|
+  needed = visual_needed_disp.call(inner)
+  prim_cover = (needed & PRIMARY_MASTER[:labels]).size
+  return PRIMARY_MASTER if needed.empty? || prim_cover == needed.size
+  # not fully covered by the primary -> pick the DM element that covers it best (tie-break
+  # on FEWER columns so the focused element wins over a denormalized superset)
+  cand = rb_els.map { |e| [(needed & rb_label_set.call(e)).size, -((e['columnLabels'] || []).size), e] }
+               .max_by { |cover, negn, _e| [cover, negn] }
+  return PRIMARY_MASTER if cand.nil? || cand[0] <= prim_cover   # nothing covers it better -> stay primary
+  e = cand[2]
+  MASTERS[e['id']] ||= { sid: "ms-#{SecureRandom.hex(4)}", name: e['name'] || 'Data',
+                         dmel: e['name'] || 'Custom SQL', dm_el_id: e['id'],
+                         cols: {}, labels: rb_label_set.call(e) }
+  MASTERS[e['id']]
+end
+
+# RCA #11 / bead 3goo.11: a QS InsightVisual with a single MAX/MIN computation + a
+# CustomNarrative ("Report Date: <expr>") is reproducible as a Sigma TEXT element with a
+# {{Agg([master/col]) | strftime}} dynamic value — not a hard drop. Returns the text body
+# or nil (skip) when the computation isn't a simple single-value one OR the column isn't
+# covered by a registered master (e.g. its dataset wasn't migrated). Conservative: emits
+# only when a master already covers the column, so it never emits a broken ref.
+qs_insight_text = lambda do |inner|
+  cfg = inner['InsightConfiguration'] || {}
+  comps = cfg['Computations'] || []
+  narr = cfg.dig('CustomNarrative', 'Narrative')
+  return nil if comps.size != 1 || narr.nil? || narr.to_s.strip.empty?
+  ckey, comp = comps.first.first
+  agg = ckey == 'MaximumMinimum' ? (comp['Type'].to_s.upcase == 'MINIMUM' ? 'Min' : 'Max') : nil
+  return nil unless agg
+  colname = nil; datefmt = nil
+  walk = lambda do |o|
+    if o.is_a?(Hash)
+      colname ||= o.dig('Column', 'ColumnName')
+      datefmt ||= o.dig('FormatConfiguration', 'DateTimeFormat') || o['DateTimeFormat']
+      o.each_value { |v| walk.call(v) }
+    elsif o.is_a?(Array) then o.each { |v| walk.call(v) }
+    end
+  end
+  walk.call(comp)
+  return nil unless colname
+  dname = disp(colname)
+  target = MASTERS.values.find { |mm| mm[:labels].include?(dname) }
+  return nil unless target   # dataset not migrated (e.g. Arine REPORT_RUN_DATES) -> skip
+  master_ref(colname, {}, target[:cols], target[:dmel])  # land the column on that master
+  fmt = qs_datefmt_to_strftime(datefmt)
+  val = "#{agg}([#{target[:name]}/#{dname}])"
+  value = fmt ? "{{#{val} | #{fmt}}}" : "{{#{val}}}"
+  prefix = narr.gsub(%r{<expression>.*?</expression>}m, '').gsub(/<[^>]+>/, '')
+  { '&amp;' => '&', '&nbsp;' => ' ', '&#39;' => "'", '&quot;' => '"' }
+    .each { |k, v| prefix = prefix.gsub(k, v) }
+  prefix = prefix.tr(" ", ' ').gsub(/\s+/, ' ').strip
+  align = narr =~ /align="right"/ ? 'right' : (narr =~ /align="center"/ ? 'center' : 'left')
+  "<p style=\"text-align: #{align}\"><span style=\"font-size: 16px\">#{prefix} #{value}</span></p>"
+end
+
+def fmt_for(name)
+  case name
+  when /margin|pct|percent|ratio|rate/i then '.1%'
+  when /revenue|profit|cost|sales|amount|price|discount/i then '$,.0f'
+  else ',.0f'
+  end
+end
+
+# Infer a Sigma region-map regionType from the geo dimension's (raw) column name.
+# Sigma regionType enum (OpenAPI): country, us-state, us-county, us-zipcode,
+# us-cbsa, us-postal-place, ca-province. Default to us-postal-place for free
+# city/place names (the most permissive name-based bucket).
+def region_type_for(rawname)
+  n = rawname.to_s.downcase
+  return 'country'         if n =~ /country|nation/
+  return 'us-state'        if n =~ /\bstate\b|province_state|^st$/
+  return 'us-county'       if n =~ /county/
+  return 'us-zipcode'      if n =~ /zip|postal_?code|postcode/
+  return 'us-cbsa'         if n =~ /cbsa|metro/
+  return 'ca-province'     if n =~ /province/
+  'us-postal-place'  # city / place name
+end
+
+# Does a Geospatial field-well carry an explicit latitude / longitude pair? If so
+# the QuickSight geo visual should become a Sigma point-map; otherwise (a region
+# NAME like state/city) it becomes a region-map.
+def latlong_pair(geo_roles)
+  lat = geo_roles.find { |r| r[1].to_s =~ /lat(itude)?/i }
+  lon = geo_roles.find { |r| r[1].to_s =~ /lon(g|gitude)?/i }
+  (lat && lon) ? [lat, lon] : nil
+end
+
+def master_ref(colname, calc, master_cols, dmel)
+  return master_cols[colname] if master_cols[colname]
+  if calc.key?(colname)
+    if qs_window_func?(calc[colname])
+      # neutralize: a window/table-calc field can't be a live Sigma calc column.
+      formula = 'Null'; nm = colname
+      master_cols[colname] = { 'id' => "m-#{SecureRandom.hex(4)}", 'formula' => formula, 'name' => nm,
+                               'description' => "QuickSight table-calc (neutralized — re-author in Sigma): #{calc[colname]}",
+                               '_window' => true }
+      return master_cols[colname]
+    end
+    formula = qs_expr_to_sigma(calc[colname], dmel, defined?(PARAM_DEFAULTS) ? PARAM_DEFAULTS : {}); nm = colname
+  else
+    formula = "[#{dmel}/#{disp(colname)}]"; nm = disp(colname)
+  end
+  master_cols[colname] = { 'id' => "m-#{SecureRandom.hex(4)}", 'formula' => formula, 'name' => nm }
+end
+
+def dim_col(role, calc, mc, dmel, m)
+  # A date dimension (4th tuple slot = granularity, defaulted to DAY in field_role) must
+  # be truncated — a raw DATETIME on a pivot Columns shelf otherwise explodes into one
+  # column per timestamp and the crosstab looks empty (RCA #6, bead 3goo.6).
+  return date_dim_col(role, calc, mc, dmel, m) if role[3]
+  ref = master_ref(role[1], calc, mc, dmel); id = nid('d')
+  [{ 'id' => id, 'formula' => "[#{m}/#{ref['name']}]", 'name' => ref['name'] }, id]
+end
+
+# QuickSight DateGranularity -> Sigma DateTrunc() part. (D20: a LineChartVisual with a
+# DateDimensionField DateGranularity=MONTH must aggregate the x-axis by month, not plot
+# raw datetime. Sigma truncates via DateTrunc("month", <date>).)
+QS_GRAIN = { 'YEAR' => 'year', 'QUARTER' => 'quarter', 'MONTH' => 'month',
+             'WEEK' => 'week', 'DAY' => 'day', 'HOUR' => 'hour',
+             'MINUTE' => 'minute', 'SECOND' => 'second' }.freeze
+
+# Date dimension column truncated to a QS DateGranularity. Returns the same
+# [col, id] shape as dim_col. The truncated column gets a date format string so the
+# axis renders as e.g. "Jun 2026" for month grain.
+def date_dim_col(role, calc, mc, dmel, m)
+  grain = QS_GRAIN[role[3].to_s.upcase]
+  return dim_col(role, calc, mc, dmel, m) unless grain
+  ref = master_ref(role[1], calc, mc, dmel); id = nid('d')
+  # Sigma datetime formatStrings are strftime conventions (NOT moment.js MMM/YYYY).
+  fmt = case grain
+        when 'year' then '%Y'
+        when 'quarter' then '%b %Y'
+        when 'month' then '%b %Y'
+        when 'week', 'day' then '%Y-%m-%d'
+        else '%Y-%m-%d %H:%M'
+        end
+  [{ 'id' => id, 'name' => ref['name'],
+     'formula' => "DateTrunc(\"#{grain}\", [#{m}/#{ref['name']}])",
+     'format' => { 'kind' => 'datetime', 'formatString' => fmt } }, id]
+end
+
+# A calc field whose translated expression is ALREADY a top-level aggregate
+# (distinct_countIf/sum/etc.) must be emitted DIRECTLY as the chart measure over the
+# master's base columns — wrapping it in the well's aggregation (Sum([m/<calc>])) yields
+# an invalid nested aggregate (RCA #10, bead 3goo.10).
+AGG_EXPR = /\A\s*(CountDistinctIf|CountDistinct|CountIf|Count|SumIf|Sum|AvgIf|Avg|MinIf|Min|MaxIf|Max|Median|StdDev\w*|Variance\w*)\s*\(/
+
+def meas_col(role, calc, mc, dmel, m)
+  _, col, agg = role
+  if calc.key?(col) && !qs_window_func?(calc[col])
+    expr = qs_expr_to_sigma(calc[col], m, defined?(PARAM_DEFAULTS) ? PARAM_DEFAULTS : {})
+    if expr =~ AGG_EXPR
+      # land each base column the aggregate references on the master, then emit the
+      # aggregate itself as the measure (refs resolve to the master via the `m` prefix).
+      calc[col].scan(/\{([^}]+)\}/).flatten.each { |bc| master_ref(bc.strip, calc, mc, dmel) }
+      id = nid('m')
+      return [{ 'id' => id, 'formula' => expr, 'name' => col, 'format' => NUM.(fmt_for(col)) }, id]
+    end
+  end
+  ref = master_ref(col, calc, mc, dmel); id = nid('m')
+  # a neutralized window calc field can't be aggregated as a live formula either
+  if ref['_window']
+    return [{ 'id' => id, 'formula' => 'Null', 'name' => ref['name'],
+              'description' => ref['description'] }, id]
+  end
+  [{ 'id' => id, 'formula' => "#{AGG[agg] || 'Sum'}([#{m}/#{ref['name']}])", 'name' => ref['name'],
+     'format' => NUM.(fmt_for(ref['name'])) }, id]
+end
+
+# D12: a measure that resolves to a QuickSight window / table-calc field (runningSum,
+# percentOfTotal, rank, difference, ...) is neutralized to Null in the master (it can't
+# be a live Sigma formula). Surfacing those as columns in a chart/table renders BLANK
+# columns that look broken. We DROP such measures from the workbook ELEMENT (they stay
+# in the data model's master with their original expr in the description, so the intent
+# is preserved and re-authorable) and record a per-visual warning.
+def window_meas?(role, calc)
+  return false unless role && role[0] == :meas
+  name = role[1]
+  calc.key?(name) && qs_window_func?(calc[name])
+end
+
+# ---- C-gap: QuickSight CONTROLS -> Sigma list controls ----------------------
+# QuickSight interactivity lives at the SHEET level as FilterControls + ParameterControls
+# (NOT inside a visual). Until now this builder emitted ZERO control elements — every QS
+# dashboard migrated as a static workbook (filters inlined as constants / element-level).
+# We now reconstruct them as real Sigma `kind:control` list controls so the dropdowns
+# populate and drive the page (the silently-dropped class the control-scope gate exists
+# to kill). Shape mirrors the live-verified qlik-to-sigma builder:
+#   { kind:"control", controlId, name, controlType:"list", mode:"include",
+#     selectionMode:"multiple", values:[],
+#     source:{ kind:"source", source:{kind:"table", elementId:"master"}, columnId },
+#     filters:[{ source:{kind:"table", elementId:"master"}, columnId }] }
+# The double-nested `source` is what POPULATES the dropdown's value list from the master
+# column; `filters` is what makes the control DRIVE the master (and so, via source-closure,
+# every chart that sources the master). Date-typed columns become date-range controls
+# (a list control on a datetime target is silently stripped by the spec API).
+#
+# QS -> Sigma mapping:
+#   * FilterControls (Dropdown/List/...) -> resolve SourceFilterId through FilterGroups to
+#     the filtered Column.ColumnName, target the master column for that name.
+#   * ParameterControls (Dropdown/List/...) bound to a Column-typed parameter -> same.
+#     A ParameterControl bound to a WHAT-IF numeric parameter (no column) has no list-
+#     control equivalent (it feeds a calc-field constant) -> recorded UNBOUND/manual, not
+#     emitted (the value is already inlined by PARAM_DEFAULTS).
+QS_CONTROL_WRAPS = %w[Dropdown List Slider TextField TextArea DateTimePicker RelativeDateTime].freeze
+
+# Every FilterId -> filtered raw ColumnName, indexed across the analysis FilterGroups.
+QS_FILTER_COL = {}
+(defn['FilterGroups'] || []).each do |fg|
+  (fg['Filters'] || []).each do |flt|
+    body = flt.is_a?(Hash) ? flt.values.first : nil
+    next unless body.is_a?(Hash)
+    fid = body['FilterId']
+    col = body.dig('Column', 'ColumnName') || body.dig('ColumnName')
+    QS_FILTER_COL[fid] = col if fid && col
+  end
+end
+
+# RCA #1 / bead 3goo.1 — PER-VISUAL FilterGroups. A QS FilterGroup whose
+# ScopeConfiguration scopes it to specific VisualIds (SheetVisualScopingConfigurations
+# with Scope==SELECTED_VISUALS) is an ELEMENT-LEVEL filter on exactly those visuals.
+# Dropping these silently produced 5 identical KPIs on the Arine dashboard — each was
+# DISTINCT_COUNT(TASK_ID) distinguished ONLY by a TASK_STATUS CategoryFilter. We index
+# VisualId -> [{col, values, mode}] and apply them as Sigma element `filters[]` so each
+# element sees the same rows QuickSight scoped it to.
+VISUAL_FILTERS = Hash.new { |h, k| h[k] = [] }
+(defn['FilterGroups'] || []).each do |fg|
+  next unless (fg['Status'] || 'ENABLED').to_s.upcase == 'ENABLED'
+  scopes = fg.dig('ScopeConfiguration', 'SelectedSheets', 'SheetVisualScopingConfigurations') || []
+  vids = scopes.select { |s| (s['Scope'] || '').to_s.upcase == 'SELECTED_VISUALS' }
+              .flat_map { |s| s['VisualIds'] || [] }.uniq
+  next if vids.empty?
+  (fg['Filters'] || []).each do |flt|
+    cf = flt.is_a?(Hash) ? (flt['CategoryFilter'] || flt.values.first) : nil
+    next unless cf.is_a?(Hash)
+    col = cf.dig('Column', 'ColumnName')
+    cfg = cf['Configuration'] || {}
+    inner = cfg['FilterListConfiguration'] || cfg['CustomFilterListConfiguration'] ||
+            cfg['CustomFilterConfiguration'] || {}
+    vals = inner['CategoryValues'] || (inner['CategoryValue'] ? [inner['CategoryValue']] : [])
+    next if col.nil? || vals.empty?
+    mop  = (inner['MatchOperator'] || 'CONTAINS').to_s.upcase
+    mode = mop.start_with?('DOES_NOT') ? 'exclude' : 'include'
+    vids.each { |vid| VISUAL_FILTERS[vid] << { 'col' => col, 'values' => vals, 'mode' => mode } }
+  end
+end
+
+# Attach a visual's scoped FilterGroups (above) to its built Sigma element as element
+# `filters[]`. The filtered column must exist ON the element (filter columnId references
+# an element column), so we add it via dim_col (reusing one if already present, e.g. a
+# pivot already grouping by that column). Filters scope rows BEFORE aggregation — so a
+# KPI's CountDistinct then equals QuickSight's filtered distinct count.
+def apply_visual_filters(el, vid, calc, master_cols, dmel, m)
+  return unless el
+  flts = VISUAL_FILTERS[vid]
+  return if flts.nil? || flts.empty?
+  el['columns'] ||= []
+  flts.each do |f|
+    dc, did = dim_col([:dim, f['col'], nil], calc, master_cols, dmel, m)
+    existing = el['columns'].find { |c| c['formula'] == dc['formula'] }
+    if existing
+      cid = existing['id']
+    else
+      el['columns'] << dc
+      cid = did
+    end
+    (el['filters'] ||= []) << { 'id' => nid('flt'), 'columnId' => cid,
+                                'kind' => 'list', 'mode' => f['mode'], 'values' => f['values'] }
+  end
+end
+
+# RCA #18 / bead 3goo.15: a QS sheet-level TextBox carries HTML in `Content`. Sigma text
+# `body` is Markdown + light inline HTML. Strip QS markup to plain paragraphs (the
+# explanatory annotations — x-axis/metric definitions — were silently dropped because the
+# builder only walked `Visuals`, never `TextBoxes`).
+def qs_textbox_to_markdown(html)
+  s = html.to_s.dup
+  s = s.gsub(%r{<br\s*/?>}i, "\n").gsub(%r{</p>}i, "\n\n").gsub(%r{</div>}i, "\n\n")
+  s = s.gsub(/<[^>]+>/, '')
+  { '&amp;' => '&', '&lt;' => '<', '&gt;' => '>', '&nbsp;' => ' ',
+    '&#39;' => "'", '&quot;' => '"', " " => ' ' }.each { |k, v| s = s.gsub(k, v) }
+  paras = s.split("\n").map(&:strip).reject(&:empty?)
+  # QS wraps each styled run (e.g. a bold word) in its own block, so a single sentence
+  # fragments into several "paragraphs" ("The x-axis represents the" / "starting date" /
+  # "of the timeframe..."). Re-join a SHORT fragment that doesn't end a sentence into the
+  # next paragraph, so captions read as prose instead of clipped stubs (RCA #18 polish).
+  merged = []
+  paras.each do |p|
+    if !merged.empty? && merged.last.length < 40 && merged.last !~ /[.!?:]\s*$/
+      merged[-1] = "#{merged.last} #{p}".strip
+    else
+      merged << p
+    end
+  end
+  merged.join("\n\n").strip
+end
+
+# Column-typed parameter? (ParameterDeclaration whose default came from a column.) We map
+# a ParameterControl to a column only when the analysis associates it with one; otherwise
+# it's a what-if scalar (inlined as a constant) and gets no list control.
+def qs_control_target_col(wrap, kind, filter_col_map)
+  body = wrap[kind] || {}
+  if (sfid = body['SourceFilterId'])
+    return [filter_col_map[sfid], body, :filter]
+  end
+  # ParameterControl: a Dropdown/List bound to a column surfaces SelectableValues or a
+  # LinkToDataSetColumn { Column: { ColumnName } }. A plain what-if param has neither.
+  col = body.dig('SelectableValues', 'LinkToDataSetColumn', 'ColumnName') ||
+        body.dig('CascadingControlConfiguration', 'SourceControls', 0, 'ColumnToMatch', 'ColumnName')
+  [col, body, :parameter]
+end
+
+# Build ONE Sigma control element for a QS FilterControl/ParameterControl wrap, or nil.
+# Pushes a control-scope CONTRACT row (scope/sourceName/status) or an `unbound` row so the
+# signal is NEVER silently dropped. Dedupes by target column (the same column filtered by
+# two controls is one Sigma control — controlIds are unique).
+def build_qs_control(wrap, master_cols, calc, dmel, scope, unbound, seen_cols, warnings, masters = {})
+  ctype, body = nil, nil
+  raw_col = nil; src_kind = :filter
+  QS_CONTROL_WRAPS.each do |k|
+    next unless wrap[k].is_a?(Hash)
+    raw_col, body, src_kind = qs_control_target_col(wrap, k, QS_FILTER_COL)
+    ctype = k
+    break
+  end
+  return nil unless body
+  cid_src = body['FilterControlId'] || body['ParameterControlId'] || nid('ctl')
+  label = body.dig('Title') || body['Title'] || raw_col || cid_src
+  sig = "#{src_kind} control #{cid_src.inspect}#{raw_col ? " on #{raw_col}" : ''}"
+  if raw_col.nil? || raw_col.to_s.empty?
+    # what-if scalar parameter control — already inlined as a constant; no list control.
+    warnings << { 'visual' => '(control)', 'type' => 'ParameterControl',
+                  'reason' => "#{sig}: not bound to a dataset column (what-if scalar) — its default is inlined; add a Sigma what-if control by hand if interactivity is needed" }
+    unbound << { 'sourceName' => sig, 'status' => 'manual',
+                 'reason' => 'what-if scalar parameter control has no Sigma list-control equivalent (value inlined as a constant)' }
+    return nil
+  end
+  if seen_cols.key?(raw_col)
+    unbound << { 'sourceName' => sig, 'status' => 'duplicate',
+                 'reason' => "same column as control '#{seen_cols[raw_col]}' — one Sigma control already covers it" }
+    return nil
+  end
+  # surface the target column on the master (master_ref adds it if absent) and target it.
+  ref = master_ref(raw_col, calc, master_cols, dmel)
+  col_id = ref['id']
+  ctl_id = 'qs-' + raw_col.to_s.gsub(/[^A-Za-z0-9]/, '') + '-filter'
+  seen_cols[raw_col] = ctl_id
+  el = { 'id' => nid('ctlel'), 'kind' => 'control', 'controlId' => ctl_id,
+         'name' => label.to_s }
+  is_date = ctype == 'DateTimePicker' || ctype == 'RelativeDateTime' ||
+            raw_col.to_s =~ /(^|_)(date|dt|timestamp)(_|$)/i
+  if is_date
+    # date target: a `list` control on a datetime column is silently stripped by the
+    # spec API, so a date-range control is the faithful shape (needs a flat `mode`).
+    el.merge!('controlType' => 'date-range', 'mode' => 'between',
+              'includeNulls' => 'when-no-value-is-selected',
+              'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'master' }, 'columnId' => col_id }])
+  else
+    el.merge!('controlType' => 'list', 'mode' => 'include', 'selectionMode' => 'multiple',
+              'values' => [],
+              'source' => { 'kind' => 'source',
+                            'source' => { 'kind' => 'table', 'elementId' => 'master' }, 'columnId' => col_id },
+              'filters' => [{ 'source' => { 'kind' => 'table', 'elementId' => 'master' }, 'columnId' => col_id }])
+  end
+  # Cross-master control fan-out (RCA #4 follow-up): a QS sheet control is GLOBAL, so it
+  # must also drive any SECONDARY master that carries the same column — else charts on a
+  # second dataset (e.g. the Weekly Tasks combo on the aggregation table) ignore the filter
+  # and render all-data instead of the controlled slice. Append a filter target per
+  # secondary master that has the column.
+  wired = [{ 'elementId' => 'master', 'columnId' => col_id }]
+  (masters || {}).each_value do |mm|
+    next if mm[:sid] == 'master' || !mm[:labels].include?(disp(raw_col))
+    scol = master_ref(raw_col, calc, mm[:cols], mm[:dmel])
+    el['filters'] << { 'source' => { 'kind' => 'table', 'elementId' => mm[:sid] }, 'columnId' => scol['id'] }
+    wired << { 'elementId' => mm[:sid], 'columnId' => scol['id'] }
+  end
+  scope << { 'controlId' => ctl_id, 'sourceName' => sig, 'status' => 'wired',
+             'controlType' => el['controlType'], 'scope' => 'page', 'mustReach' => [],
+             'wired' => wired }
+  el
+end
+
+# control-scope + signal accounting (filled in the sheet loop, written as control-scope.json)
+control_scope = []      # CONTRACT rows for control_lint.rb gate (c)
+control_unbound = []     # manual/duplicate/unbound signals (loud, never silent)
+control_seen_cols = {}   # raw col -> ctl_id (dedupe; QS associative = global, like qlik)
+n_control_signals = 0    # QS filter/parameter control objects encountered (sourceFilterSignals)
+n_textboxes = 0          # QS sheet-level TextBoxes emitted as Sigma text elements (bead 3goo.15)
+
+# MULTI-SHEET -> MULTI-PAGE (the big fidelity fix): every QuickSight SHEET becomes its
+# own Sigma PAGE (page name = sheet name), each page holding only that sheet's visuals.
+# Previously ALL sheets flattened onto a single "page-dash", so the layout step (which
+# only read Sheets[0]) silently lost every visual on sheet 2..N. We now collect elements
+# PER SHEET and record the sheet<->page<->visual mapping for the layout step.
+sheet_pages = []   # [{ "pageId"=>, "name"=>, "sheetIndex"=>, "elements"=>[...] }]
+vis_map = {}       # QS VisualId -> Sigma element id (globally unique within an analysis)
+defn['Sheets'].each_with_index do |sh, sheet_idx|
+  elements = []
+  (sh['Visuals'] || []).each do |v|
+    vtype, inner = v.first
+    title = qs_visual_title(inner, vtype)
+    kind = KIND[vtype]
+    is_fallback = false
+    unless kind
+      # D18: a QS type with no native Sigma kind. If it has a dim+measure fallback
+      # mapping, DATA-MIGRATE it (build a Sigma table/bar from the underlying fields)
+      # and still warn; otherwise it is a genuine drop (Insight/CustomContent/Plugin/
+      # Empty/LayerMap) and we skip it.
+      fk = QS_FALLBACK[vtype]
+      reason = QS_UNSUPPORTED[vtype] || "unrecognized QuickSight visual type '#{vtype}'"
+      build_warnings << { 'visual' => title, 'type' => vtype, 'reason' => reason }
+      unless fk
+        # RCA #11: a simple single-computation Insight narrative -> Sigma text element.
+        if vtype == 'InsightVisual' && (ibody = qs_insight_text.call(inner))
+          tid = nid('txt')
+          elements << { 'id' => tid, 'kind' => 'text', 'name' => 'Insight', 'body' => ibody }
+          vis_map[inner['VisualId']] = tid
+          build_warnings.pop   # supersede the generic "dropped" warning we just queued
+          build_warnings << { 'visual' => title, 'type' => vtype, 'reason' => 'migrated as a dynamic text element (single-computation narrative)' }
+          STDERR.puts "  ~ InsightVisual (#{title}): migrated as dynamic text"
+          next
+        end
+        STDERR.puts "  ! skipped #{vtype} (#{title}): #{reason}"
+        next
+      end
+      kind = fk; is_fallback = true
+      STDERR.puts "  ~ #{vtype} (#{title}): no native Sigma kind -> migrated as #{fk} (#{reason})"
+    end
+    eid = nid
+    vis_map[inner['VisualId']] = eid
+    # PieChartVisual → pie-chart by default. Map to donut-chart ONLY when QuickSight
+    # is rendering a REAL donut: DonutOptions.ArcOptions.ArcThickness is present AND
+    # not 'WHOLE'. QuickSight's ArcThickness enum is WHOLE|SMALL|MEDIUM|LARGE — WHOLE
+    # means a solid pie (no hole), SMALL/MEDIUM/LARGE are donuts. (The QS console also
+    # emits a DonutOptions block for a plain pie, so presence of the key alone is not a
+    # donut signal — orders-overview "Net Revenue by Region"=MEDIUM stays a donut;
+    # D3 "Revenue Mix by Channel"=WHOLE becomes a pie.)
+    if vtype == 'PieChartVisual'
+      arc = inner.dig('ChartConfiguration', 'DonutOptions', 'ArcOptions', 'ArcThickness')
+      kind = 'donut-chart' if arc && arc.to_s.upcase != 'WHOLE'
+    end
+    fw = (inner['ChartConfiguration'] || {})['FieldWells'] || {}
+    w = fw.values.find { |x| x.is_a?(Hash) } || fw
+    rol = ->(key) { (w[key] || []).map { |f| field_role(f) }.compact }
+    # route this visual to the master whose DM element covers its columns (RCA #4)
+    mr = route_master.call(inner)
+    mc_ = mr[:cols]; dmel_ = mr[:dmel]; m_ = mr[:name]; mid_ = mr[:sid]
+    base = { 'id' => eid, 'kind' => kind, 'name' => title, 'source' => { 'elementId' => mid_, 'kind' => 'table' } }
+    # value labels on bar/pie/donut (Sigma defaults them OFF); lines stay clean
+    base['dataLabel'] = { 'labels' => 'shown' } if %w[bar-chart pie-chart donut-chart].include?(kind)
+    el = nil
+
+    case kind
+    when 'kpi-chart'
+      # KPI + Gauge both surface a single value
+      vals = rol.('Values'); (next if vals.empty?)
+      c, cid = meas_col(vals[0], calc, mc_, dmel_, m_)
+      el = base.merge('columns' => [c.merge('name' => title)], 'value' => { 'columnId' => cid })
+    when 'bar-chart', 'line-chart', 'area-chart'
+      # funnel/treemap land here too: their dim is in Category/Groups, measure in Values/Sizes
+      if is_fallback
+        # D18 waterfall/histogram -> bar. Use the generic flattener (non-standard wells).
+        fdims, fmeas = all_field_roles(w)
+        dims = fdims; vals = fmeas
+      else
+        dims = rol.('Category'); dims = rol.('Groups') if dims.empty?
+        vals = rol.('Values'); vals = rol.('Sizes') if vals.empty?
+      end
+      # Histogram fallback has only a numeric measure and NO category. Use that column
+      # as the (un-aggregated) x dimension and Count the rows as y, so the per-value
+      # distribution still migrates as bars.
+      if is_fallback && dims.empty? && !vals.empty?
+        dims = [[:dim, vals[0][1], nil]]
+        vals = [[:meas, vals[0][1], 'COUNT']]
+      end
+      # D12: drop null window/table-calc measures (they render as blank series); keep them
+      # in the DM master. If none survive, the chart has nothing to plot -> skip it.
+      dropped_w = vals.select { |mv| window_meas?(mv, calc) }
+      dropped_w.each { |mv| build_warnings << { 'visual' => title, 'type' => 'WindowCalcColumn', 'reason' => "measure '#{mv[1]}' is a QuickSight window/table-calc - dropped from the chart (kept in the data model); re-author in Sigma" } }
+      vals -= dropped_w
+      if vals.empty?
+        STDERR.puts "  ! skipped #{kind} (#{title}): only measure(s) were QuickSight window/table-calc (null in Sigma)"
+        next
+      end
+      (next if dims.empty? || vals.empty?)
+      # D20: a date dimension carrying a QS DateGranularity (e.g. MONTH on a line chart)
+      # is truncated to that grain so the x-axis aggregates by month/quarter/year instead
+      # of plotting raw datetime (otherwise the line is spiky/per-row).
+      dc, did = if dims[0][3]
+                  date_dim_col(dims[0], calc, mc_, dmel_, m_)
+                else
+                  dim_col(dims[0], calc, mc_, dmel_, m_)
+                end
+      cols = [dc]; ycids = []
+      vals.each { |mv| c, id = meas_col(mv, calc, mc_, dmel_, m_); cols << c; ycids << id }
+      el = base.merge('columns' => cols, 'xAxis' => { 'columnId' => did }, 'yAxis' => { 'columnIds' => ycids })
+      # D20: honor QuickSight BarChartVisual Orientation. HORIZONTAL -> Sigma
+      # orientation:"horizontal"; VERTICAL (default) is expressed by OMITTING the field
+      # (Sigma rejects orientation:"vertical"). Only meaningful for bar charts.
+      if kind == 'bar-chart'
+        qs_orient = (inner['ChartConfiguration'] || {})['Orientation']
+        el['orientation'] = 'horizontal' if qs_orient.to_s.upcase == 'HORIZONTAL'
+        el['stacking'] = qs_bars_stacking(inner)   # CLUSTERED -> unstacked (Sigma defaults to stacked)
+      end
+      # B-gap COLOR: by-measure (ColorScale dup column) / by-dimension (Colors well).
+      cclr = qs_color(inner, w, el, [did], ycids, calc, mc_, dmel_, m_)
+      el['color'] = cclr if cclr
+      # A-gap REFERENCE LINES -> refMarks (wrapped value:{type:formula}).
+      rms = qs_reference_lines(inner, calc, mc_, dmel_, m_, title, build_warnings)
+      el['refMarks'] = rms unless rms.empty?
+    when 'pie-chart', 'donut-chart'
+      dims = rol.('Category'); vals = rol.('Values'); (next if dims.empty? || vals.empty?)
+      dc, did = dim_col(dims[0], calc, mc_, dmel_, m_); mc2, mid = meas_col(vals[0], calc, mc_, dmel_, m_)
+      el = base.merge('columns' => [dc, mc2], 'color' => { 'id' => did }, 'value' => { 'id' => mid })
+    when 'combo-chart'
+      dims = rol.('Category'); bars = rol.('BarValues'); lines = rol.('LineValues')
+      [bars, lines].each do |arr|
+        arr.select { |mv| window_meas?(mv, calc) }.each do |mv|
+          build_warnings << { 'visual' => title, 'type' => 'WindowCalcColumn', 'reason' => "measure '#{mv[1]}' is a QuickSight window/table-calc - dropped from the combo chart (kept in the data model)" }
+        end
+      end
+      bars  = bars.reject  { |mv| window_meas?(mv, calc) }
+      lines = lines.reject { |mv| window_meas?(mv, calc) }
+      if bars.empty? && lines.empty?
+        STDERR.puts "  ! skipped combo-chart (#{title}): only measure(s) were QuickSight window/table-calc"
+        next
+      end
+      (next if dims.empty? || (bars.empty? && lines.empty?))
+      dc, did = dim_col(dims[0], calc, mc_, dmel_, m_); cols = [dc]; ycids = []
+      bars.each  { |mv| c, id = meas_col(mv, calc, mc_, dmel_, m_); cols << c; ycids << id }
+      lines.each { |mv| c, id = meas_col(mv, calc, mc_, dmel_, m_); cols << c; ycids << { 'columnId' => id, 'type' => 'line' } }
+      el = base.merge('columns' => cols, 'xAxis' => { 'columnId' => did }, 'yAxis' => { 'columnIds' => ycids })
+      # A QS ComboChartVisual with NO LineValues (all measures in BarValues) is a clustered
+      # BAR chart, not a combo — Sigma renders a combo-chart's extra series as a line, so a
+      # bars-only QS combo (e.g. Arine "Weekly Tasks": Tasks Closed + Generated) would show a
+      # spurious line. Emit bar-chart when there are no line series.
+      el['kind'] = 'bar-chart' if lines.empty?
+      el['stacking'] = qs_bars_stacking(inner)   # QS BarsArrangement: CLUSTERED -> unstacked
+      cclr = qs_color(inner, w, el, [did], [], calc, mc_, dmel_, m_)  # combo: by-dimension only
+      el['color'] = cclr if cclr && cclr['by'] == 'category'
+      rms = qs_reference_lines(inner, calc, mc_, dmel_, m_, title, build_warnings)
+      el['refMarks'] = rms unless rms.empty?
+    when 'scatter-chart'
+      xs = rol.('XAxis'); ys = rol.('YAxis'); cat = rol.('Category'); sz = rol.('Size')
+      (next if xs.empty? || ys.empty?)
+      xc, xid = meas_col(xs[0], calc, mc_, dmel_, m_); yc, yid = meas_col(ys[0], calc, mc_, dmel_, m_)
+      if cat.any?
+        # A QuickSight scatter is measure-vs-measure with the Category field as the POINT
+        # identity. Sigma's scatter axis is a GROUPING axis: an aggregate (Sum(...)) over
+        # the UNGROUPED master evaluates per-row and every point collapses to one x — the
+        # spec POSTs but renders wrong (bead ry0n; ported from the live-verified
+        # qlik-to-sigma builder, 2026-06-15). Correct shape: bind the scatter to a HIDDEN
+        # GROUPED source table (one row per point dim) and reference its grouped columns
+        # with raw refs; the dim stays on color:{by:category} so points don't merge.
+        dc, did = dim_col(cat[0], calc, mc_, dmel_, m_)
+        gcols = [dc, xc, yc]          # group dim + x + y (+ size); columns live on the source
+        gcids = [xid, yid]            # aggregated calculations (size appended below)
+        szc = nil
+        if sz.any?
+          szc, szid = meas_col(sz[0], calc, mc_, dmel_, m_)
+          gcols << szc; gcids << szid
+        end
+        src_id = "#{eid}-src"; src_name = "Scatter Source #{eid[-6..-1]}"
+        grp_id = "#{src_id}-g"
+        scatter_sources << { 'id' => src_id, 'kind' => 'table', 'name' => src_name,
+                             'visibleAsSource' => false,
+                             'source' => { 'elementId' => mid_, 'kind' => 'table' },
+                             'columns' => gcols,
+                             'groupings' => [{ 'id' => grp_id, 'groupBy' => [did], 'calculations' => gcids }] }
+        # RAW (non-aggregating) refs into the grouped source, one per channel.
+        raw = lambda do |col|
+          { 'id' => "#{eid}-#{col['id']}", 'formula' => "[#{src_name}/#{col['name']}]", 'name' => col['name'] }
+        end
+        s_dim = raw.(dc); s_x = raw.(xc); s_y = raw.(yc)
+        scols = [s_dim, s_x, s_y]
+        el = base.merge('source' => { 'elementId' => src_id, 'kind' => 'table', 'groupingId' => grp_id },
+                        'xAxis' => { 'columnId' => s_x['id'] }, 'yAxis' => { 'columnIds' => [s_y['id']] },
+                        'color' => { 'by' => 'category', 'column' => s_dim['id'] })
+        # D8 (now a real channel): QuickSight scatter Size becomes a Sigma scatter
+        # size:{id} channel over the grouped source's size aggregate.
+        if szc
+          s_sz = raw.(szc); scols << s_sz; el['size'] = { 'id' => s_sz['id'] }
+        end
+        el['columns'] = scols
+      else
+        # No point dimension: keep the prior measure-vs-measure-on-master behavior
+        # (a single ungrouped scatter point is still the faithful migration here).
+        el = base.merge('columns' => [xc, yc], 'xAxis' => { 'columnId' => xid }, 'yAxis' => { 'columnIds' => [yid] })
+        # D8: QuickSight scatter Size (bubble radius) with no grouping. Sigma scatter has no
+        # verified ungrouped size channel, so we PROJECT the size measure as a column (data
+        # migrates) and record a warning that bubble-sizing renders uniform.
+        if sz.any?
+          szc, _szid = meas_col(sz[0], calc, mc_, dmel_, m_); el['columns'] << szc
+          build_warnings << { 'visual' => title, 'type' => 'ScatterBubbleSize', 'reason' => "QuickSight scatter bubble-size ('#{sz[0][1]}') has no Sigma scatter size channel (no point dimension to group on); the measure is projected as a column but bubbles render uniform-size (Sigma limitation)" }
+        end
+      end
+      # A-gap REFERENCE LINES on scatter (e.g. an x=Margin-Target line).
+      rms = qs_reference_lines(inner, calc, mc_, dmel_, m_, title, build_warnings)
+      el['refMarks'] = rms unless rms.empty?
+    when 'table'
+      cf_fieldmap = {}   # QS FieldId -> Sigma column id (for D19 conditional formatting)
+      if is_fallback
+        # D18 sankey/box-plot/word-cloud/radar/heat-map -> table. Flatten every well
+        # (Source/Destination/Weight, GroupBy/Size, Category/Color/Values, ...) into a
+        # grouped table: all dims become group-bys, all measures become aggregates.
+        dims, vals = all_field_roles(w)
+        raw_dims = []; raw_vals = []  # fallback has no CF
+      else
+        dims = rol.('GroupBy'); vals = rol.('Values')
+        raw_dims = (w['GroupBy'] || []); raw_vals = (w['Values'] || [])
+      end
+      # D12: drop null window/table-calc measures from the TABLE (blank columns look broken);
+      # they remain in the DM master with their original expr in the description.
+      unless is_fallback
+        keep_idx = vals.each_index.reject { |i| window_meas?(vals[i], calc) }
+        dropped_idx = vals.each_index.to_a - keep_idx
+        dropped_idx.each { |i| build_warnings << { 'visual' => title, 'type' => 'WindowCalcColumn', 'reason' => "column '#{vals[i][1]}' is a QuickSight window/table-calc - dropped from the table (kept in the data model); re-author in Sigma" } }
+        vals = keep_idx.map { |i| vals[i] }
+        raw_vals = keep_idx.map { |i| raw_vals[i] }
+      end
+      cols = []; gids = []; cids = []
+      dims.each_with_index { |d, i| c, id = dim_col(d, calc, mc_, dmel_, m_); cols << c; gids << id; (fi = field_id(raw_dims[i])) && (cf_fieldmap[fi] = id) }
+      vals.each_with_index { |mv, i| c, id = meas_col(mv, calc, mc_, dmel_, m_); cols << c; cids << id; (fi = field_id(raw_vals[i])) && (cf_fieldmap[fi] = id) }
+      (next if cols.empty?)
+      el = base.merge('columns' => cols)
+      el['groupings'] = [{ 'id' => nid('g'), 'groupBy' => gids, 'calculations' => cids }] unless gids.empty?
+      # D19: migrate QS TableVisual ConditionalFormatting (gradient cell color / data bars)
+      # into Sigma `conditionalFormats` on the table element.
+      if (cfb = inner['ConditionalFormatting'])
+        cfmts = qs_conditional_formats(cfb, cf_fieldmap)
+        unless cfmts.empty?
+          el['conditionalFormats'] = cfmts
+          STDERR.puts "  + #{cfmts.size} conditional format rule(s) migrated on table \"#{title}\""
+        end
+      end
+    when 'pivot-table'
+      rows = rol.('Rows'); pcols = rol.('Columns'); vals = rol.('Values'); cols = []; rids = []; coids = []; vids = []
+      rows.each  { |d| c, id = dim_col(d, calc, mc_, dmel_, m_); cols << c; rids << id }
+      pcols.each { |d| c, id = dim_col(d, calc, mc_, dmel_, m_); cols << c; coids << id }
+      vals.each  { |mv| c, id = meas_col(mv, calc, mc_, dmel_, m_); cols << c; vids << id }
+      (next if rids.empty? || vids.empty?)
+      el = base.merge('columns' => cols, 'rowsBy' => rids.map { |i| { 'id' => i } }, 'values' => vids)
+      el['columnsBy'] = coids.map { |i| { 'id' => i } } unless coids.empty?
+    when 'region-map', 'point-map'
+      # QuickSight FilledMap/GeospatialMap: Geospatial holds the geo field(s),
+      # Values holds the measure that fills/sizes the map. (Colors is optional and
+      # rendered automatically by Sigma from the measure, so it is not a separate well.)
+      geo  = rol.('Geospatial')
+      vals = rol.('Values')
+      (next if geo.empty?)
+      pair = latlong_pair(geo)
+      cols = []
+      if pair
+        # real lat/long -> point-map
+        latc, latid = meas_col([:meas, pair[0][1], 'AVERAGE'], calc, mc_, dmel_, m_)
+        lonc, lonid = meas_col([:meas, pair[1][1], 'AVERAGE'], calc, mc_, dmel_, m_)
+        # carry lat/long as dimension-style refs (no aggregation) for the point geometry
+        latc = { 'id' => latid, 'formula' => latc['formula'].sub(/^Avg\(/, '').sub(/\)$/, ''), 'name' => latc['name'] }
+        lonc = { 'id' => lonid, 'formula' => lonc['formula'].sub(/^Avg\(/, '').sub(/\)$/, ''), 'name' => lonc['name'] }
+        cols << latc << lonc
+        vals.each { |mv| c, _ = meas_col(mv, calc, mc_, dmel_, m_); cols << c }
+        el = base.merge('kind' => 'point-map', 'columns' => cols,
+                        'latitude' => { 'id' => latid }, 'longitude' => { 'id' => lonid })
+      else
+        # geo NAME (state/city/country/zip) -> region-map
+        dc, did = dim_col(geo[0], calc, mc_, dmel_, m_); cols << dc
+        vals.each { |mv| c, _ = meas_col(mv, calc, mc_, dmel_, m_); cols << c }
+        el = base.merge('kind' => 'region-map', 'columns' => cols,
+                        'region' => { 'id' => did, 'regionType' => region_type_for(geo[0][1]) })
+      end
+    end
+    # carry the visual's QS SortConfiguration (CategorySort/RowSort) when present
+    apply_qs_sorts(el, inner, kind, title, build_warnings) if el
+    # RCA #1 / bead 3goo.1: apply this visual's scoped QS FilterGroups as element filters
+    apply_visual_filters(el, inner['VisualId'], calc, mc_, dmel_, m_) if el
+    elements << el if el
+  end
+  # C-gap: QuickSight sheet-level FilterControls + ParameterControls -> Sigma list
+  # controls. QS selections are GLOBAL on the sheet (and FilterGroups can scope AllSheets),
+  # so a control wired to the master propagates to every chart that sources it.
+  ((sh['FilterControls'] || []) + (sh['ParameterControls'] || [])).each do |wrap|
+    next unless wrap.is_a?(Hash)
+    n_control_signals += 1
+    ctl = build_qs_control(wrap, master_cols, calc, DMEL,
+                           control_scope, control_unbound, control_seen_cols, build_warnings, MASTERS)
+    if ctl
+      elements.unshift(ctl)   # controls render at the top of the page band
+      vis_map[ctl['controlId']] = ctl['id']   # layout step can place it if QS gives coords
+    end
+  end
+  # RCA #18 / bead 3goo.15: QS sheet-level TextBoxes -> Sigma text elements. Skip the one
+  # whose text is just the sheet title (the layout header band already renders it).
+  (sh['TextBoxes'] || []).each do |tb|
+    body = qs_textbox_to_markdown(tb['Content'])
+    next if body.empty?
+    next if body.casecmp?(sh['Name'].to_s)   # title duplicate -> header band already has it
+    tid = nid('txt')
+    elements << { 'id' => tid, 'kind' => 'text', 'name' => 'Text', 'body' => body }
+    vis_map[tb['TextBoxId']] = tid if tb['TextBoxId']
+    n_textboxes += 1
+  end
+  # one Sigma page per QS sheet (skip a sheet that produced zero elements)
+  pid = sheet_idx.zero? ? 'page-dash' : "page-sheet-#{sheet_idx}"
+  sheet_pages << { 'pageId' => pid, 'name' => (sh['Name'] || "Sheet #{sheet_idx + 1}"),
+                   'sheetIndex' => sheet_idx, 'elements' => elements }
+end
+
+# Record a (c)-tail warning for any what-if PARAMETER inlined as a constant (the
+# interactive control itself is a manual Sigma re-author; the default value is what
+# the migrated workbook shows).
+PARAM_DEFAULTS.each do |nm, dv|
+  used = (defn['CalculatedFields'] || []).any? { |c| c['Expression'].to_s.include?("${#{nm}}") }
+  next unless used
+  build_warnings << { 'visual' => '(parameter)', 'type' => 'WhatIfParameter',
+                      'reason' => "QuickSight what-if parameter '#{nm}' inlined as its default (#{dv}); add a Sigma control to make it interactive" }
+end
+
+# strip the private _window marker before emit
+
+master_cols.each_value { |c| c.delete('_window'); c.delete('description') if c['formula'] != 'Null' }
+
+master = { 'id' => 'master', 'name' => M, 'kind' => 'table', 'visibleAsSource' => false,
+           'source' => { 'dataModelId' => dm_id, 'elementId' => dm_el, 'kind' => 'data-model' },
+           'columns' => master_cols.values }
+
+# ---- apply surfaced dataset filter(s) (beads-sigma-23xu FilterOperation) ----
+# convert-model writes the QS predicate(s) to dm-filters.json. We translate a simple
+# {COL}='VALUE' equality predicate into a Sigma element-level list filter on the
+# master, so every downstream aggregate honors it. The filtered column is added to
+# the master if it isn't already projected.
+filters_path = opts[:filters] || File.join(File.dirname(File.expand_path(opts[:an])), 'dm-filters.json')
+applied_filters = []
+if File.exist?(filters_path)
+  fdata = JSON.parse(File.read(filters_path)) rescue {}
+  (fdata['filters'] || []).each do |pred|
+    m = pred.to_s.match(/\{([^}]+)\}\s*=\s*'([^']*)'/) || pred.to_s.match(/\{([^}]+)\}\s*=\s*"([^"]*)"/)
+    next unless m
+    raw_col = m[1].strip; val = m[2]
+    ref = master_ref(raw_col, calc, master_cols, DMEL)
+    # master_cols may have been re-read; ensure the col is on the master
+    unless master.fetch('columns').any? { |c| c['id'] == ref['id'] }
+      master['columns'] << master_cols[raw_col]
+    end
+    applied_filters << { 'id' => "flt-#{SecureRandom.hex(4)}", 'kind' => 'list',
+                         'columnId' => ref['id'], 'values' => [val] }
+  end
+  master['filters'] = applied_filters unless applied_filters.empty?
+end
+# refresh master columns (master_ref may have added the filter column)
+master['columns'] = master_cols.values
+
+# Build one Sigma page per QS sheet. A sheet that produced zero elements is still
+# emitted (named after the sheet) so the page exists — but a single dash page is the
+# common case. The shared Data page (master) is always page 0.
+dash_pages = sheet_pages.map do |sp|
+  { 'id' => sp['pageId'], 'name' => sp['name'], 'elements' => sp['elements'] }
+end
+# defensive: if an analysis somehow had no sheets, keep an empty dash page so the
+# workbook is still valid.
+if dash_pages.empty?
+  dash_pages = [{ 'id' => 'page-dash', 'name' => (an['Name'] || 'Dashboard'), 'elements' => [] }]
+  sheet_pages = [{ 'pageId' => 'page-dash', 'name' => (an['Name'] || 'Dashboard'), 'sheetIndex' => 0, 'elements' => [] }]
+end
+
+# Multi-master (RCA #4): any SECONDARY master that a visual routed to (non-empty cols)
+# becomes its own hidden Data-page table sourcing its DM element. The primary `master`
+# above carries the dm-filters; secondaries are plain passthrough masters.
+secondary_masters = MASTERS.values.reject { |mm| mm[:sid] == 'master' || mm[:cols].empty? }.map do |mm|
+  mm[:cols].each_value { |c| c.delete('_window'); c.delete('description') if c['formula'] != 'Null' }
+  { 'id' => mm[:sid], 'name' => mm[:name], 'kind' => 'table', 'visibleAsSource' => false,
+    'source' => { 'dataModelId' => dm_id, 'elementId' => mm[:dm_el_id], 'kind' => 'data-model' },
+    'columns' => mm[:cols].values }
+end
+STDERR.puts "multi-master: routed visuals across #{1 + secondary_masters.size} master(s) (#{secondary_masters.map { |s| s['name'] }.join(', ')})" unless secondary_masters.empty?
+# Page controls fan out to every master that SHARES the control's column (build_qs_control).
+# A control whose column exists ONLY on the primary still won't constrain a secondary
+# master (that dataset lacks the column) — surface it so the gap is understood, not silent.
+unless secondary_masters.empty?
+  build_warnings << { 'visual' => '(controls)', 'type' => 'MultiMasterControlScope',
+                      'reason' => "page controls fan out to secondary master(s) (#{secondary_masters.map { |s| s['name'] }.join(', ')}) for SHARED columns; a control on a column that exists only on the primary does not constrain a secondary master that lacks it — verify cross-dataset filter coverage in Sigma" }
+end
+
+# Scatter charts emit a hidden GROUPED source table (one row per point dim). Park
+# them on the Data page next to the master (visibleAsSource:false, so they need no
+# layout slot) — they're sourced by the scatter element via {elementId, groupingId}.
+data_elements = [master] + secondary_masters + scatter_sources
+
+spec = { 'name' => (an['Name'] || 'QuickSight Migration') + ' (from QuickSight)',
+         'schemaVersion' => 1,
+         'pages' => [{ 'id' => 'page-data', 'name' => 'Data', 'elements' => data_elements }] + dash_pages }
+spec['folderId'] = opts[:folder] if opts[:folder]
+
+File.write(opts[:out], JSON.pretty_generate(spec))
+map_out = opts[:out].sub(/\.json$/, '') + '.map.json'
+# Map carries: the legacy single dashPageId (= first sheet's page, for back-compat),
+# the per-sheet page list (sheetIndex -> pageId/name) so the layout step lays out EACH
+# page from its OWN sheet's QS layout, and the global visual->element map.
+# controlElementIds: the Sigma element ids of the kind:control elements (per page).
+# QS controls live in SheetControlLayouts, not the visual GridLayout, so the layout step
+# can't place them by QS coords — it LIFTS them into a clean full-width top band instead
+# (Sigma's grid has no z-order; floating a control over a chart renders stacked).
+control_eids_by_page = {}
+dash_pages.each do |pg|
+  ids = (pg['elements'] || []).select { |e| e['kind'] == 'control' }.map { |e| e['id'] }
+  control_eids_by_page[pg['id']] = ids unless ids.empty?
+end
+File.write(map_out, JSON.pretty_generate(
+  'dashPageId' => (sheet_pages.first && sheet_pages.first['pageId']) || 'page-dash',
+  'masterElementId' => 'master',
+  'sheetPages' => sheet_pages.map { |sp| { 'pageId' => sp['pageId'], 'name' => sp['name'], 'sheetIndex' => sp['sheetIndex'] } },
+  'controlElementIds' => control_eids_by_page,
+  'visualToElement' => vis_map))
+
+# Persist a machine-readable per-visual warning manifest for any QuickSight visual
+# Sigma can't recreate (sankey/radar/box-plot/waterfall/word-cloud/histogram/heat-map/
+# layer-map/insight-ML/custom-content/plugin). This is the (c)-tail record — a clear
+# "dropped, here's why" rather than a silent omission.
+warn_out = opts[:out].sub(/\.json$/, '') + '.warnings.json'
+File.write(warn_out, JSON.pretty_generate('warnings' => build_warnings))
+
+# control-scope.json — the intended-scope contract sidecar (schema: the CONTRACT block
+# in scripts/lib/control_lint.rb). QuickSight sheet/AllSheets filters are GLOBAL, so every
+# wired control's mustReach = every queryable element on every CONTENT page (Qlik parity).
+# post-and-readback.rb (--type workbook) and assert-phase6-ran.rb gate 7 pick it up from
+# <workdir>/control-scope.json automatically; we write it next to the spec (= the workdir).
+# sourceFilterSignals > 0 with zero spec controls FAILS gate 7 — the silently-dropped class
+# this change exists to kill.
+CTL_QUERYABLE = %w[table pivot-table bar-chart line-chart pie-chart donut-chart
+                   area-chart scatter-chart combo-chart kpi-chart region-map point-map].to_set
+must_reach = dash_pages.flat_map { |pg| pg['elements'] }
+                       .select { |e| CTL_QUERYABLE.include?(e['kind']) }
+                       .map { |e| e['id'] }
+control_scope.each { |sc| sc['mustReach'] = must_reach if sc['status'] == 'wired' }
+scope_out = File.join(File.dirname(File.expand_path(opts[:out])), 'control-scope.json')
+File.write(scope_out, JSON.pretty_generate(
+  'version' => 1, 'source' => 'quicksight', 'sourceFilterSignals' => n_control_signals,
+  'controls' => control_scope, 'unbound' => control_unbound))
+STDERR.puts "control-scope: #{n_control_signals} QS control signal(s) -> #{control_scope.size} wired Sigma control(s)" \
+            "#{control_unbound.empty? ? '' : ", #{control_unbound.size} unbound/manual/duplicate"} → #{scope_out}"
+
+all_elements = sheet_pages.flat_map { |sp| sp['elements'] }
+STDERR.puts "workbook spec: master sources DM element \"#{DMEL}\" (#{dm_el}); #{sheet_pages.size} page(s)/#{all_elements.size} chart elements, #{master_cols.size} master cols#{applied_filters.empty? ? '' : "; #{applied_filters.size} filter(s) applied"} → #{opts[:out]} (+ #{map_out})"
+sheet_pages.each do |sp|
+  STDERR.puts "  page \"#{sp['name']}\" (#{sp['pageId']}): #{sp['elements'].size} element(s)"
+  sp['elements'].each { |e| STDERR.puts "    - #{e['kind']}: #{e['name']}" }
+end
+unless build_warnings.empty?
+  fb, dropped = build_warnings.partition { |w| QS_FALLBACK.key?(w['type']) }
+  STDERR.puts "#{build_warnings.size} visual(s) with no native Sigma kind → #{warn_out}" \
+              " (#{fb.size} data-migrated as table/bar fallback, #{dropped.size} genuinely dropped)"
+  fb.each      { |w| STDERR.puts "  ~ #{w['type']}: #{w['reason']}" }
+  dropped.each { |w| STDERR.puts "  ! #{w['type']}: #{w['reason']}" }
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/build-workbook-spec.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/build-workbook-spec.rb
@@ -1,0 +1,149 @@
+#!/usr/bin/env ruby
+# Assemble a complete Sigma workbook spec from build-charts-from-signals
+# output + DM IDs + a master-columns config. Replaces the per-conversion
+# hand-written assemble-*.py one-offs that crept in during dashboard-mode
+# conversions.
+#
+# Usage:
+#   ruby scripts/build-workbook-spec.rb \
+#     --chart-specs /tmp/<name>/chart-specs.json    # build-charts-from-signals output
+#     --dm-ids      /tmp/<name>/dm-ids.json         # post-and-readback output for the DM
+#     --master-cols /tmp/<name>/master-columns.yaml # see schema below
+#     --workbook-name "<name>"
+#     --description "<one-liner>"
+#     --folder-id   <uuid>
+#     [--mode dashboard|page-per-worksheet]         # default: page-per-worksheet
+#     [--dm-element-name "Order Fact"]              # which DM element the master sources from (default: first non-Date)
+#     --out /tmp/<name>/wb-spec.json
+#
+# --master-cols schema (YAML):
+#   columns:
+#     - { id: m-order-id,      name: "Order Id",       formula: "[Order Fact/Order Id]" }
+#     - { id: m-order-date,    name: "Order Date",     formula: "[Order Fact/Order Date]" }
+#     - { id: m-gross-revenue, name: "Gross Revenue",  formula: "[Order Fact/Gross Revenue]" }
+#     ...
+#
+# Or omit --master-cols entirely: the script will auto-build a master that
+# passes through every column of the named DM element by name. Suitable for
+# small workbooks; for complex masters with renames or Lookup columns, supply
+# the YAML explicitly.
+
+require 'json'
+require 'yaml'
+require 'optparse'
+require 'net/http'
+require 'uri'
+require 'base64'
+
+opts = { mode: 'page-per-worksheet' }
+OptionParser.new do |p|
+  p.on('--chart-specs PATH')    { |v| opts[:specs] = v }
+  p.on('--dm-ids PATH')         { |v| opts[:dm_ids] = v }
+  p.on('--master-cols PATH')    { |v| opts[:master_cols] = v }
+  p.on('--workbook-name S')     { |v| opts[:name] = v }
+  p.on('--description S')       { |v| opts[:description] = v }
+  p.on('--folder-id S')         { |v| opts[:folder_id] = v }
+  p.on('--mode S')              { |v| opts[:mode] = v }
+  p.on('--dm-element-name S')   { |v| opts[:dm_el_name] = v }
+  p.on('--out PATH')            { |v| opts[:out] = v }
+end.parse!
+%i[specs dm_ids name folder_id out].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+abort("--mode must be dashboard or page-per-worksheet") unless %w[dashboard page-per-worksheet].include?(opts[:mode])
+
+specs   = JSON.parse(File.read(opts[:specs]))
+dm_ids  = JSON.parse(File.read(opts[:dm_ids]))
+
+dm_id = dm_ids['dataModelId'] || abort('dm-ids.json missing dataModelId')
+
+# Find the DM element to source the master from. Default heuristic: pick the
+# first element whose name doesn't start with a dimension-table prefix
+# (Date Dim / Customer Dim / etc.). User can override via --dm-element-name.
+dm_elements = (dm_ids['pages'] || []).flat_map { |p| p['elements'] || [] }
+abort('no elements in dm-ids') if dm_elements.empty?
+target = if opts[:dm_el_name]
+           dm_elements.find { |e| e['name'] == opts[:dm_el_name] } ||
+             abort("no DM element named #{opts[:dm_el_name].inspect}")
+         else
+           # First non-dim-suffixed element, fallback to first
+           dm_elements.find { |e| !(e['name'] || '').end_with?(' Dim') } || dm_elements.first
+         end
+dm_el_id   = target['id']
+dm_el_name = target['name']
+
+# Master columns: either explicit from --master-cols or auto-passthrough from the DM element
+master_columns =
+  if opts[:master_cols]
+    cfg = YAML.safe_load(File.read(opts[:master_cols]))
+    cfg['columns'] || abort('master-cols YAML missing `columns:` key')
+  else
+    # Auto: pull the DM element's column DDL via REST (limited fields — name only)
+    # Sigma.request handles initial token fetch + 401-retry-with-refresh.
+    $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+    require 'sigma_rest'
+    spec = Sigma.request(:get, "/v2/dataModels/#{dm_id}/spec")
+    el = spec['pages'].flat_map { |p| p['elements'] }.find { |e| e['id'] == dm_el_id }
+    abort("DM element #{dm_el_id} not found in spec") unless el
+    (el['columns'] || []).map do |c|
+      nm = c['name'] || (c['formula'].to_s.match(/^\[[^\/]+\/([^\]]+)\]$/) || [nil, c['id']])[1]
+      slug = nm.to_s.downcase.gsub(/\W+/, '-').sub(/-$/, '')
+      { 'id' => "m-#{slug}", 'name' => nm, 'formula' => "[#{dm_el_name}/#{nm}]" }
+    end
+  end
+abort('no master columns to emit') if master_columns.empty?
+
+# Build the data page
+data_page = {
+  'id'   => 'page-data',
+  'name' => 'Data',
+  'elements' => [{
+    'id'   => 'master',
+    'kind' => 'table',
+    'name' => 'Master',
+    'visibleAsSource' => false,
+    'source' => { 'kind' => 'data-model', 'dataModelId' => dm_id, 'elementId' => dm_el_id },
+    'columns' => master_columns,
+    'order'   => master_columns.map { |c| c['id'] }
+  }]
+}
+
+# Build the visible pages from chart-specs.json
+# Two shapes:
+#  - dashboard mode: chart-specs.json is a flat array → one page with all elements
+#  - page-per-worksheet: chart-specs.json is { pages: [{name, elements}, ...] }
+visible_pages = []
+if specs.is_a?(Hash) && specs['pages']
+  specs['pages'].each do |p|
+    slug = p['name'].to_s.downcase
+    %w[ / ( ) %].each { |ch| slug = slug.tr(ch, '-') }
+    slug = slug.tr(' ', '-').gsub(/-+/, '-').sub(/^-/, '').sub(/-$/, '')[0..40]
+    visible_pages << {
+      'id'       => "page-#{slug}",
+      'name'     => p['name'],
+      'elements' => p['elements']
+    }
+  end
+elsif specs.is_a?(Array)
+  # Dashboard mode → single visible page
+  visible_pages << {
+    'id'       => 'page-overview',
+    'name'     => opts[:name] && opts[:mode] == 'dashboard' ? opts[:name].sub(/\(.*\)$/, '').strip : 'Overview',
+    'elements' => specs
+  }
+else
+  abort('chart-specs.json must be either { pages: [...] } or [ ... ]')
+end
+
+wb = {
+  'name'          => opts[:name],
+  'schemaVersion' => 1,
+  'folderId'      => opts[:folder_id],
+  'pages'         => [data_page] + visible_pages
+}
+wb['description'] = opts[:description] if opts[:description]
+
+File.write(opts[:out], JSON.pretty_generate(wb))
+warn "wrote #{opts[:out]}"
+warn "  mode: #{opts[:mode]}"
+warn "  Data page: master sourced from '#{dm_el_name}' (#{dm_el_id})  #{master_columns.size} columns"
+warn "  visible pages: #{visible_pages.size}"
+visible_pages.each { |p| warn "    - #{p['name']}: #{p['elements'].size} elements" }

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/cleanup-orphan-workbooks.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/cleanup-orphan-workbooks.rb
@@ -1,0 +1,142 @@
+#!/usr/bin/env ruby
+# Delete orphan Sigma workbooks left behind by spec-iteration retries during
+# a single conversion. Reads <workdir>/posted-workbooks.jsonl (written by
+# post-and-readback.rb), keeps the most-recent entry as the "live" workbook,
+# and deletes everything older via DELETE /v2/files/{id} (per
+# feedback_sigma_workbook_delete_endpoint memory — NOT /v2/workbooks/{id}).
+#
+# See beads-sigma-38a for the regression motivating this script: a customer
+# migration on 2026-05-28 created three workbooks (one final + two orphans
+# from iterative POSTs) and the agent declared done without cleaning up.
+#
+# Usage:
+#   ruby scripts/cleanup-orphan-workbooks.rb --workdir /tmp/<name>
+#     [--dry-run]               # report what would be deleted; don't call DELETE
+#     [--keep ID]               # explicit workbook ID to keep (default: most recent)
+#     [--allow-empty-log]       # exit 0 when the log doesn't exist (default: exit 0
+#                                 silently anyway; this flag is just for clarity)
+#
+# Writes <workdir>/cleanup-marker.json with the deleted IDs and timestamp so
+# assert-phase6-ran.rb can confirm cleanup ran.
+#
+# Exit codes:
+#   0  cleanup ran (or no cleanup needed — single workbook in log)
+#   1  one or more DELETE calls failed; cleanup-marker.json reflects partial state
+#   2  setup error (missing env, bad args)
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'time'
+require 'optparse'
+
+opts = { dry_run: false }
+OptionParser.new do |p|
+  p.on('--workdir DIR')    { |v| opts[:workdir] = v }
+  p.on('--dry-run')        { opts[:dry_run] = true }
+  p.on('--keep ID')        { |v| opts[:keep] = v }
+  p.on('--allow-empty-log') { opts[:allow_empty] = true }
+end.parse!
+abort('--workdir required') unless opts[:workdir]
+
+log = File.join(opts[:workdir], 'posted-workbooks.jsonl')
+unless File.exist?(log)
+  puts "[OK] no posted-workbooks.jsonl at #{log} — nothing to clean up"
+  exit 0
+end
+
+ids = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+if ids.empty?
+  puts "[OK] posted-workbooks.jsonl is empty — nothing to clean up"
+  exit 0
+end
+
+# Keep target: --keep override, otherwise the most-recent (last appended) entry.
+keep_id = opts[:keep] || ids.last['id']
+to_delete = ids.map { |e| e['id'] }.reject { |id| id == keep_id }.uniq
+
+if to_delete.empty?
+  puts "[OK] only one POSTed workbook (#{keep_id}) — no orphans to clean up"
+  marker = {
+    'ran_at'  => Time.now.utc.iso8601,
+    'kept'    => keep_id,
+    'deleted' => [],
+    'dry_run' => opts[:dry_run]
+  }
+  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
+  exit 0
+end
+
+base = ENV['SIGMA_BASE_URL'] or (warn 'SIGMA_BASE_URL not set'; exit 2)
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+def http_delete(base, tok, path)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{base}#{path}")
+    req = Net::HTTP::Delete.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept']        = 'application/json'
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+puts "Keeping:  #{keep_id}"
+puts "Orphans:  #{to_delete.length}"
+to_delete.each { |id| puts "          - #{id}" }
+puts ''
+
+if opts[:dry_run]
+  puts "[DRY-RUN] would DELETE /v2/files/<id> for each orphan above. No calls made."
+  marker = {
+    'ran_at'  => Time.now.utc.iso8601,
+    'kept'    => keep_id,
+    'deleted' => [],
+    'would_delete' => to_delete,
+    'dry_run' => true
+  }
+  File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
+  exit 0
+end
+
+deleted = []
+failed  = []
+to_delete.each do |id|
+  r = http_delete(base, nil, "/v2/files/#{id}")
+  code = r.code.to_i
+  if code.between?(200, 299) || code == 404
+    # 404 = already gone; treat as success for idempotency
+    puts "  [deleted] #{id} (HTTP #{code})"
+    deleted << { 'id' => id, 'status' => code }
+  else
+    body = r.body.to_s[0..200]
+    puts "  [FAIL]    #{id} (HTTP #{code}) — #{body}"
+    failed << { 'id' => id, 'status' => code, 'body' => body }
+  end
+end
+
+marker = {
+  'ran_at'  => Time.now.utc.iso8601,
+  'kept'    => keep_id,
+  'deleted' => deleted,
+  'failed'  => failed,
+  'dry_run' => false
+}
+File.write(File.join(opts[:workdir], 'cleanup-marker.json'), JSON.pretty_generate(marker))
+
+if failed.any?
+  warn "\n#{failed.length} of #{to_delete.length} delete(s) FAILED — cleanup-marker.json"
+  warn "records the failure. Re-run with the failing IDs (--keep <good-id>) or"
+  warn "delete them manually via the Sigma UI before declaring done."
+  exit 1
+end
+
+puts "\n[OK] cleaned up #{deleted.length} orphan workbook(s); kept #{keep_id}"
+exit 0

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/convert-model.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/convert-model.rb
@@ -1,0 +1,368 @@
+#!/usr/bin/env ruby
+# convert-model.rb — quicksight-to-sigma "convert" phase helper.
+#
+# MODE A (--emit-mcp): print the exact convert_quicksight_to_sigma MCP-tool call the agent
+#                      should run (files = analysis.json + each dataset json from discovery).
+# MODE B (--fixup):    take the merged QuickSight converter's output Sigma DM JSON and
+#                      do ONLY the post-processing the converter itself cannot, plus
+#                      make it POST-ready. The converter (src/quicksight.ts, beads
+#                      vy4k/nc6g/woaa/23xu) is now the single source of truth for
+#                      element/column naming, [Custom SQL/RAW] refs, multi-element +
+#                      relationship joins, window->Null+description, and CastColumnType
+#                      self-ref — those steps were REMOVED here (beads-sigma-dqyv,
+#                      verified no-ops on D1/D5/D6/D10/D12). Remaining fixup steps:
+#                        - synthesize ONE denormalized kind:sql element for any
+#                          JoinInstruction dataset (CustomSql OR RelationalTable),
+#                          collapsing the converter's multi-element+relationship output
+#                          so the workbook master sources every charted column from a
+#                          single element with simple [Custom SQL/RAW] refs (no builder
+#                          cross-element ref logic needed). KEPT because the converter's
+#                          CustomSql-join path emits NO derived view projecting the dim
+#                          columns, so the builder couldn't reach them. (beads-sigma-nc6g)
+#                        - drop the UNAPPLIED FilterOperation boolean calc column the
+#                          converter emits and surface its predicate to dm-filters.json so
+#                          the workbook builder can apply it as a real element-level list
+#                          filter — a true row-filter genuinely cannot live on a
+#                          warehouse-table DM element. (beads-sigma-23xu)
+#                        - name the synthesized join element + its columns, force
+#                          schemaVersion = 1, inject folderId (REQUIRED by the API).
+#
+# Usage:
+#   ruby scripts/convert-model.rb --emit-mcp --discover-dir DIR --connection-id ID [--database DB --schema SCH]
+#   ruby scripts/convert-model.rb --fixup --in converter-out.json --discover-dir DIR --folder-id ID --out dm-spec.json
+require 'json'
+require 'optparse'
+require 'set'
+
+opts = {}
+OptionParser.new do |o|
+  o.on('--emit-mcp') { opts[:emit] = true }
+  o.on('--fixup') { opts[:fixup] = true }
+  o.on('--in F') { |v| opts[:in] = v }
+  o.on('--out F') { |v| opts[:out] = v }
+  o.on('--discover-dir D') { |v| opts[:dir] = File.expand_path(v) }
+  o.on('--connection-id ID') { |v| opts[:conn] = v }
+  o.on('--database DB') { |v| opts[:db] = v }
+  o.on('--schema SCH') { |v| opts[:schema] = v }
+  o.on('--folder-id ID') { |v| opts[:folder] = v }
+end.parse!
+
+def titleize(s)
+  s.to_s.gsub(/[_.]/, ' ').split.map { |w| w[0..0].upcase + w[1..-1].to_s.downcase }.join(' ')
+end
+
+# Strip parentheses (and their contents) and other ref-breaking chars out of an
+# element/column name. The converter sometimes emits cross-relation columns like
+# "Region (CUSTOMER_DIM)" — the parens collide with Sigma's function-call syntax
+# inside [..] refs, so a downstream [El/Region (CUSTOMER_DIM)] ref never resolves.
+# (beads-sigma-nc6g point 3)
+def sanitize_name(s)
+  s.to_s.gsub(/\s*\([^)]*\)/, '').gsub(/[()\[\]]/, '').strip
+end
+
+# Reconstruct a single denormalized SELECT for a QuickSight dataset whose
+# LogicalTableMap contains one or more JoinInstructions, so that a CustomSql
+# multi-table dataset (which the converter splits into N separate kind:sql
+# elements with no join) collapses to ONE kind:sql element that contains every
+# OutputColumn the visuals reference. (beads-sigma-nc6g — CustomSql-join path)
+# Returns the SQL string, or nil if the dataset isn't a join.
+def synth_join_sql(ds)
+  ltm = ds['LogicalTableMap'] || {}
+  ptm = ds['PhysicalTableMap'] || {}
+  return nil unless ltm.values.any? { |v| v.dig('Source', 'JoinInstruction') }
+
+  frag = {}      # logicalId -> "(...)" or "DB.SCH.TBL"
+  colmap = {}    # logicalId -> { logicalColName => physicalColName }
+  ltm.each do |lid, lt|
+    src = lt['Source'] || {}
+    pid = src['PhysicalTableId']
+    next unless pid
+    phys = ptm[pid] || {}
+    cmap = {}
+    if (cs = phys['CustomSql'])
+      frag[lid] = "(#{cs['SqlQuery'].to_s.strip})"
+      (cs['Columns'] || []).each { |c| cmap[c['Name']] = c['Name'] }
+    elsif (rt = phys['RelationalTable'])
+      parts = [rt['Catalog'], rt['Schema'], rt['Name']].compact.reject(&:empty?)
+      frag[lid] = parts.join('.')
+      (rt['InputColumns'] || []).each { |c| cmap[c['Name']] = c['Name'] }
+    end
+    (lt['DataTransforms'] || []).each do |t|
+      if (ro = t['RenameColumnOperation'])
+        old = ro['ColumnName']; nw = ro['NewColumnName']
+        cmap[nw] = cmap.delete(old) || old
+      end
+    end
+    colmap[lid] = cmap
+  end
+
+  # SQL-safe table aliases (logical ids may contain hyphens, e.g. "orders-log")
+  sa = {}
+  ltm.each_key { |lid| sa[lid] = lid.to_s.gsub(/[^A-Za-z0-9_]/, "_") }
+  joins = ltm.select { |_, v| v.dig("Source", "JoinInstruction") }
+  referenced = joins.values.flat_map { |v| ji = v['Source']['JoinInstruction']; [ji['LeftOperand'], ji['RightOperand']] }
+  root_id = joins.keys.find { |jid| !referenced.include?(jid) } || joins.keys.first
+
+  emitted = {}
+  from_sql = +''
+  walk = lambda do |jid|
+    ji = ltm[jid]['Source']['JoinInstruction']
+    jt = (ji['Type'] || 'INNER').upcase
+    left = ji['LeftOperand']; right = ji['RightOperand']
+    if joins.key?(left)
+      walk.call(left)
+    elsif !emitted[left]
+      from_sql << "#{frag[left]} #{sa[left]}"
+      emitted[left] = true
+    end
+    if joins.key?(right)
+      walk.call(right)
+    elsif !emitted[right]
+      on = ji['OnClause'].to_s
+      on_sql = on.gsub(/\{([^}]+)\}/) do
+        col = Regexp.last_match(1).strip
+        owner = ([left, right] + emitted.keys).uniq.find { |lid| (colmap[lid] || {}).key?(col) }
+        phys = owner ? colmap[owner][col] : col
+        owner ? "#{sa[owner]}.#{phys}" : col
+      end
+      from_sql << " #{jt} JOIN #{frag[right]} #{sa[right]} ON #{on_sql}"
+      emitted[right] = true
+    end
+  end
+  walk.call(root_id)
+
+  sels = (ds['OutputColumns'] || []).map do |oc|
+    lid, _ = oc['Id'].to_s.split('.', 2)
+    pcol = (colmap[lid] || {})[oc['Name']] || oc['Name']
+    "#{sa[lid]}.#{pcol} AS #{oc['Name']}"
+  end
+  return nil if sels.empty? || from_sql.empty?
+  "SELECT #{sels.join(', ')} FROM #{from_sql}"
+end
+
+dir = opts[:dir]
+sig_path = dir && File.join(dir, 'signals.json')
+signals = (sig_path && File.exist?(sig_path)) ? JSON.parse(File.read(sig_path)) : nil
+
+if opts[:emit]
+  abort 'need --discover-dir' unless dir
+  files = [File.join(dir, 'analysis.json')] + Dir[File.join(dir, 'datasets', '*.json')].sort
+  puts 'Call the MCP tool `convert_quicksight_to_sigma` with:'
+  puts '  files: [ {name, content} for each ]'
+  files.each { |f| puts "    - #{f}" }
+  puts "  connection_id: #{opts[:conn] || '<SIGMA_CONNECTION_ID>'}"
+  puts "  database: #{opts[:db] || '(override if dataset path is incomplete)'}"
+  puts "  schema:   #{opts[:schema] || '(override if dataset path is incomplete)'}"
+  puts
+  # --folder-id is REQUIRED by --fixup (POST /v2/dataModels/spec rejects specs without
+  # folderId) — print it in the next-step command so the agent doesn't hit the abort.
+  puts "Save the returned model, then: ruby scripts/convert-model.rb --fixup --in <model>.json --discover-dir #{dir} --folder-id #{opts[:folder] || '<SIGMA_FOLDER_ID>'} --out dm-spec.json"
+  exit 0
+end
+
+if opts[:fixup]
+  abort 'need --in' unless opts[:in]
+  model = JSON.parse(File.read(opts[:in]))
+  # The MCP converter wraps its output; unwrap to the bare model. Newer builds
+  # double-wrap as {sigmaDataModel: {name, schemaVersion, pages}}, older ones as
+  # {model: {...}} — handle both (and a sigmaDataModel that itself nests model).
+  model = model['sigmaDataModel'] if model.is_a?(Hash) && model['sigmaDataModel']
+  model = model['model'] if model.is_a?(Hash) && model['model']
+  model['schemaVersion'] = 1
+  ds_names = signals ? signals['datasets'].map { |d| d['name'] }.compact : []
+
+  ds_jsons = []
+  if dir
+    Dir[File.join(dir, 'datasets', '*.json')].sort.each do |f|
+      j = JSON.parse(File.read(f)) rescue nil
+      ds = j && (j['DataSet'] || j)
+      ds_jsons << ds if ds.is_a?(Hash) && ds['LogicalTableMap']
+    end
+  end
+  # Any dataset with a JoinInstruction (CustomSql OR RelationalTable physical
+  # tables). The converter mishandles BOTH shapes: CustomSql joins are split into
+  # N nameless kind:sql elements with no join at all; RelationalTable joins get a
+  # fragile relationship "view" element that under-projects dimension columns and
+  # drops the 2nd join hop on a chained 3-way join. We replace both with a single
+  # denormalized kind:sql element built straight from the QS join tree, so the
+  # workbook master sources every charted column from one element. (beads-sigma-nc6g)
+  join_dataset = ds_jsons.find do |ds|
+    (ds['LogicalTableMap'] || {}).values.any? { |v| v.dig('Source', 'JoinInstruction') }
+  end
+
+  fixed = 0
+  filter_exprs = []
+
+  if join_dataset
+    join_sql = synth_join_sql(join_dataset)
+    if join_sql
+      conn = nil
+      (model['pages'] || []).each do |pg|
+        (pg['elements'] || []).each { |el| conn ||= el.dig('source', 'connectionId') }
+      end
+      out_cols = (join_dataset['OutputColumns'] || []).map do |oc|
+        nm = sanitize_name(titleize(oc['Name']))
+        { 'id' => "Custom SQL/#{oc['Name']}", 'name' => nm, 'formula' => "[Custom SQL/#{oc['Name']}]" }
+      end
+      # physical table names participating in this join (to identify which
+      # warehouse-table elements to remove when collapsing to the SQL element)
+      join_tables = (join_dataset['PhysicalTableMap'] || {}).values.map do |p|
+        (p.dig('RelationalTable', 'Name'))
+      end.compact
+      join_el = {
+        'id' => "join-#{join_dataset['DataSetId'] || 'view'}".gsub(/[^A-Za-z0-9_-]/, ''),
+        'kind' => 'table',
+        'name' => sanitize_name(join_dataset['Name'] || ds_names[0] || 'Join View'),
+        'source' => { 'connectionId' => conn, 'kind' => 'sql', 'statement' => join_sql },
+        'columns' => out_cols,
+        'order' => out_cols.map { |c| c['id'] }
+      }
+      (model['pages'] || []).each do |pg|
+        kept = (pg['elements'] || []).reject do |el|
+          srck = el.dig('source', 'kind')
+          srck == 'sql' || srck == 'table' ||
+            (srck == 'warehouse-table' && join_tables.include?((el.dig('source', 'path') || []).last))
+        end
+        pg['elements'] = kept + [join_el]
+      end
+      STDERR.puts "fixup: synthesized join element \"#{join_el['name']}\" with #{out_cols.size} cols (collapsed #{join_tables.size} joined table(s))"
+      fixed += 1
+    end
+  end
+
+  all_els = (model['pages'] || []).flat_map { |pg| pg['elements'] || [] }
+
+  all_els.each_with_index do |el, i|
+    src = el['source'] || {}
+    if el['name'].nil? || el['name'].to_s.empty?
+      el['name'] =
+        if src['kind'] == 'warehouse-table' && src['path'].is_a?(Array) && !src['path'].empty?
+          titleize(src['path'].last)
+        elsif src['kind'] == 'table'
+          'Join View'
+        elsif ds_names[i]
+          ds_names[i]
+        elsif ds_names.length == 1
+          ds_names[0]
+        else
+          "Query #{i + 1}"
+        end
+      fixed += 1
+    end
+    el['name'] = sanitize_name(el['name'])
+  end
+
+  id_to_name = {}
+  all_els.each { |el| id_to_name[el['id']] = el['name'] }
+
+  all_els.each do |el|
+    next unless el.dig('source', 'kind') == 'table'
+    next unless el['name'] == 'Join View'
+    srcnm = id_to_name[el.dig('source', 'elementId')]
+    el['name'] = sanitize_name("#{srcnm} View") if srcnm
+    id_to_name[el['id']] = el['name']
+  end
+
+  # Valid bracket-ref prefixes: every element's display name, its raw warehouse name
+  # (source.path tail), AND the "Custom SQL" self-reference idiom that kind:sql elements
+  # (incl. the synthesized join element) use for their own output columns — without it the
+  # prune wrongly drops every legit join-element column (regression caught on a live 3-way
+  # join). Passthrough refs use the raw name; cross-element refs the display name.
+  known_refs = all_els.flat_map { |e| [e['name'], (e.dig('source', 'path') || []).last] }
+                      .compact.map { |n| n.downcase }.to_set
+  known_refs << 'custom sql'
+
+  all_els.each do |el|
+    src = el['source'] || {}
+    cols = el['columns'] || []
+
+    cols.each do |c|
+      if c['name'].nil? || c['name'].to_s.empty?
+        alias_raw = c['id'].to_s.split('/').last
+        c['name'] = titleize(alias_raw) unless alias_raw.nil? || alias_raw.empty?
+      end
+      c['name'] = sanitize_name(c['name']) if c['name']
+    end
+
+    # RCA #9 / bead 3goo.9: normalize calc-column bracket refs to the EXACT sibling display
+    # name (case-insensitive resolution). The converter sometimes emits `[Hours to Close]`
+    # while the sibling column is "Hours To Close" — "not a sibling column" at POST. Only
+    # rewrites the column part of an existing [..]/[Elem/..] ref that matches a sibling under
+    # a different case; cross-element refs to non-siblings are left untouched.
+    sib = {}
+    cols.each { |c| (sib[c['name'].to_s.strip.downcase] = c['name']) if c['name'] }
+    cols.each do |c|
+      next unless c['formula'].is_a?(String)
+      c['formula'] = c['formula'].gsub(/\[([^\]\/]*\/)?([^\]\/]+)\]/) do
+        pre = Regexp.last_match(1); nm = Regexp.last_match(2)
+        canon = sib[nm.strip.downcase]
+        canon && canon != nm ? "[#{pre}#{canon}]" : Regexp.last_match(0)
+      end
+    end
+
+    # Drop calc columns whose bracket refs can't resolve — a ref with `/` must name a known
+    # element (prefix before the first `/`), a bare ref must be a sibling. These are
+    # aggregate-of-aggregate / metric-style calc fields the converter emitted but can't be
+    # row-level DM columns (e.g. an "Outreach/Task Rate" dividing two distinct_countIf
+    # metrics); they fail POST regardless. Drop + warn rather than emit an unpostable spec
+    # (RCA #9/#10, bead 3goo.9 — matches the manual Arine fix).
+    dropped = []
+    el['columns'] = cols.reject do |c|
+      next false unless c['formula'].is_a?(String)
+      bad = c['formula'].scan(/\[([^\]]+)\]/).flatten.any? do |ref|
+        if ref.include?('/')
+          !known_refs.include?(ref.split('/', 2).first.strip.downcase)
+        else
+          !sib.key?(ref.strip.downcase)
+        end
+      end
+      dropped << c['name'] if bad
+      bad
+    end
+    unless dropped.empty?
+      el['order'] = (el['order'] || []).reject { |oid| el['columns'].none? { |c| c['id'] == oid } } if el['order']
+      STDERR.puts "fixup: dropped #{dropped.size} calc column(s) with unresolvable refs on \"#{el['name']}\": #{dropped.join(', ')}"
+    end
+
+    # NOTE: window/table-calc neutralization, [Custom SQL/RAW] ref rewriting,
+    # join-"view" ref rewriting and CastColumnType self-ref repair USED to live
+    # here, but the merged QuickSight converter now does all of that at source
+    # (beads-sigma-vy4k/nc6g/woaa/23xu). Verified no-ops on D1/D5/D6/D10/D12, so
+    # they were removed (beads-sigma-dqyv). The fixup now only does post-processing
+    # the converter genuinely cannot: collapse a join dataset to one SQL element
+    # (above), surface an UNAPPLIED FilterOperation to the workbook builder (below),
+    # set folderId/schemaVersion, and name the synthesized join element + its cols.
+
+    before = cols.size
+    keep = cols.reject do |c|
+      m = c['name'].to_s.match(/\AFilter:\s*(.+)\z/)
+      if m
+        filter_exprs << m[1].strip
+        true
+      else
+        false
+      end
+    end
+    if keep.size != before
+      el['columns'] = keep
+      el['order'] = (el['order'] || []).select { |oid| keep.any? { |c| c['id'] == oid } } if el['order']
+    end
+  end
+
+  # POST /v2/dataModels/spec REQUIRES folderId ("Expecting UUID at 0.folderId")
+  # — without it the post fails, so refuse to emit an unpostable spec.
+  abort('--folder-id is required with --fixup: POST /v2/dataModels/spec rejects specs without folderId') unless opts[:folder]
+  model['folderId'] = opts[:folder]
+
+  if dir && !filter_exprs.empty?
+    File.write(File.join(dir, 'dm-filters.json'), JSON.pretty_generate('filters' => filter_exprs.uniq))
+    STDERR.puts "fixup: surfaced #{filter_exprs.uniq.size} dataset filter(s) -> dm-filters.json (#{filter_exprs.uniq.join('; ')})"
+  end
+
+  out = opts[:out] || 'dm-spec.json'
+  File.write(out, JSON.pretty_generate(model))
+  STDERR.puts "fixup: named #{fixed} element(s); schemaVersion=1#{opts[:folder] ? '; folderId set' : ''} -> #{out}"
+  exit 0
+end
+
+abort 'specify --emit-mcp or --fixup'

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/escalate-gap.py
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/escalate-gap.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""escalate-gap — opt-in GitHub-issue filer for gap-scout escalations.
+
+Shared across every migration skill (vendored identically into each plugin's
+scripts/). When the gap scout can't find a working Sigma translation for a
+source feature, the main agent offers the user the *option* to open a tracking
+issue in the appropriate repo. This script is what turns that "yes" into filed
+issues — with dedupe, repo routing, converter-repo mirroring, and a cross-linked
+bead.
+
+DESIGN: opt-in, never automatic.
+  - Default (no --yes): DRY RUN. Prints the drafted issue(s), the target repo(s),
+    and any existing open issues/beads that already cover this gap. Files NOTHING.
+    This is what the agent shows the user.
+  - With --yes: actually files. Skips any repo where dedupe already found a match
+    (unless --force).
+
+ROUTING (category -> repos):
+  converter  -> twells89/sigma-data-model-manager + twells89/sigma-data-model-mcp
+               (a source expression the *converter* failed to translate — the
+                browser tool and the MCP must stay in sync, so mirror to both)
+  builder    -> twells89/sigma-migration-skills   (workbook/DM spec builder gap)
+  skill      -> twells89/sigma-migration-skills   (skill-logic / discovery gap)
+
+Usage (dry-run draft the agent shows the user):
+  python3 scout/escalate-gap.py \
+    --skill tableau-to-sigma --category converter \
+    --feature WINDOW_AVG --description 'moving average over SUM' \
+    --source-pattern 'WINDOW_AVG(SUM([...]))' \
+    --template-attempted 'MovingAvg(Sum([Master/\\1]), -10, 10)' \
+    --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+    --sigma-response '<failing column type / error json>' \
+    --example-from 'Sales.twb line 412' \
+    --escalation-yaml ~/.tableau-to-sigma/escalations/window_avg.yaml
+
+Then, only if the user says yes, the agent re-runs the same command with --yes.
+
+Requires `gh` on PATH and authed for the target repos. `bd` (beads) optional.
+Exit codes: 0 = ok (drafted or filed), 3 = nothing fileable / gh missing on --yes.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+ROUTES = {
+    "converter": ["twells89/sigma-data-model-manager", "twells89/sigma-data-model-mcp"],
+    "builder":   ["twells89/sigma-migration-skills"],
+    "skill":     ["twells89/sigma-migration-skills"],
+}
+BEADS_DIR = os.path.expanduser("~/.beads-sigma")
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def run(args, **kw):
+    """Run a command, return (ok, stdout, stderr)."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, **kw)
+        return p.returncode == 0, p.stdout.strip(), p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return False, "", str(e)
+
+
+def build_issue(a):
+    title = f"{a.skill} gap: {a.feature}" + (f" ({a.description})" if a.description else "")
+    body = []
+    body.append(f"**Skill:** `{a.skill}`")
+    body.append(f"**Gap category:** `{a.category}`")
+    body.append(f"**Feature:** `{a.feature}`")
+    if a.description:
+        body.append(f"**Description:** {a.description}")
+    if a.source_pattern:
+        body.append(f"**Source pattern:** `{a.source_pattern}`")
+    if a.template_attempted:
+        body.append(f"**Sigma template attempted:** `{a.template_attempted}`")
+    if a.test_formula:
+        body.append(f"**Test formula POSTed:** `{a.test_formula}`")
+    if a.sigma_response:
+        body.append(f"**Sigma response:**\n```\n{a.sigma_response}\n```")
+    body.append(f"**Example source:** {a.example_from or '(not provided)'}")
+    if a.escalation_yaml:
+        body.append(f"**Local escalation record:** `{a.escalation_yaml}`")
+    body.append("\n_Filed via the gap-scout opt-in escalation flow (`escalate-gap.py`)._")
+    return title, "\n\n".join(body)
+
+
+def labels_for(a):
+    return ["gap-scout-escalation", a.skill, f"category:{a.category}"]
+
+
+def ensure_labels(repo, labels):
+    """Best-effort: create labels so `gh issue create --label` won't fail."""
+    for lab in labels:
+        run(["gh", "label", "create", lab, "--repo", repo, "--force"])
+
+
+def find_dupes(repo, feature, skill):
+    """Return list of {number,title,url} open issues that look like this gap."""
+    ok, out, _ = run([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--label", "gap-scout-escalation", "--search", feature,
+        "--json", "number,title,url",
+    ])
+    if not ok or not out:
+        return []
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return []
+    feat = feature.lower()
+    return [i for i in items if feat in (i.get("title", "").lower())]
+
+
+def find_bead_dupe(feature):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    ok, out, _ = run(["bd", "list", "--json"], cwd=BEADS_DIR)
+    if not ok or not out:
+        return None
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return None
+    rows = items if isinstance(items, list) else items.get("issues", items.get("beads", []))
+    feat = feature.lower()
+    for b in rows or []:
+        if feat in (str(b.get("title", "")) + str(b.get("summary", ""))).lower():
+            return b.get("id") or b.get("bead_id")
+    return None
+
+
+def create_bead(title, body, skill, category):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    labels = f"sigma-converter,{skill},gap-scout-escalation,category:{category}"
+    ok, out, _ = run([
+        "bd", "create", title, "--priority", "2", "--labels", labels,
+        "--description", body, "--silent",
+    ], cwd=BEADS_DIR)
+    return out.strip() if ok else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--feature", required=True)
+    ap.add_argument("--category", default="converter", choices=list(ROUTES))
+    ap.add_argument("--description", default="")
+    ap.add_argument("--source-pattern", default="")
+    ap.add_argument("--template-attempted", default="")
+    ap.add_argument("--test-formula", default="")
+    ap.add_argument("--sigma-response", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--escalation-yaml", default="")
+    ap.add_argument("--extra-repo", action="append", default=[],
+                    help="additional target repo(s), repeatable")
+    ap.add_argument("--yes", action="store_true",
+                    help="actually file. Without it: dry-run, prints the draft only.")
+    ap.add_argument("--force", action="store_true",
+                    help="file even if a matching open issue already exists")
+    ap.add_argument("--no-beads", action="store_true")
+    a = ap.parse_args()
+
+    repos = list(dict.fromkeys(ROUTES[a.category] + a.extra_repo))
+    title, body = build_issue(a)
+    labels = labels_for(a)
+
+    # Dedupe scan (read-only) up front so the agent can show it to the user.
+    gh_ok = have("gh")
+    dupes = {r: (find_dupes(r, a.feature, a.skill) if gh_ok else []) for r in repos}
+    bead_dupe = None if a.no_beads else find_bead_dupe(a.feature)
+
+    if not a.yes:
+        # DRY RUN — this is what the agent presents to the user.
+        out = {
+            "mode": "draft",
+            "would_file_in": repos,
+            "labels": labels,
+            "title": title,
+            "body": body,
+            "existing_issues": {r: d for r, d in dupes.items() if d},
+            "existing_bead": bead_dupe,
+            "gh_available": gh_ok,
+            "next_step": "re-run with --yes to file (skips repos already covered)",
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    # --yes: actually file.
+    if not gh_ok:
+        print(json.dumps({"status": "error", "error": "gh not on PATH; cannot file"}))
+        return 3
+
+    # Bead first (authoritative tracker), so its id can be embedded in issues.
+    bead_id = bead_dupe
+    if bead_id is None and not a.no_beads:
+        bead_id = create_bead(title, body, a.skill, a.category)
+    issue_body = body + (f"\n\n**Bead:** `{bead_id}`" if bead_id else "")
+
+    filed, skipped = [], []
+    for repo in repos:
+        if dupes.get(repo) and not a.force:
+            skipped.append({"repo": repo, "existing": dupes[repo]})
+            continue
+        ensure_labels(repo, labels)
+        ok, out, err = run([
+            "gh", "issue", "create", "--repo", repo,
+            "--title", title, "--body", issue_body,
+            "--label", ",".join(labels),
+        ])
+        if ok:
+            filed.append({"repo": repo, "url": out.strip()})
+        else:
+            # retry once without labels (in case label creation was denied)
+            ok2, out2, err2 = run([
+                "gh", "issue", "create", "--repo", repo,
+                "--title", title, "--body", issue_body,
+            ])
+            if ok2:
+                filed.append({"repo": repo, "url": out2.strip(), "note": "filed without labels"})
+            else:
+                filed.append({"repo": repo, "error": err or err2})
+
+    # Cross-link mirrored issues to each other.
+    urls = [f["url"] for f in filed if f.get("url")]
+    if len(urls) > 1:
+        for f in filed:
+            if not f.get("url"):
+                continue
+            others = [u for u in urls if u != f["url"]]
+            num = f["url"].rstrip("/").split("/")[-1]
+            link_body = issue_body + "\n\n**Mirrored to:** " + ", ".join(others)
+            run(["gh", "issue", "edit", num, "--repo", f["repo"], "--body", link_body])
+
+    # Cross-link the bead back to the filed issue urls.
+    if bead_id and urls and have("bd"):
+        run(["bd", "update", bead_id, "--description",
+             issue_body + "\n\nFiled issues: " + ", ".join(urls)], cwd=BEADS_DIR)
+
+    print(json.dumps({
+        "status": "filed",
+        "filed": filed,
+        "skipped_existing": skipped,
+        "bead_id": bead_id,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/find-or-pick-dm.rb
@@ -1,0 +1,372 @@
+#!/usr/bin/env ruby
+# Phase 1.5 — Reuse existing Sigma data models when one already covers the
+# Tableau workbook's needs. Goals:
+#   1. Avoid DM sprawl: don't add a 4th "Orders" DM when the customer already
+#      has three that all point at the same warehouse table.
+#   2. Performance: skip Phase 2 (warehouse column discovery) and Phase 3
+#      (DM build + POST + validate) when reusing — often 2-3 min savings.
+#
+# This script DOES NOT mutate any DM. It only scores existing DMs against the
+# Tableau workbook signature and recommends a candidate (with a warning about
+# inherited columns / RLS / metrics). The downstream phase decides whether to
+# reuse or create new.
+#
+# Usage:
+#   ruby scripts/find-or-pick-dm.rb \
+#     --workbook-signature /tmp/<name>/workbook-signature.json \
+#     --out /tmp/<name>/dm-match.json \
+#     [--limit 200]                    # max DMs to scan
+#     [--min-score 0.6]                # below: no recommendation, build new
+#     [--force-new]                    # always recommend new (skip scan)
+#
+# Input signature shape (produced by Phase 1 + 2.5 — adjust paths as needed):
+#   {
+#     "tableau_workbook":   "Monthly Revenue",
+#     "warehouse_tables":   ["CSA.ORDER_FACT"],          # FQN list
+#     "referenced_columns": ["ORDER_DATE","GROSS_REVENUE","REGION","STATE"],
+#     "measures":           [{"col":"GROSS_REVENUE","derivation":"Sum"}, ...]
+#   }
+#
+# Output: dm-match.json with shape documented in SKILL.md Phase 1.5.
+# Exit: 0 if any candidate ≥ --min-score, 1 if none (caller can choose to
+# build new). Never aborts on missing inputs — always emits a result file so
+# the agent can decide.
+
+require 'json'
+require 'yaml'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
+# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
+# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
+# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
+# picker run with no score regression. beads-sigma-3kw.
+opts = { limit: 25, min_score: 0.6 }
+OptionParser.new do |p|
+  p.on('--workbook-signature P') { |v| opts[:sig]      = v }
+  p.on('--out P')                { |v| opts[:out]      = v }
+  p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
+  p.on('--force-new')            { |_| opts[:force_new]= true }
+  p.on('--auto-pick',
+       'Auto-recommend without UX prompt when top score >= --auto-pick-threshold AND no other candidate within --auto-pick-tie-window of it. Sets `auto_picked: true` on the result so the caller can WARN about inherited columns.') { |_| opts[:auto_pick] = true }
+  p.on('--auto-pick-threshold F', Float, 'Min score for auto-pick (default 0.55).')                  { |v| opts[:auto_pick_threshold] = v }
+  p.on('--auto-pick-tie-window F', Float, 'Gap from top score within which other candidates count as a tie that disables auto-pick (default 0.05).') { |v| opts[:auto_pick_tie_window] = v }
+end.parse!
+%i[sig out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# DM-shortlisting scans many candidates and is called per-follower in cluster
+# orchestration — auto-refresh on 401 to survive long batch runs.
+def http_get(path)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{BASE}#{path}")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept'] = 'application/json'
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+sig = JSON.parse(File.read(opts[:sig]))
+warn "workbook: #{sig['tableau_workbook'] || '(unnamed)'}"
+warn "  warehouse_tables:   #{sig['warehouse_tables']&.size || 0}"
+warn "  referenced_columns: #{sig['referenced_columns']&.size || 0}"
+
+# Force-new short-circuit: emit a no-match result and exit 1.
+if opts[:force_new]
+  File.write(opts[:out], JSON.pretty_generate({
+    'recommended_dm_id' => nil,
+    'score' => 0.0,
+    'rationale' => '--force-new: bypassed DM-reuse scan',
+    'candidates' => []
+  }))
+  warn "force-new mode — wrote empty match"
+  exit 1
+end
+
+# 1. List ALL data models, then sort deterministically before applying --limit.
+# Sigma's /v2/dataModels list endpoint returns server page-order, not
+# relevance order. Without a stable client-side sort, the same workbook
+# picks different candidates on different runs (observed: 3 conversions of
+# the same Tableau workbook reached 3 different recommendations). Fix:
+# fetch all DMs (cheap — one list call per 100), sort by updatedAt desc
+# (recent DMs are usually more relevant), then take the first --limit for
+# parallel spec-fetch + scoring. Stable tiebreaker by name. beads-sigma-3kw.
+all_dms = []
+page = nil
+hard_cap = 500
+loop do
+  qs = "limit=100"
+  qs += "&page=#{page}" if page
+  r = http_get("/v2/dataModels?#{qs}")
+  break unless r.code.to_i == 200
+  data = JSON.parse(r.body)
+  rows = data['entries'] || data['dataModels'] || []
+  break if rows.empty?
+  all_dms.concat(rows)
+  break if all_dms.size >= hard_cap
+  page = data['nextPage']
+  break if page.nil? || page.empty?
+end
+
+# Deterministic ranking: updatedAt desc, then name asc.
+# NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
+# every timestamp rescues to 0, and the sort silently degrades to name-ascending
+# (recently-updated DMs past the --limit window are never scanned).
+require 'time'
+all_dms = all_dms.sort_by do |dm|
+  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+end
+
+warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+
+# 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
+def normalize_fqn(s)
+  return nil if s.nil? || s.empty?
+  parts = s.to_s.split('.').reject(&:empty?).map(&:upcase)
+  parts.join('.')
+end
+
+def normalize_col(s)
+  s.to_s.upcase.gsub(/[^A-Z0-9]/, '')
+end
+
+# Fetch all DM specs in parallel (10 threads). Some DMs return non-200
+# (archived, permission-restricted, broken refs) — log and continue. Single
+# transient 5xx errors are retried once.
+dm_specs = {}
+dm_failures = []
+require 'thread'
+mu = Mutex.new
+queue = Queue.new
+all_dms.take(opts[:limit]).each { |dm| queue << dm }
+threads = 5.times.map do
+  Thread.new do
+    until queue.empty?
+      dm = queue.pop(true) rescue nil
+      break unless dm
+      dm_id = dm['dataModelId'] || dm['id']
+      next unless dm_id
+      r = nil
+      # Retry on 429 (Cloudflare burst limit) with exponential backoff. The
+      # /v2/dataModels endpoint commonly 429s at >5 concurrent across
+      # tj-wells-1989 — see beads-sigma-cn5.
+      4.times do |attempt|
+        r = http_get("/v2/dataModels/#{dm_id}/spec")
+        code = r.code.to_i
+        break if code == 200 || (code != 429 && code < 500)
+        sleep (0.5 * (2 ** attempt))  # 0.5s, 1s, 2s, 4s
+      end
+      if r.code.to_i != 200
+        mu.synchronize { dm_failures << { name: dm['name'], id: dm_id, code: r.code, body_head: r.body[0..80] } }
+        next
+      end
+      spec = begin
+        JSON.parse(r.body)
+      rescue JSON::ParserError
+        YAML.safe_load(r.body, permitted_classes: [Date, Time])
+      end
+      mu.synchronize { dm_specs[dm_id] = spec }
+    end
+  end
+end
+threads.each(&:join)
+warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
+dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
+
+dm_signatures = []
+all_dms.take(opts[:limit]).each do |dm|
+  dm_id = dm['dataModelId'] || dm['id']
+  spec = dm_specs[dm_id]
+  next unless spec
+
+  tables = []
+  columns = []
+  metrics = []
+  column_captions = {}  # normalized → original, so output can be human-readable
+
+  # Walk every element. Sigma DM specs nest elements under pages[*].elements
+  # (NOT top-level `elements` — that's a workbook-only convention). Fall back
+  # to top-level for robustness in case schema changes.
+  all_elements = spec['elements'] || (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  all_elements.each do |el|
+    src = el['source'] || {}
+    case src['kind']
+    when 'warehouse-table', 'table'
+      # source like { kind: warehouse-table, connectionId, path: "DB.SCHEMA.TABLE" }.
+      # Live API specs return path as an ARRAY (["DB","SCHEMA","TABLE"]) — join it,
+      # else normalize_fqn sees the array's to_s and table-match never fires.
+      raw = src['path']
+      fqn = raw.is_a?(Array) ? raw.join('.') : (raw || [src['database'], src['schema'], src['name']].compact.join('.'))
+      tables << normalize_fqn(fqn) if fqn && !fqn.empty?
+    when 'sql'
+      # Custom SQL — surface a sentinel so the agent knows; not directly comparable
+      tables << 'CUSTOM_SQL'
+    end
+    (el['columns'] || []).each do |c|
+      colname = c['name'] || (c['formula'].to_s.match(/\[.*?([^\/\]]+)\]/) || [])[1]
+      if colname && !colname.empty?
+        norm = normalize_col(colname)
+        columns << norm
+        column_captions[norm] ||= colname
+      end
+    end
+    (el['metrics'] || []).each do |m|
+      metrics << "#{m['name']}/#{m['aggregation'] || m['derivation']}"
+    end
+  end
+
+  dm_signatures << {
+    dm_id: dm_id,
+    dm_name: dm['name'],
+    tables: tables.uniq.compact,
+    columns: columns.uniq.compact,
+    column_captions: column_captions,
+    metrics: metrics.uniq.compact,
+    raw_element_count: all_elements.size
+  }
+end
+
+# 3. Score each DM.
+tableau_tables  = (sig['warehouse_tables']   || []).map { |t| normalize_fqn(t) }.compact
+# Keep both forms: normalized for matching, original for human-readable output.
+tableau_columns_orig = (sig['referenced_columns'] || [])
+tableau_columns      = tableau_columns_orig.map { |c| normalize_col(c) }
+tableau_col_caption  = tableau_columns.zip(tableau_columns_orig).to_h
+tableau_measure_keys = (sig['measures'] || []).map { |m| "#{normalize_col(m['col'])}/#{m['derivation']}" }
+
+candidates = dm_signatures.map do |dm|
+  # Table match: 1.0 if Tableau tables ⊆ DM tables. 0.5 if partial. 0 if disjoint.
+  shared_tables = (tableau_tables & dm[:tables])
+  table_match =
+    if tableau_tables.empty?
+      0.0
+    elsif shared_tables.size == tableau_tables.size
+      1.0
+    elsif shared_tables.any?
+      0.5 + 0.5 * (shared_tables.size.to_f / tableau_tables.size)
+    else
+      0.0
+    end
+
+  # Column match: % of Tableau-referenced columns present in DM.
+  shared_cols = (tableau_columns & dm[:columns])
+  col_match =
+    tableau_columns.empty? ? 0.0 : shared_cols.size.to_f / tableau_columns.size
+
+  # Metric overlap (small weight).
+  shared_metrics = (tableau_measure_keys & dm[:metrics])
+  metric_match =
+    tableau_measure_keys.empty? ? 0.0 : shared_metrics.size.to_f / tableau_measure_keys.size
+
+  # Weighting rationale: column overlap is the most reliable signal —
+  # a DM's source table FQN can vary (raw warehouse table vs view vs joined
+  # element) but the column set must be a superset of what the workbook
+  # references for reuse to be safe. Table-match is a soft tiebreaker.
+  score = 0.2 * table_match + 0.7 * col_match + 0.1 * metric_match
+
+  # Extras the workbook would inherit. Surface original captions (not the
+  # normalized form) so the user-facing report is readable.
+  extra_cols_norm = dm[:columns] - tableau_columns
+  caption_of = ->(norm) { dm[:column_captions][norm] || norm }
+  {
+    'dm_id'             => dm[:dm_id],
+    'dm_name'           => dm[:dm_name],
+    'score'             => score.round(3),
+    'table_match'       => table_match.round(2),
+    'column_match'      => col_match.round(2),
+    'metric_match'      => metric_match.round(2),
+    'shared_tables'     => shared_tables,
+    'missing_tables'    => tableau_tables - dm[:tables],
+    'shared_columns'    => shared_cols.map(&caption_of),
+    'missing_columns'   => (tableau_columns - dm[:columns]).map { |c| tableau_col_caption[c] || c },
+    'extra_columns'     => extra_cols_norm.size,
+    'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
+    'raw_element_count' => dm[:raw_element_count]
+  }
+end
+
+# Tie-break: identical scores are common (duplicate / derived DMs sourcing the
+# same tables and column set). Prefer a DM whose name matches the source
+# workbook, then the one with the fewest extra columns — otherwise ordering is
+# arbitrary and the recommendation can land on a sprawling lookalike instead
+# of the purpose-built twin.
+sig_name_norm = normalize_col(sig['tableau_workbook'] || sig['workbook'] || '')
+candidates = candidates.sort_by do |c|
+  name_mismatch = (!sig_name_norm.empty? && normalize_col(c['dm_name']) == sig_name_norm) ? 0 : 1
+  [-c['score'], name_mismatch, c['extra_columns'] || 0]
+end
+
+best = candidates.first
+second = candidates[1]
+
+# Auto-pick gate (reuse-first). Fires when --auto-pick is set and the top
+# candidate (a) clears the auto-pick threshold AND (b) COVERS ALL of the
+# workbook's source tables (table_match 1.0). Table coverage is the safety
+# invariant: a DM that sources every table the workbook needs can satisfy every
+# column ref through its element set, so reusing it is safe; a DM missing a table
+# is never auto-picked (its denorm view can't resolve the missing columns).
+#
+# We deliberately DO NOT block on a score tie here. A tie among table-covering
+# candidates is duplicate-DM SPRAWL (the same star modeled two or three times) —
+# exactly what reuse-first exists to collapse — so we take the top (the
+# deterministic tie-break already prefers a name match, then the fewest extra
+# columns, over the most-recently-updated set). A column-SUPERSET (every
+# referenced column present, column_match 1.0) is the safest case and always
+# qualifies. Callers should reuse `recommended_dm_id` only when `auto_picked`.
+auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
+auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
+tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
+best_name_matches    = best && !sig_name_norm.empty? && normalize_col(best['dm_name']) == sig_name_norm
+best_covers_tables   = best && best['table_match'].to_f >= 1.0
+best_is_superset     = best_covers_tables && best['column_match'].to_f >= 1.0
+auto_picked          = !!(opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && best_covers_tables)
+
+# Standard recommend path keeps the old semantics (printed for human opt-in).
+recommended_via_std  = best && best['score'] >= opts[:min_score]
+recommended_dm_id    = (auto_picked || recommended_via_std) ? best['dm_id'] : nil
+
+rationale =
+  if best.nil?
+    'no DMs in org'
+  elsif auto_picked
+    kind = best_is_superset ? 'column-superset' : 'covers all source tables'
+    tie  = tie_with_second ? " (collapsing a #{best['score']}-score tie — duplicate-DM sprawl)" : ''
+    "AUTO-PICKED at score #{best['score']} — #{kind}#{tie}. #{best['shared_columns'].size}/#{tableau_columns.size} cols, #{best['shared_tables'].size}/#{tableau_tables.size} tables matched. Caller must WARN about #{best['extra_columns']} inherited columns."
+  elsif opts[:auto_pick] && best['score'] >= auto_pick_threshold && !best_covers_tables
+    "score #{best['score']} clears the bar but the candidate is MISSING source table(s) #{best['missing_tables'].join(', ')} — not a safe reuse — build a new DM"
+  elsif best['score'] >= opts[:min_score]
+    'ambiguous match — ASK USER before reusing'
+  else
+    'no candidate above min-score; build a new DM'
+  end
+
+result = {
+  'workbook_signature_path' => opts[:sig],
+  'scanned_dm_count'        => candidates.size,
+  'recommended_dm_id'       => recommended_dm_id,
+  'auto_picked'             => auto_picked,
+  'score'                   => best ? best['score'] : 0.0,
+  'rationale'               => rationale,
+  'warning'                 => (best && best['extra_columns'] > 0) ? "Reusing inherits #{best['extra_columns']} extra columns (sample: #{best['extra_columns_sample'].join(', ')})" : nil,
+  'candidates'              => candidates.first(5)
+}.compact
+
+File.write(opts[:out], JSON.pretty_generate(result))
+warn ""
+warn "wrote #{opts[:out]}"
+warn "best score: #{result['score']}  →  #{result['rationale']}"
+exit result['recommended_dm_id'].nil? ? 1 : 0

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/gap-scout.md
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/gap-scout.md
@@ -1,0 +1,127 @@
+# gap-scout subagent — guide for the main agent
+
+When the converter can't translate a QuickSight calculated-field expression (or
+a high-volume analysis function) into a Sigma formula, spawn a separate subagent
+— the "gap scout" — to find a Sigma translation that validates against the
+customer's actual Sigma site.
+
+The scout writes successful translations to
+`~/.quicksight-to-sigma/learned-rules.yaml` (the customer's home dir, NOT the
+skill repo, so `git pull` of the skill never clobbers them). The build script
+(`build-charts-from-signals.rb`) loads these via `LearnedRules.load` and applies
+them *before* the built-in translators, so a customer's discovered rule wins.
+
+## When to spawn
+
+After conversion flags an untranslated QuickSight expression. Spawn ONE scout
+per distinct feature; run them in parallel where possible — they're independent.
+
+## How to spawn (from the main agent)
+
+Use the Agent tool with `subagent_type: 'general-purpose'`. Self-contained
+prompt:
+
+```
+You are a translation scout. Your job: propose a Sigma formula that replaces a
+QuickSight calculated-field expression, validate it against Sigma's API, and
+persist the rule if it works.
+
+INPUTS
+- QuickSight feature: <function name, e.g. "runningSum">
+- Sample expressions: <3-5 examples from the analysis definition>
+- Sigma data-model id: <dm-id>
+- Sigma denormalized element id: <element-id>
+- Sigma folder id: <folder-id>
+
+PROCEDURE
+1. Read the relevant skill docs:
+   - refs/ (translation notes for QuickSight functions)
+   - scripts/lib/sigma_functions.rb (the whitelist — anything outside ALL_SET
+     silently errors)
+2. Propose ONE candidate Sigma formula. Prefer functions in the whitelist.
+   For window/running/percentOfTotal functions, remember they silently error in
+   workbook-master grouping-table calc cols AND in DM-element calc cols — route
+   to a non-grouping context or a Custom SQL DM element with explicit OVER(...).
+3. Run:
+   ruby scripts/scout-validate-and-persist.rb \
+     --feature '<feature>' \
+     --pattern '<QuickSight regex, capture groups for column refs>' \
+     --template '<Sigma template using \1, \2 for captures>' \
+     --test-formula '<the candidate with REAL column names from this DM>' \
+     --data-model-id <dm-id> \
+     --master-element-id <element-id> \
+     --folder-id <folder-id> \
+     --description '<one-line>' \
+     --hint '<post-publish caveat, e.g., "non-grouping context only">' \
+     --example-from '<which analysis/field>' \
+     --gap-id '<the EXACT --gap-id printed by the GAP-SCOUT REQUIRED gate>' \
+     --workdir '<the conversion working dir printed by the gate>'
+   ⚠ `--gap-id` + `--workdir` are REQUIRED for the run-each-time gate (bead
+   5l5e): they record this scout to `<workdir>/scout-ledger.jsonl` so
+   migrate-quicksight can confirm EVERY degraded calc was scouted before it
+   proceeds. Copy the `--gap-id` value verbatim from the gate output; omitting
+   them means the gate will still see the calc as unscouted and stop again.
+4. Parse the JSON result.
+   - status=validated → success; rule is now in the customer's local YAML
+   - status=escalated → propose a different candidate (up to 3 attempts). After
+                        the last attempt the result carries an
+                        `escalation.dry_run_cmd` / `escalation.file_cmd`. Do NOT
+                        file anything yourself — see "Opt-in issue filing" below.
+
+OUTPUT
+Return a one-paragraph summary: feature, candidate, status (validated /
+escalated / abandoned-after-N-attempts), the workbook_id of the test spec for
+cleanup later, and — if escalated — the `escalation.dry_run_cmd` so the main
+agent can offer the user a tracking issue.
+```
+
+## Opt-in issue filing (escalations)
+
+Filing a GitHub issue is **opt-in and confirm-before-file** — never automatic.
+When `scout-validate-and-persist.rb` returns `status=escalated`, the main agent:
+
+1. Runs the returned `escalation.dry_run_cmd` (the shared `escalate-gap.py` filer
+   in dry-run mode). This files NOTHING — it prints the drafted issue, the
+   **target repo(s)**, and any **existing open issues / beads** that already
+   cover the gap (dedupe).
+2. Shows the user that draft and asks whether to open the issue.
+3. Only if the user says yes, re-runs with `--yes` (the `escalation.file_cmd`).
+
+QuickSight calc-field gaps are **converter** gaps, so they mirror to both
+converter repos (`sigma-data-model-manager` + `sigma-data-model-mcp`) with a
+cross-link; a bead is created/linked as the authoritative tracker. Builder/spec
+gaps would route to `sigma-migration-skills` instead (`--category builder`).
+See `scripts/escalate-gap.py`.
+
+## What the scout depends on
+
+- `scripts/validate-sigma-formula.rb` — primitive that POSTs a minimal test
+  workbook + runs the column-type guard. Returns JSON. Tool-agnostic.
+- `scripts/scout-validate-and-persist.rb` — wraps validate-sigma-formula; on
+  success appends to `~/.quicksight-to-sigma/learned-rules.yaml`; on failure
+  writes a structured escalation to `~/.quicksight-to-sigma/escalations/` and
+  returns the opt-in `escalate-gap.py` commands.
+- `scripts/escalate-gap.py` — shared opt-in issue filer: category→repo routing,
+  dedupe (open issues + beads), converter-repo mirroring, bead cross-link.
+  Dry-run by default; files only with `--yes`. Identical copy across all
+  migration skills.
+- `scripts/learned-rules.rb` — the loader the build script uses. The customer
+  never edits this; the scout writes it.
+
+## File locations (CRITICAL)
+
+| File | Path | Why |
+|---|---|---|
+| Learned rules | `~/.quicksight-to-sigma/learned-rules.yaml` | Customer home. `git pull` cannot clobber. |
+| Escalations | `~/.quicksight-to-sigma/escalations/*.yaml` | Same — customer-local. |
+| Override for testing | `$QUICKSIGHT_TO_SIGMA_HOME` env var | Points at a sandbox path for CI. |
+
+## Why a separate subagent
+
+- **Context isolation**: each Sigma POST response is verbose. Keeping the
+  reasoning + validation loops out of the main conversion's context matters for
+  large multi-dashboard migrations.
+- **Bounded budget**: capped at N attempts per gap. Failure doesn't block the
+  main conversion — failed gaps remain WARN lines for manual post-publish.
+- **Compounds across customers**: every customer who runs the scout contributes
+  to their local rules library; strong rules can be promoted into the converter.

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/get-token.sh
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/get-token.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SIGMA_API_TOKEN=${TOKEN}"

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/learned-rules.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/learned-rules.rb
@@ -1,0 +1,134 @@
+#!/usr/bin/env ruby
+# Load + apply customer-accumulated translation rules. The rules live in the
+# customer's HOME directory (~/.quicksight-to-sigma/learned-rules.yaml), NOT in
+# the skill repo — that means `git pull` of the skill never clobbers what a
+# customer has discovered locally, and one customer's wins persist across
+# every workbook they migrate.
+#
+# File location is canonical: ~/.quicksight-to-sigma/learned-rules.yaml
+# Override for testing via QUICKSIGHT_TO_SIGMA_HOME env var.
+#
+# Schema (YAML):
+#   rules:
+#     - feature: "WINDOW_AVG"
+#       description: "Tableau WINDOW_AVG(SUM(x)) → Sigma MovingAvg"
+#       tableau_pattern: '\bWINDOW_AVG\s*\(\s*SUM\s*\(\[([^\]]+)\]\)\s*\)'
+#       sigma_template: 'MovingAvg(Sum([Master/\1]), -10, 10)'
+#       hint: "Sigma window functions silently error in grouping-table charts"
+#       validated_at: "2026-05-19T16:42:00Z"
+#       validated_workbook: "wb-id-here"
+#       example_from: "workbook.twb line 1234"
+#       confidence: "validated" | "proposed" | "experimental"
+#
+# Usage from the build script:
+#   require_relative 'learned-rules'
+#   rules = LearnedRules.load
+#   translated, hint = LearnedRules.apply(rules, formula)
+
+require 'yaml'
+require 'date'
+require 'time'
+
+module LearnedRules
+  HOME_OVERRIDE = ENV['QUICKSIGHT_TO_SIGMA_HOME']
+  DEFAULT_HOME  = File.expand_path('~/.quicksight-to-sigma')
+
+  def self.home
+    HOME_OVERRIDE || DEFAULT_HOME
+  end
+
+  def self.rules_path
+    File.join(home, 'learned-rules.yaml')
+  end
+
+  def self.escalations_dir
+    File.join(home, 'escalations')
+  end
+
+  def self.ensure_home
+    Dir.mkdir(home) unless Dir.exist?(home)
+    Dir.mkdir(escalations_dir) unless Dir.exist?(escalations_dir)
+  end
+
+  # Load the customer's accumulated rules. Returns [] if the file is missing —
+  # that's the normal first-time case, NOT an error.
+  def self.load
+    return [] unless File.exist?(rules_path)
+    data = YAML.safe_load(File.read(rules_path), permitted_classes: [Time, Date]) || {}
+    (data['rules'] || []).select do |r|
+      # Only apply confidence=validated rules by default. proposed/experimental
+      # rules are loaded but flagged so the agent can dry-run before trusting.
+      conf = r['confidence'] || 'validated'
+      conf == 'validated'
+    end
+  rescue StandardError => e
+    warn "WARN  learned-rules.yaml at #{rules_path} unreadable: #{e.message}; skipping"
+    []
+  end
+
+  # Apply rules to a formula. Returns [translated_formula, hint] when a rule
+  # matched, [nil, nil] when none did. First matching rule wins so customers
+  # can override built-in rules by adding a more-specific pattern earlier.
+  def self.apply(rules, formula)
+    return [nil, nil] if formula.nil? || formula.empty?
+    rules.each do |r|
+      pat = r['tableau_pattern']
+      tmpl = r['sigma_template']
+      next if pat.nil? || tmpl.nil?
+      begin
+        re = Regexp.new(pat)
+      rescue RegexpError
+        next
+      end
+      next unless formula =~ re
+      translated = formula.gsub(re, tmpl)
+      next if translated == formula
+      hint_parts = []
+      hint_parts << "learned-rule:#{r['feature']}"
+      hint_parts << r['hint'] if r['hint']
+      hint_parts << "(confidence=#{r['confidence']})" if r['confidence'] && r['confidence'] != 'validated'
+      return [translated, hint_parts.join(' — ')]
+    end
+    [nil, nil]
+  end
+
+  # Append a freshly-validated rule to the customer's file. Called by the
+  # gap-scout subagent after a successful Sigma POST + column-type guard.
+  def self.append(rule)
+    ensure_home
+    existing = if File.exist?(rules_path)
+                 YAML.safe_load(File.read(rules_path), permitted_classes: [Time, Date]) || {}
+               else
+                 {}
+               end
+    existing['rules'] ||= []
+    # Deduplicate by feature+pattern
+    existing['rules'].reject! { |r| r['feature'] == rule['feature'] && r['tableau_pattern'] == rule['tableau_pattern'] }
+    existing['rules'] << rule
+    File.write(rules_path, existing.to_yaml)
+    rules_path
+  end
+
+  # Save a structured escalation for a gap the scout couldn't solve. Filed
+  # locally — Phase 4 will mirror to GitHub/beads via `gh issue create` or
+  # `bd create`.
+  def self.escalate(payload)
+    ensure_home
+    slug = (payload['feature'] || 'unknown').downcase.gsub(/\W+/, '-')[0..40].sub(/-$/, '')
+    path = File.join(escalations_dir, "#{Time.now.strftime('%Y%m%d-%H%M%S')}-#{slug}.yaml")
+    File.write(path, payload.to_yaml)
+    path
+  end
+end
+
+# CLI: when invoked directly, dump the loaded rules for debugging
+if $PROGRAM_NAME == __FILE__
+  rules = LearnedRules.load
+  puts "Learned-rules file: #{LearnedRules.rules_path}"
+  puts "  rules loaded:      #{rules.length}"
+  rules.each_with_index do |r, i|
+    puts "  [#{i}] #{r['feature']} (#{r['confidence'] || 'validated'})"
+    puts "      pattern: #{r['tableau_pattern']}"
+    puts "      → #{r['sigma_template']}"
+  end
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/control_lint.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/control_lint.rb
@@ -1,0 +1,304 @@
+# frozen_string_literal: true
+#
+# control_lint.rb — mechanized control-wiring lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as layout_lint.rb / sigma_rest.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the layout lint
+#   - assert-phase6-ran.rb gate 7 (with a --skip-control-lint escape)
+#   - scripts/probe-controls.rb (reuses the reach computation to pick its
+#     in-closure / out-of-closure probe elements)
+#
+# It exists because a workbook can pass parity + layout gates and still ship
+# controls that DO NOTHING (the "Orders Overview (from Looker)" estate escape:
+# three list controls bound to no element at all) or controls that silently
+# skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
+# escape, and the Qlik class: source full of listboxes, spec with zero
+# controls). Three checks:
+#
+#   (a) dead control — every kind:control element must have >=1 `filters`
+#       target resolving to a REAL element id in the spec, OR be referenced
+#       as [controlId] in at least one non-control element (formula / spec
+#       reference). A control with neither is furniture: a user changes it
+#       and nothing on the page reacts.
+#   (b) reach — source-closure walk from the control's targets (filter
+#       targets + formula-referencing elements, expanded downstream through
+#       source.elementId chains). Any same-page QUERYABLE element outside
+#       the closure flags PARTIAL with the element names. Intentional
+#       single-chart switchers (grain / geo-level segmented controls) are
+#       allow-listed via the controlScope annotation (CONTRACT below).
+#   (c) source-scope coverage — when a control-scope sidecar is provided
+#       (emitted by the builder from the SOURCE BI artifact's filter
+#       signals), FAIL if the source had filter signals but the spec has
+#       zero controls, if an annotated control is missing from the spec,
+#       or if an annotated mustReach element is not in that control's
+#       closure.
+#
+# CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
+# to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
+# up from the workdir automatically, or take --control-scope PATH):
+#
+#   {
+#     "version": 1,
+#     "source": "qlik",               // provenance tag, free-form
+#     "sourceFilterSignals": 3,       // count of filter-like signals detected
+#                                     //   in the source artifact (listboxes,
+#                                     //   quick filters, actions, slicers,
+#                                     //   prompts, dashboard filters...).
+#                                     //   >0 with zero spec controls = FAIL.
+#     "controls": [
+#       {
+#         "controlId": "ctl-region",           // spec controlId (required)
+#         "sourceName": "Region quick filter", // optional, for messages
+#         "scope": "page",                     // "page" (default): the reach
+#                                              //   check applies to every
+#                                              //   same-page queryable element
+#                                              // OR an array of element ids /
+#                                              //   display names the control
+#                                              //   is INTENDED to affect — the
+#                                              //   single-chart-switcher
+#                                              //   allowlist (grain controls)
+#         "mustReach": ["Monthly Revenue Trend"] // optional hard assertions:
+#                                              //   each must be in the closure
+#       }
+#     ]
+#   }
+#
+# In-spec alternative (pre-POST local specs only): a control element may carry
+#   "controlScope": ["Element Name", ...]   // or "page"
+# with the same meaning as scope. NOTE: Sigma strips unknown keys on readback,
+# so the SIDECAR is the durable form — builders should emit both when the
+# allowlist must survive a live re-lint of the posted workbook.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query) evaluates a workbook
+# element WITH the workbook's saved control DEFAULTS applied and exposes NO
+# parameter mechanism to override them. The REST export API
+# (POST /v2/workbooks/{id}/export with `"parameters": {"<controlId>": "<value>"}`)
+# IS the only programmatic way to exercise a non-default control value — which
+# is why probe-controls.rb (the flip test) is built on export, not MCP.
+#
+# API:
+#   report     = ControlLint.controls_report(spec)   # per-control reach rows
+#   violations = ControlLint.lint(spec, scope: nil)  # scope = parsed sidecar
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/control_lint.rb <spec.json|spec.yaml> [control-scope.json]
+require 'json'
+require 'set'
+
+module ControlLint
+  QUERYABLE = %w[
+    table pivot-table input-table bar-chart line-chart pie-chart donut-chart
+    area-chart scatter-chart combo-chart kpi-chart box-chart funnel-chart
+    gauge-chart waterfall-chart sankey-chart region-map point-map viz chart
+    treemap-chart heatmap-chart word-cloud
+  ].to_set.freeze
+
+  module_function
+
+  # { element_id => {el:, page:, kind:, name:, srcel:} } for every element.
+  def elements(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        eid = el['id'] || el['elementId']
+        next unless eid
+        out[eid] = { el: el, page: pg['name'] || pg['id'],
+                     kind: (el['kind'] || el['type']).to_s,
+                     name: el['name'], srcel: source_element_id(el) }
+      end
+    end
+    out
+  end
+
+  # Unwraps {kind:"source", source:{elementId}} and direct {elementId} forms.
+  def source_element_id(el)
+    src = el['source']
+    return nil unless src.is_a?(Hash)
+    src = src['source'] if src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src.is_a?(Hash) ? src['elementId'] : nil
+  end
+
+  def control?(info)
+    info[:kind].include?('control')
+  end
+
+  # Transitive closure of elements sourcing (directly or via chains) from any
+  # element in `roots`. Returns roots + downstream ids.
+  def closure(elems, roots)
+    reach = roots.to_set
+    loop do
+      grew = false
+      elems.each do |eid, info|
+        next if reach.include?(eid)
+        next unless info[:srcel] && reach.include?(info[:srcel])
+        reach << eid
+        grew = true
+      end
+      break unless grew
+    end
+    reach
+  end
+
+  # Non-control elements whose serialized spec references [controlId] —
+  # catches formula refs (If([GeoLevel]="State",...)) and any other spec-level
+  # binding that names the control.
+  def formula_refs(elems, cid)
+    return [] if cid.nil? || cid.to_s.empty?
+    pat = /\[#{Regexp.escape(cid)}\]/
+    elems.select { |_eid, info| !control?(info) && JSON.generate(info[:el]).match?(pat) }
+         .keys
+  end
+
+  # Per-control reach report. Each row:
+  #   { control_element_id:, control_id:, name:, page:, control_type:,
+  #     filter_targets: [ids], ghost_targets: [ids], formula_refs: [ids],
+  #     reach: Set[ids], page_queryable: [ids], uncovered: [ids] }
+  def controls_report(spec)
+    elems = elements(spec)
+    rows = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      cid = el['controlId']
+      tgt_ids = (el['filters'] || []).map { |t| t.is_a?(Hash) ? t.dig('source', 'elementId') : nil }.compact
+      live    = tgt_ids.select { |t| elems.key?(t) }
+      frefs   = formula_refs(elems, cid)
+      roots   = (live + frefs).uniq
+      reach   = roots.empty? ? Set.new : closure(elems, roots)
+      page_q  = elems.select do |qid, i|
+        qid != eid && i[:page] == info[:page] && QUERYABLE.include?(i[:kind])
+      end.keys
+      rows << { control_element_id: eid, control_id: cid, name: info[:name],
+                page: info[:page], control_type: el['controlType'],
+                filter_targets: live, ghost_targets: tgt_ids - live,
+                formula_refs: frefs, reach: reach, page_queryable: page_q,
+                uncovered: page_q.reject { |q| reach.include?(q) } }
+    end
+    rows
+  end
+
+  # Resolve a sidecar element reference (id or display name) to element ids.
+  def resolve_ref(elems, ref)
+    return [ref] if elems.key?(ref)
+    elems.select { |_eid, i| i[:name] == ref }.keys
+  end
+
+  def label(elems, eid)
+    n = elems[eid] && elems[eid][:name]
+    n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
+  end
+
+  def lint(spec, scope: nil)
+    violations = []
+    elems = elements(spec)
+    rows  = controls_report(spec)
+
+    scope_by_cid = {}
+    if scope.is_a?(Hash)
+      Array(scope['controls']).each do |c|
+        scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
+      end
+      # (c) the Qlik class: source had filter signals, spec built zero controls.
+      signals = scope['sourceFilterSignals'].to_i
+      if signals.positive? && rows.empty?
+        violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
+                      '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
+                      'elements — the source dashboard is interactive and the migration shipped a ' \
+                      'static one; build the controls (or set sourceFilterSignals to 0 with a ' \
+                      'reason if the signals are genuinely non-portable)'
+      end
+    end
+
+    rows.each do |r|
+      ann = scope_by_cid.delete(r[:control_id]) || {}
+      ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
+      ctl_label = "control #{label(elems, r[:control_element_id])}#{r[:control_id] ? " [#{r[:control_id]}]" : ''} on page #{r[:page].inspect}"
+
+      r[:ghost_targets].each do |g|
+        violations << "ghost target: #{ctl_label} lists filter target #{g.inspect} which does not " \
+                      'resolve to any element in the spec — fix or drop the target'
+      end
+
+      # (a) dead control --------------------------------------------------------
+      if r[:reach].empty?
+        violations << "dead control: #{ctl_label} has no resolving `filters` target and no " \
+                      '[controlId] reference in any non-control element — a user changes it and ' \
+                      'nothing reacts; wire it (filters: [{source:{elementId}, columnId}]) or, if ' \
+                      'the bound column genuinely does not exist on any element, REMOVE the ' \
+                      'control (honest) instead of shipping furniture'
+        next
+      end
+
+      # (c) mustReach assertions -------------------------------------------------
+      Array(ann['mustReach']).each do |ref|
+        ids = resolve_ref(elems, ref)
+        if ids.empty?
+          violations << "scope mustReach: #{ctl_label} — annotated element #{ref.inspect} does not " \
+                        'exist in the spec'
+        elsif ids.none? { |i| r[:reach].include?(i) }
+          violations << "scope mustReach: #{ctl_label} does NOT reach annotated element " \
+                        "#{ref.inspect} — wire a filter target (or formula ref) so it does"
+        end
+      end
+
+      # (b) reach / PARTIAL --------------------------------------------------------
+      if ann_scope.is_a?(Array)
+        # Explicit allowlist (single-chart switcher): every listed element must
+        # be reached; same-page elements OUTSIDE the list are intentionally
+        # unaffected and not flagged.
+        ann_scope.each do |ref|
+          ids = resolve_ref(elems, ref)
+          if ids.empty?
+            violations << "controlScope: #{ctl_label} — scoped element #{ref.inspect} does not exist " \
+                          'in the spec'
+          elsif ids.none? { |i| r[:reach].include?(i) }
+            violations << "controlScope: #{ctl_label} does NOT reach its scoped element #{ref.inspect}"
+          end
+        end
+      elsif r[:uncovered].any?
+        names = r[:uncovered].map { |u| label(elems, u) }
+        violations << "partial control: #{ctl_label} affects #{r[:page_queryable].length - r[:uncovered].length} " \
+                      "of #{r[:page_queryable].length} same-page queryable element(s); NOT affected: " \
+                      "#{names.join(', ')} — wire those elements (add filter targets on their " \
+                      'sources, matching the source dashboard\'s filter scope) or declare the ' \
+                      'narrow scope intentional via controlScope (sidecar control-scope.json ' \
+                      'scope:[...] — see header CONTRACT)'
+      end
+    end
+
+    # (c) annotated controls that never made it into the spec ------------------
+    scope_by_cid.each do |cid, c|
+      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                    'has no control with that controlId — the source filter was not migrated'
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  abort 'usage: ruby control_lint.rb <workbook-spec.json|yaml> [control-scope.json]' unless ARGV[0] && File.exist?(ARGV[0])
+  body = File.read(ARGV[0])
+  spec =
+    begin
+      JSON.parse(body)
+    rescue JSON::ParserError
+      require 'yaml'
+      require 'date'
+      YAML.safe_load(body, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+  scope = ARGV[1] && File.exist?(ARGV[1]) ? JSON.parse(File.read(ARGV[1])) : nil
+  v = ControlLint.lint(spec, scope: scope)
+  if v.empty?
+    n = ControlLint.controls_report(spec).length
+    puts "control lint: clean (#{n} control(s) checked)"
+  else
+    warn "control lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/layout.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/layout.rb
@@ -1,0 +1,219 @@
+# Layout-XML helpers. require'd by per-workbook layout configs.
+#
+# Container-based layouts (layout-playbook.md, verified 2026-06-10):
+#   - spec side: a `kind: container` placeholder element per band
+#     (container_el / header_text_el below build those spec objects)
+#   - layout side: a <GridContainer> (NOT <LayoutElement type="grid">, which
+#     silently drops children) whose child <LayoutElement>s use
+#     CONTAINER-RELATIVE coordinates (rows restart at 1).
+module SigmaLayout
+  module_function
+
+  HEADER_STYLE = { 'backgroundColor' => '#0F172A', 'borderRadius' => 'round' }.freeze
+  HEADER_ROWS  = 3 # header band height in grid rows
+  GRID_COLS    = 24 # page/container grid width (gridTemplateColumns repeat(24))
+  MIN_BAND_FILL = 0.60 # a band must fill >=60% of the grid columns (lint parity)
+  # Generic auto-names (Sigma page names / source section names) that must
+  # NEVER become a header-band title — "Page 1" / "Sheet 3" / "Dashboard 2".
+  GENERIC_TITLE = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+
+  # True when a candidate header title is a generic auto-name.
+  def generic_title?(s)
+    s.to_s.strip.match?(GENERIC_TITLE)
+  end
+
+  # First usable header-band title from a priority-ordered candidate list:
+  # skips nil/empty and generic auto-names ("Page 1" etc). Callers pass, in
+  # order: promoted source title -> source dashboard/report display name ->
+  # workbook name. Returns nil when nothing usable remains (caller decides).
+  def resolve_header_title(*candidates)
+    candidates.map { |c| c.to_s.strip }.find { |c| !c.empty? && !generic_title?(c) }
+  end
+
+  def gc(eid, c0, c1, r0, r1, inner)
+    "<GridContainer elementId=\"#{eid}\" type=\"grid\" " \
+    "gridColumn=\"#{c0} / #{c1}\" gridRow=\"#{r0} / #{r1}\" " \
+    "gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\">\n#{inner}\n</GridContainer>"
+  end
+
+  def le(eid, c0, c1, r0, r1)
+    "  <LayoutElement elementId=\"#{eid}\" gridColumn=\"#{c0} / #{c1}\" gridRow=\"#{r0} / #{r1}\"/>"
+  end
+
+  def page_xml(page_id, *children)
+    header = "<Page type=\"grid\" gridTemplateColumns=\"repeat(24, 1fr)\" gridTemplateRows=\"auto\" id=\"#{page_id}\">"
+    [header, *children.compact, "</Page>"].join("\n")
+  end
+
+  def assemble(*pages)
+    %(<?xml version="1.0" encoding="utf-8"?>\n) + pages.join("\n")
+  end
+
+  # ---- container-layout helpers --------------------------------------------
+
+  # Spec-side placeholder for a band container.
+  def container_el(id, style = nil)
+    el = { 'id' => id, 'kind' => 'container' }
+    el['style'] = style if style
+    el
+  end
+
+  # Spec-side page-title text element (white text over the dark header band).
+  def header_text_el(id, title)
+    { 'id' => id, 'kind' => 'text',
+      'body' => %(# <span style="color: #FFFFFF">#{title}</span>) }
+  end
+
+  # Header band XML: dark full-width container at the top of the page wrapping
+  # the title text (child coordinates are container-relative).
+  def header_band_xml(container_id, text_id, rows: HEADER_ROWS)
+    gc(container_id, 1, 25, 1, 1 + rows, le(text_id, 1, 25, 1, 1 + rows))
+  end
+
+  # Cluster placed items into horizontal bands by row overlap. Items are
+  # [eid, c0, c1, r0, r1, *rest] tuples with PAGE-ABSOLUTE rows. Returns an
+  # array of bands (each an array of items), top-to-bottom.
+  def cluster_bands(items)
+    bands = []
+    items.sort_by { |i| [i[3], i[1]] }.each do |it|
+      if bands.any? && it[3] < bands.last[:r1]
+        bands.last[:items] << it
+        bands.last[:r1] = [bands.last[:r1], it[4]].max
+      else
+        bands << { r0: it[3], r1: it[4], items: [it] }
+      end
+    end
+    bands.map { |b| b[:items] }
+  end
+
+  # Fraction of the GRID_COLS columns covered by a band's items (union).
+  def band_fill(items)
+    covered = Array.new(GRID_COLS, false)
+    items.each do |i|
+      (i[1]...i[2]).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+    end
+    covered.count(true).to_f / GRID_COLS
+  end
+
+  # Re-flow under-filled bands (phase-e layout-quality fix, round 2): when any
+  # band's items cover <60% of the grid columns — e.g. a small chart left
+  # alone in band 1 after its neighboring title textbox was promoted into the
+  # header band — the page's items are redistributed across the same number
+  # of bands EVENLY (sizes differ by at most 1, remainder to the bottom bands:
+  # 5 charts -> 2+3), and each band's items are tiled edge-to-edge across the
+  # full grid width at the band's original height (uniform rows — no stagger).
+  # Pages whose bands all fill >=60% keep the source-canvas geometry exactly.
+  def reflow_bands(bands)
+    return bands unless bands.any? { |b| band_fill(b) < MIN_BAND_FILL }
+    heights = bands.map { |b| b.map { |i| i[4] }.max - b.map { |i| i[3] }.min }
+    items = bands.flat_map { |b| b.sort_by { |i| [i[3], i[1]] } }
+    k = items.length
+    nb = [bands.length, k].min
+    base = k / nb
+    sizes = Array.new(nb) { |bi| base + (bi >= nb - (k % nb) ? 1 : 0) }
+    out = []
+    idx = 0
+    cursor = 1
+    sizes.each_with_index do |n, bi|
+      band_items = items[idx, n]
+      idx += n
+      h = [heights[bi] || heights.compact.max || 8, 4].max
+      band = band_items.each_with_index.map do |it, j|
+        c0 = 1 + (GRID_COLS * j / n.to_f).round
+        c1 = 1 + (GRID_COLS * (j + 1) / n.to_f).round
+        [it[0], c0, c1, cursor, cursor + h, *it[5..]]
+      end
+      out << band
+      cursor += h
+    end
+    out
+  end
+
+  # Two placed items collide when their column AND row ranges both overlap.
+  # Items are [eid, c0, c1, r0, r1, *rest] with grid-line (exclusive-end) coords.
+  def collide?(a, b)
+    a[1] < b[2] && b[1] < a[2] && a[3] < b[4] && b[3] < a[4]
+  end
+
+  # De-overlap each band. Sigma's grid has NO z-order, so two items sharing a
+  # cell — common when a source tool floats a filter/legend/listbox on top of a
+  # chart (e.g. Qlik's associative-model listboxes over charts) — render
+  # stacked on top of each other. When any pair in a band overlaps in BOTH
+  # axes, tile that band's items edge-to-edge across the full grid width at the
+  # band's row range (same tiling math as reflow_bands). Collision-free bands
+  # are returned untouched, so clean source geometry is preserved exactly. This
+  # is the universal safety net that runs after reflow on every banded_page.
+  def decollide_bands(bands)
+    bands.map do |band|
+      next band unless band.combination(2).any? { |a, b| collide?(a, b) }
+      r0 = band.map { |i| i[3] }.min
+      r1 = band.map { |i| i[4] }.max
+      n = band.length
+      band.sort_by { |i| [i[1], i[3]] }.each_with_index.map do |it, j|
+        c0 = 1 + (GRID_COLS * j / n.to_f).round
+        c1 = 1 + (GRID_COLS * (j + 1) / n.to_f).round
+        [it[0], c0, c1, r0, r1, *it[5..]]
+      end
+    end
+  end
+
+  # One band of items -> a full-width GridContainer spanning the band's row
+  # range at page level, children re-emitted with CONTAINER-RELATIVE rows.
+  # row_offset shifts the container's page-level position (e.g. +3 when a
+  # header band was prepended above the original geometry).
+  def band_container_xml(cid, items, row_offset: 0)
+    r0 = items.map { |i| i[3] }.min
+    r1 = items.map { |i| i[4] }.max
+    inner = items.map { |i| le(i[0], i[1], i[2], i[3] - r0 + 1, i[4] - r0 + 1) }.join("\n")
+    gc(cid, 1, 25, r0 + row_offset, r1 + row_offset, inner)
+  end
+
+  # Full container-banded page: header band + one container per row band.
+  # Returns [page_xml_string, extra_spec_elements] — the caller must add the
+  # extra elements (containers + header text) to the page's spec `elements`
+  # (directly, or via put-layout.rb's <layout>.elements.json sidecar).
+  # `title` of nil/empty skips the header band (e.g. when the caller bands an
+  # existing title text element explicitly).
+  # `header_el`: an EXISTING text element id to wrap as the header band's text
+  # (e.g. the source dashboard's own title textbox — phase-e layout-quality
+  # fix: a short title text left inside band 1 reads as a dead zone). It must
+  # NOT also appear in `items`; the caller should recolor its body for the
+  # dark band (see header_text_el's white span).
+  # `title` must already be resolved through resolve_header_title (promoted
+  # source title -> source display name -> workbook name) — a generic
+  # auto-name ("Page 1") raises rather than ships a wrong header band.
+  # `reflow: true` (default) runs reflow_bands so no band ships <60% filled.
+  def banded_page(page_id, items, title: nil, id_prefix: "band-#{page_id}", header_el: nil,
+                  reflow: true)
+    extra = []
+    children = []
+    offset = 0
+    if header_el
+      hdr_id = "#{id_prefix}-hdr"
+      extra << container_el(hdr_id, HEADER_STYLE.dup)
+      children << header_band_xml(hdr_id, header_el)
+      offset = HEADER_ROWS
+    elsif title && !title.to_s.empty?
+      raise ArgumentError, "banded_page: generic header title #{title.inspect} — " \
+                           'resolve via resolve_header_title (source display name / workbook name)' \
+        if generic_title?(title)
+      hdr_id = "#{id_prefix}-hdr"
+      txt_id = "#{id_prefix}-hdrtext"
+      extra << container_el(hdr_id, HEADER_STYLE.dup)
+      extra << header_text_el(txt_id, title)
+      children << header_band_xml(hdr_id, txt_id)
+      offset = HEADER_ROWS
+    end
+    bands = cluster_bands(items)
+    bands = reflow_bands(bands) if reflow
+    bands = decollide_bands(bands)
+    top = bands.flatten(1).map { |i| i[3] }.min
+    offset += (1 - top) if top # first band starts right under the header
+    bands.each_with_index do |band, i|
+      cid = "#{id_prefix}-#{i + 1}"
+      extra << container_el(cid)
+      children << band_container_xml(cid, band, row_offset: offset)
+    end
+    [page_xml(page_id, *children), extra]
+  end
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/layout_lint.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,247 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  # The column count a container's children are laid out against — its OWN
+  # gridTemplateColumns (a child's gridColumn refs are LOCAL to its container,
+  # not the page's 24-col grid). "repeat(N, ...)" -> N; an explicit track list
+  # -> token count; absent -> the page-grid default. A vertical rail declares
+  # repeat(1, 1fr): one full-width column, NOT 1/24 of the page.
+  def grid_col_count(attrs)
+    tmpl = attrs.to_s[/gridTemplateColumns="([^"]*)"/, 1]
+    return GRID_COLS if tmpl.nil? || tmpl.strip.empty?
+    if (rep = tmpl[/repeat\(\s*(\d+)/, 1])
+      return [[rep.to_i, 1].max, GRID_COLS * 4].min
+    end
+    n = tmpl.strip.split(/\s+/).reject(&:empty?).length
+    n.positive? ? n : GRID_COLS
+  end
+
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      cols = grid_col_count(attrs)
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, cols: cols, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        # Measure fill against the container's OWN column count — a child's
+        # gridColumn is local to its container's gridTemplateColumns. A vertical
+        # rail (repeat(1, 1fr)) whose children fill its one column is 100% full,
+        # not 1/24 (was a false-positive hard-fail on every sidebar layout).
+        ncols = b[:cols] || GRID_COLS
+        covered = Array.new(ncols, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= ncols }
+        end
+        fill = covered.count(true).to_f / ncols
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), ncols, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/preflight_lint.rb
@@ -1,0 +1,110 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Preflight lint for a workbook spec — catches the two EDNA-class failure modes
+# BEFORE POST, with a precise message instead of the opaque "Invalid kind: control"
+# or a silently-detail-rendered table.
+#
+#   ruby preflight_lint.rb <workbook-spec.json>
+#     exit 0  = clean
+#     exit 1  = violations (printed, one per line)
+#
+# Checks:
+#   T1  a `table` with aggregate column(s) + dimension(s) but NO `groupings`
+#       → renders raw detail rows (the 9.6M-row / $0 / duplicate-dim EDNA bug).
+#   T2  a `groupings.calculations` column that is a PASSTHROUGH of an aggregate
+#       (re-aggregates to "multiple values"); calc cols must be Sum(...)/etc.
+#   C1  a `control` missing id / controlId / controlType.
+#   C2  any control nesting its value fields under a bogus `value` OBJECT
+#       (control fields are FLAT top-level) → the opaque `Invalid kind: control`.
+#       NOTE: a scalar `value:` is legitimate (slider handle position); only an
+#       OBJECT value is the trap. Also: a `source`, if present, must be double-nested.
+#   C3  a list/segmented/hierarchy control wired to NOTHING — neither a `source`
+#       (value-list) nor `filters` (target columns). A filters-only list control
+#       is VALID (live-verified), so source is NOT independently required.
+require 'json'
+
+AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
+PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
+LISTY = %w[list segmented hierarchy].freeze
+
+def lint(spec)
+  errs = []
+  cols_by_id = {}
+  pages = spec['pages'] || []
+  pages.each do |pg|
+    (pg['elements'] || []).each do |el|
+      (el['columns'] || []).each { |c| cols_by_id[c['id']] = c }
+    end
+  end
+  pages.each do |pg|
+    (pg['elements'] || []).each do |el|
+      kind = el['kind']
+      name = el['name'] || el['id'] || '(unnamed)'
+      cols = el['columns'] || []
+
+      if kind == 'table'
+        agg = cols.select { |c| c['formula'].to_s =~ AGG }
+        dim = cols.select { |c| c['formula'].to_s =~ PLAIN_REF }
+        grouped = el['groupings'].is_a?(Array) && !el['groupings'].empty?
+        if agg.any? && dim.any? && !grouped
+          errs << "T1 table '#{name}': has aggregate column(s) #{agg.map { |c| c['name'] }.inspect} + dimension(s) but NO `groupings` → will render raw detail rows, not an aggregated summary. Add groupings:[{groupBy:[<dim id>], calculations:[<agg id>...]}]."
+        end
+        # T2: a grouping calculation that points at a passthrough-of-aggregate column
+        (el['groupings'] || []).each do |g|
+          (g['calculations'] || []).each do |cid|
+            f = (cols_by_id[cid] || {})['formula'].to_s
+            # a calc that is a plain ref to another column whose own formula is an aggregate
+            if f =~ PLAIN_REF
+              # can't always resolve cross-element; flag bare passthroughs that look like measures
+              errs << "T2 table '#{name}': grouping calculation '#{cid}' is a passthrough (`#{f}`) — a grouped calculation must be an aggregate expression (Sum([...]) etc.), not a passthrough of an already-aggregated column (renders 'multiple values')." if cols_by_id[cid] && (cols_by_id[cid]['name'].to_s =~ /total|sum|count|avg|revenue|profit|tcv|amount/i)
+            end
+          end
+        end
+      end
+
+      if kind == 'control'
+        %w[id controlId controlType].each do |f|
+          errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
+        end
+        errs << "C1 control '#{name}': `id` and `controlId` must be DISTINCT." if !el['id'].to_s.empty? && el['id'] == el['controlId']
+
+        # C2: control value fields are FLAT top-level — never nested under a `value` OBJECT.
+        # (Live-verified: a nested value:{...} yields the opaque "Invalid kind: control" for
+        #  list / date-range / number-range / slider alike.) A SCALAR value: is legitimate
+        #  (the slider handle position), so only flag `value` when it is a Hash.
+        errs << "C2 control '#{name}': value fields nested under a `value` object — control fields must be FLAT top-level (list: mode/selectionMode/values; ranges: low/high; slider: low/high/mode/<scalar value>)." if el['value'].is_a?(Hash)
+
+        # `source`, if present, must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}).
+        if el['source'].is_a?(Hash) && !el['source']['source'].is_a?(Hash)
+          errs << "C2 control '#{name}': `source` present but not double-nested — needs {kind:source, source:{kind:table,elementId}, columnId}."
+        end
+
+        # C3: a list-type control must be wired to SOMETHING — a `source` (value-list) and/or
+        # `filters` (target columns). A filters-only list control is VALID (live-verified), so we
+        # require source OR filters, never both, and never the bare mode/selectionMode/values.
+        if LISTY.include?(el['controlType'])
+          has_source  = el['source'].is_a?(Hash)
+          has_filters = el['filters'].is_a?(Array) && !el['filters'].empty?
+          unless has_source || has_filters
+            errs << "C3 control '#{name}': list-type control has neither `source` (value-list) nor `filters` (target columns) — it controls nothing. Add filters:[{source:{kind:table,elementId}, columnId}] and/or a double-nested source."
+          end
+        end
+      end
+    end
+  end
+  errs
+end
+
+if __FILE__ == $PROGRAM_NAME
+  path = ARGV[0] or abort('usage: preflight_lint.rb <workbook-spec.json>')
+  spec = JSON.parse(File.read(path))
+  errs = lint(spec)
+  if errs.empty?
+    puts 'preflight lint: clean'
+    exit 0
+  end
+  warn "preflight lint: #{errs.size} violation(s)"
+  errs.each { |e| warn "  ✗ #{e}" }
+  exit 1
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/scout_gate.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/scout_gate.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+#
+# Shared "run-each-time gap-scout gate" (bead beads-sigma-5l5e).
+#
+# The guarantee: a migration may NOT proceed past its unhandled-feature gaps
+# unless the gap-scout actually ran for EVERY one — either it validated a Sigma
+# translation (`validated`) or it tried and could not (`escalated`). A blanket
+# --force must NOT skip the scout; it may only accept gaps the scout escalated.
+#
+# This module is the reusable core, identical across every migration plugin:
+#   - ScoutGate.record  — scout-validate-and-persist.rb appends one ledger row
+#   - ScoutGate.classify — the orchestrator reads the ledger and splits the
+#                          unhandled gaps into unscouted / escalated / validated
+# Each plugin maps its own gap representation to a list of stable gap-id strings
+# and calls classify; the gap-id naming is the plugin's business, the gate is not.
+#
+# Kept dependency-free (json/time only) so it can be vendored into any plugin's
+# scripts/lib/ unchanged.
+require 'json'
+require 'time'
+
+module ScoutGate
+  LEDGER = 'scout-ledger.jsonl'
+
+  def self.ledger_path(workdir)
+    File.join(workdir.to_s, LEDGER)
+  end
+
+  # Append one scout result to the per-conversion ledger. Non-fatal on error —
+  # a failed ledger write must never crash a scout that otherwise succeeded.
+  def self.record(workdir, gap_id:, feature:, status:)
+    return false unless workdir && Dir.exist?(workdir)
+    row = { 'gap_id' => (gap_id || feature).to_s, 'feature' => feature.to_s,
+            'status' => status.to_s, 'at' => Time.now.utc.iso8601 }
+    File.open(ledger_path(workdir), 'a') { |f| f.puts(JSON.generate(row)) }
+    true
+  rescue StandardError => e
+    warn "scout-ledger write failed (non-fatal): #{e.message}"
+    false
+  end
+
+  def self.read_ledger(workdir)
+    p = ledger_path(workdir)
+    return [] unless File.exist?(p)
+    File.readlines(p).map { |l| JSON.parse(l) rescue nil }.compact
+  end
+
+  # gap_ids: Array<String> — the unhandled gaps the scout was supposed to cover.
+  # Returns a Hash with three disjoint buckets of gap-ids:
+  #   :unscouted — no ledger row at all (the scout never ran) → hard STOP
+  #   :escalated — scouted, every row is 'escalated' (tried, unsolved) → --force
+  #   :validated — has at least one 'validated' row (solved locally)
+  def self.classify(workdir, gap_ids)
+    by = read_ledger(workdir).group_by { |e| e['gap_id'].to_s }
+    unscouted = gap_ids.reject { |id| by[id.to_s] }
+    rest      = gap_ids.select { |id| by[id.to_s] }
+    validated = rest.select { |id| by[id.to_s].any? { |x| x['status'] == 'validated' } }
+    escalated = rest - validated
+    { unscouted: unscouted, escalated: escalated, validated: validated }
+  end
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/sigma_functions.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/sigma_functions.rb
@@ -1,0 +1,120 @@
+# Canonical Sigma formula function whitelist.
+# Source: https://help.sigmacomputing.com (Function reference, categories below).
+# Last refreshed: 2026-05-18.
+#
+# Use this list to validate that every function name appearing in a Sigma calc
+# formula is a real Sigma function. Anything outside the list is either a
+# Tableau-syntax leak (IIF / COUNTD / WINDOW_*), a non-existent helper an agent
+# imagined (IsIn / ToText / DateParse — wait, DateParse IS real, see below), or
+# a typo. The right fix is always:
+#   - rewrite the formula using a function from this list, OR
+#   - move the logic into a Custom SQL data-model element (kind: "sql") and
+#     reference its columns as plain `[Custom SQL/COL]` refs
+
+module SigmaFunctions
+  CATEGORIES = {
+    aggregate: %w[
+      ArrayAgg ArrayAggDistinct Avg AvgIf Corr Count CountDistinct
+      CountDistinctIf CountIf GrandTotal ListAgg ListAggDistinct Max MaxIf
+      Median Min MinIf PercentileCont PercentileDisc PercentOfTotal
+      RegressionIntercept RegressionR2 RegressionSlope StdDev Subtotal Sum
+      SumIf SumProduct Variance VariancePop
+    ],
+    array: %w[
+      Array ArrayCompact ArrayConcat ArrayContains ArrayDistinct ArrayExcept
+      ArrayIntersection ArrayJoin ArrayLength ArraySlice RaggedHierarchy
+      Sequence SplitToArray Sparkline SparklineAgg
+    ],
+    date: %w[
+      ConvertTimezone DateAdd DateDiff DateFormat DateFromUnix DateFromUnixMs
+      DateFromUnixUs DateLookback DatePart DateParse DateTrunc Day DayOfYear
+      EndOfMonth Hour InDateRange InPriorDateRange LastDay MakeDate Minute
+      Month MonthName Now Quarter Second Today Weekday WeekdayName Year
+    ],
+    financial: %w[CAGR Effect FV IPmt Nominal NPer Pmt PPmt PV XNPV],
+    geography: %w[
+      Area Centroid Distance Geography Intersects Json Latitude Longitude
+      MakeLine MakePoint Perimeter Text Within
+    ],
+    logical: %w[Between Choose Coalesce If In IsNotNull IsNull Switch Zn NullIf],
+    math: %w[
+      Abs Acos Asin Atan Atan2 BinFixed BinRange BitAnd BitOr Ceiling Cos Cot
+      Degrees DistanceGlobe DistancePlane Div Exp Floor Greatest GreatestNonNull
+      Int IsEven IsOdd Least LeastNonNull Ln Log Mod MRound Pi Power Radians
+      Round RoundDown RoundUp RowAvg Sign Sin Sqrt Tan Trunc
+    ],
+    text: %w[
+      Concat Contains EndsWith Find ILike Left Len Like LPad Lower LTrim MD5
+      Mid Proper RegexpCount RegexpExtract RegexpMatch RegexpReplace Repeat
+      Replace Reverse Right RPad RTrim SHA256 SplitPart StartsWith Substring
+      Trim Upper UrlPart
+    ],
+    type_conversion: %w[Date Json Logical Number Text Variant],
+    window: %w[
+      CumulativeAvg CumulativeCorr CumulativeCount CumeDist CumulativeMax
+      CumulativeMin CumulativeStdDev CumulativeSum CumulativeVariance FillDown
+      First FirstNonNull Lag Last LastNonNull Lead MovingAvg MovingCorr
+      MovingCount MovingMax MovingMin MovingStdDev MovingSum MovingVariance
+      Nth Ntile Rank RankDense RankPercentile RowNumber VisibilityLimit
+    ],
+    join: %w[Lookup Rollup],
+    system: %w[
+      CurrentTimezone CurrentUserAttributeText CurrentUserEmail
+      CurrentUserFirstName CurrentUserFullName CurrentUserInTeam
+    ],
+    passthrough: %w[
+      AggDatetime AggGeography AggLogical AggNumber AggText AggVariant
+      CallDatetime CallGeography CallLogical CallNumber CallText CallVariant
+    ]
+  }.freeze
+
+  ALL = CATEGORIES.values.flatten.freeze
+  ALL_SET = ALL.to_set rescue Set.new(ALL)
+
+  def self.includes?(name)
+    ALL_SET.include?(name)
+  end
+
+  # Returns the list of UNDOCUMENTED function names referenced in a formula.
+  # Detection rule: identifier followed by `(` that isn't already a known Sigma
+  # function. Identifiers are simple [A-Za-z_][A-Za-z0-9_]*.
+  def self.unknown_functions(formula)
+    return [] if formula.nil?
+    # Strip string literals so SQL-ish content inside Custom SQL contexts doesn't
+    # trigger false positives. Sigma calc formulas use "..." for strings.
+    cleaned = formula.gsub(/"(?:\\.|[^"\\])*"/, '""')
+    names = cleaned.scan(/\b([A-Za-z_][A-Za-z0-9_]*)\s*\(/).flatten.uniq
+    names.reject { |n| includes?(n) }
+  end
+
+  # Known Tableau-syntax leak patterns. These DEFINITELY don't work in Sigma
+  # and most of them resemble valid Sigma syntax just enough that a non-strict
+  # whitelist might miss them. Flag with explicit translation hints.
+  TABLEAU_LEAKS = {
+    /\bIIF\s*\(/i        => 'IIF(c, t, e) → Sigma If(c, t, e)',
+    /\bCOUNTD\s*\(/i     => 'COUNTD(x) → Sigma CountDistinct(x)',
+    /\bIFNULL\s*\(/i     => 'IFNULL(x, y) → Sigma Coalesce(x, y)',
+    /\bIS\s+NULL\b/i     => 'x IS NULL → Sigma IsNull(x)',
+    /\bIS\s+NOT\s+NULL\b/i => 'x IS NOT NULL → Sigma IsNotNull(x)',
+    /\bDATEPART\s*\(\s*['"]/i => 'DATEPART("part", date) → Sigma DatePart("part", date) — capitalization matters',
+    /\bWINDOW_(SUM|AVG|MIN|MAX|COUNT|MEDIAN|PERCENTILE)\b/i =>
+      'WINDOW_* aggregates → use Sigma Cumulative*/Moving* OR a Custom SQL element with OVER(...)',
+    /\bRUNNING_(SUM|AVG|COUNT|MIN|MAX)\b/i =>
+      'RUNNING_* → Sigma CumulativeSum/CumulativeAvg/etc. inside a non-grouping context, OR Custom SQL with OVER(... ROWS UNBOUNDED PRECEDING)',
+    /\bRANK_(DENSE|MODIFIED|UNIQUE|PERCENTILE)\b/i =>
+      'RANK_* → Sigma RankDense / RankPercentile / RowNumber, OR Custom SQL with RANK()/DENSE_RANK()/ROW_NUMBER() OVER(...)',
+    /\b\{\s*(FIXED|INCLUDE|EXCLUDE)\b/i =>
+      'Tableau LOD → use Sigma window function family OR a Custom SQL data-model element',
+    /\bIsIn\s*\(/        => 'IsIn() is not a Sigma function — use Sigma In(value, list...) OR an or chain',
+    /\bToText\s*\(/      => 'ToText() is not a Sigma function — use Sigma Text(...) instead',
+    /\bToString\s*\(/    => 'ToString() is not a Sigma function — use Sigma Text(...) instead',
+    /\bToNumber\s*\(/    => 'ToNumber() is not a Sigma function — use Sigma Number(...) instead'
+  }.freeze
+
+  def self.tableau_leaks(formula)
+    return [] if formula.nil?
+    TABLEAU_LEAKS.each_with_object([]) do |(re, hint), acc|
+      acc << hint if formula.match?(re)
+    end
+  end
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/sigma_rest.rb
@@ -1,0 +1,130 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Sigma creds aren't in ENV yet, load
+# them from the neutral cred file written by setup.rb. Existing env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env) do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN'] || refresh_token!
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      @token_mutex.synchronize { @token_override = tok }
+      # Surface the refreshed token to child processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/lib/tableau_rest.rb
@@ -1,0 +1,212 @@
+# Tableau REST API wrapper for tableau-to-sigma when the MCP isn't available.
+# Requires TABLEAU_SERVER_URL, TABLEAU_SITE_ID, TABLEAU_AUTH_TOKEN, TABLEAU_API_VERSION in ENV
+# (set by scripts/get-tableau-token.sh).
+#
+# All methods return parsed Hash/Array (or raw bytes for view_image). Network/HTTP errors raise
+# Tableau::Error with the response body included.
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'cgi'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Tableau PAT creds aren't in ENV yet,
+# load them from the neutral cred file written by setup-tableau.rb. Existing
+# env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['TABLEAU_PAT_SECRET'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env) do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+module Tableau
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @site_id_override = nil
+
+  module_function
+
+  def server_url
+    ENV.fetch('TABLEAU_SERVER_URL') { raise Error, 'TABLEAU_SERVER_URL not set — run get-tableau-token.sh' }
+  end
+
+  def site_id
+    @token_mutex.synchronize { @site_id_override } || ENV.fetch('TABLEAU_SITE_ID') { raise Error, 'TABLEAU_SITE_ID not set — run get-tableau-token.sh' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV.fetch('TABLEAU_AUTH_TOKEN') { raise Error, 'TABLEAU_AUTH_TOKEN not set — run get-tableau-token.sh' }
+  end
+
+  def api_version
+    ENV.fetch('TABLEAU_API_VERSION', '3.22')
+  end
+
+  # Re-sign in with the PAT env vars and update the in-memory token. Thread-safe.
+  # Long-running scripts (hours) should call this before Tableau's session times
+  # out (cloud default: 240 min idle, can be much shorter under strict policies).
+  # Single-flight: concurrent callers all wait for one signin and share the result.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      name = ENV.fetch('TABLEAU_PAT_NAME')   { raise AuthError, 'TABLEAU_PAT_NAME not set — cannot refresh' }
+      secret = ENV.fetch('TABLEAU_PAT_SECRET'){ raise AuthError, 'TABLEAU_PAT_SECRET not set — cannot refresh' }
+      site_url = ENV.fetch('TABLEAU_SITE_CONTENT_URL') { raise AuthError, 'TABLEAU_SITE_CONTENT_URL not set' }
+      uri = URI.join(server_url, "/api/#{api_version}/auth/signin")
+      req = Net::HTTP::Post.new(uri)
+      req['Content-Type'] = 'application/xml'
+      req['Accept'] = 'application/json'
+      req.body = %(<tsRequest><credentials personalAccessTokenName="#{name}" personalAccessTokenSecret="#{secret}"><site contentUrl="#{site_url}"/></credentials></tsRequest>)
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "signin -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      j = JSON.parse(res.body)
+      @token_mutex.synchronize do
+        @token_override = j.dig('credentials', 'token')
+        @site_id_override = j.dig('credentials', 'site', 'id')
+      end
+      @token_override
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def base_path
+    "/api/#{api_version}/sites/#{site_id}"
+  end
+
+  # ---- low-level transport -------------------------------------------------
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI.join(server_url, path)
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get  then Net::HTTP::Get.new(uri)
+            when :post then Net::HTTP::Post.new(uri)
+            when :put  then Net::HTTP::Put.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['X-Tableau-Auth'] = auth_token
+      req['Accept'] = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https', read_timeout: 120) { |h| h.request(req) }
+            end
+      if res.code.to_i == 401 && attempts == 1 && ENV['TABLEAU_PAT_NAME']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+
+  # ---- workbooks -----------------------------------------------------------
+
+  # Returns the first workbook matching name, or nil. Use search_workbooks for full list.
+  def find_workbook_by_name(name)
+    encoded = CGI.escape("name:eq:#{name}")
+    j = request(:get, "#{base_path}/workbooks?filter=#{encoded}")
+    list = j.dig('workbooks', 'workbook') || []
+    list = [list] unless list.is_a?(Array)
+    list.first
+  end
+
+  def get_workbook(workbook_id)
+    request(:get, "#{base_path}/workbooks/#{workbook_id}")['workbook']
+  end
+
+  # Returns the raw .twb XML (string) or .twbx bytes for workbooks with embedded extracts.
+  # Embedded check: if the response starts with PK\x03\x04 it's a zip (twbx); otherwise raw XML.
+  def download_workbook_content(workbook_id, include_extract: false)
+    qs = include_extract ? '' : '?includeExtract=false'
+    request(:get, "#{base_path}/workbooks/#{workbook_id}/content#{qs}",
+            accept: '*/*', binary: true)
+  end
+
+  # ---- views ---------------------------------------------------------------
+
+  def view_data(view_id)
+    request(:get, "#{base_path}/views/#{view_id}/data", accept: '*/*')
+  end
+
+  def view_image(view_id, width: 1400, height: 900, resolution: 'high')
+    qs = "?resolution=#{resolution}&maxAge=1"
+    qs += "&vf_width=#{width}&vf_height=#{height}" if width && height
+    request(:get, "#{base_path}/views/#{view_id}/image#{qs}", accept: '*/*', binary: true)
+  end
+
+  # ---- datasources ---------------------------------------------------------
+
+  def list_datasources(page_size: 100, page: 1)
+    request(:get, "#{base_path}/datasources?pageSize=#{page_size}&pageNumber=#{page}")
+  end
+
+  def find_datasource_by_name(name)
+    encoded = CGI.escape("name:eq:#{name}")
+    j = request(:get, "#{base_path}/datasources?filter=#{encoded}")
+    list = j.dig('datasources', 'datasource') || []
+    list = [list] unless list.is_a?(Array)
+    list.first
+  end
+
+  # VizQL Data Service — full field list with calc formulas. This is the REST equivalent
+  # of mcp__tableau__get-datasource-metadata.
+  def read_metadata(datasource_luid)
+    body = { datasource: { datasourceLuid: datasource_luid } }.to_json
+    request(:post, "/api/v1/vizql-data-service/read-metadata", body: body)
+  end
+
+  # ---- metadata GraphQL ----------------------------------------------------
+
+  # Convenience: fetch a published datasource by luid, returning fields + calc formulas.
+  # Cleaner display names than read_metadata (which uses GUIDs for fields belonging to
+  # joined logical tables).
+  def graphql_datasource_fields(datasource_luid)
+    query = <<~GQL
+      {
+        publishedDatasources(filter:{luid:"#{datasource_luid}"}) {
+          name luid
+          fields {
+            name
+            fullyQualifiedName
+            ... on CalculatedField { formula isHidden }
+          }
+        }
+      }
+    GQL
+    body = { query: query }.to_json
+    request(:post, "/api/metadata/graphql", body: body)
+  end
+
+  def graphql(query, variables: nil)
+    payload = { query: query }
+    payload[:variables] = variables if variables
+    request(:post, "/api/metadata/graphql", body: payload.to_json)
+  end
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/migrate-quicksight.rb
@@ -1,0 +1,642 @@
+#!/usr/bin/env ruby
+# migrate-quicksight.rb — ONE-SHOT, single-process orchestrator for the
+# quicksight-to-sigma pipeline. Runs the whole phased workflow in one Ruby
+# process to cut agent turns / token cost, WITHOUT turning the migration into a
+# black box: every phase prints a visible header + concise result, and the
+# genuine human decision points are surfaced as a structured OPEN QUESTIONS
+# block (exit 10) rather than silently auto-resolved.
+#
+# This script does NOT re-implement any phase — it chains the existing scripts:
+#   quicksight-discover.py [--from-fixtures]                       (Phase 1)
+#   convert-model.rb --emit-mcp → MCP gate → --converted resume,
+#     or a local sigma-data-model-mcp build via a node shim        (Phase 2)
+#   qs-dm-signature.py + find-or-pick-dm.rb (DM-reuse check)       (Phase 2.5)
+#   convert-model.rb --fixup --folder-id + validate-spec.rb
+#     + post-and-readback.rb                                       (Phase 3/DM)
+#   build-workbook-from-quicksight.rb + post-and-readback.rb       (Phase 4/workbook)
+#   build-quicksight-layout.rb (fixed 36-col inference) + put-layout.rb (Phase 5)
+#   phase6-parity-quicksight.rb two-pass (emit query list → MCP gate →
+#     --actuals/--expected resume) + assert-phase6-ran.rb --workdir (Phase 6/parity)
+#
+# Usage (live):
+#   ruby scripts/migrate-quicksight.rb \
+#     --analysis-id <ID> --account-id <ACCT> --region <REGION> --profile <PROFILE> \
+#     --connection <SIGMA_CONNECTION_ID> --folder <SIGMA_FOLDER_ID-or-name> \
+#     [--database DB --schema SCH] [--name "My Dashboard"] \
+#     [--out DIR] [--answers '<json>'] [--yes]
+#   --folder accepts a folder id OR an exact folder NAME (looked up via
+#   /v2/files; ambiguous names abort with the candidate ids).
+#
+# IDEMPOTENT RESUME: re-running with the same --out after a mid-run crash
+# NEVER duplicates the DM or workbook — ids already posted by this workdir
+# (dm-readback.json / wb-id.txt) are verified live and reused. Use a fresh
+# --out (or delete the workdir) to force a fresh build.
+#
+# Usage (offline fixtures — no AWS needed):
+#   ruby scripts/migrate-quicksight.rb --from-fixtures fixtures/ \
+#     --connection <ID> --folder <ID> --database DB --schema SCH --yes
+#
+# RESUME PATTERNS (each gate prints its own exact resume command):
+#   converter MCP gate → re-run with --converted <mcp-tool-result.json>
+#   parity MCP gate    → write <out>/parity-expected.json + parity-actuals.json
+#                        (or pass --expected/--actuals) and re-run; phases 1-5
+#                        are skipped automatically when their artifacts exist.
+#
+# Exit codes: 0 = done (parity + hard gate pass); 10 = gate/decisions (printed);
+#             3 = parity fail; other = error.
+require 'json'
+require 'optparse'
+require 'fileutils'
+require 'open3'
+require_relative 'lib/scout_gate'
+
+HERE = __dir__
+$LOAD_PATH.unshift File.expand_path('lib', HERE)
+
+opts = { region: 'us-east-1' }
+OptionParser.new do |o|
+  o.on('--analysis-id ID')  { |v| opts[:analysis] = v }
+  o.on('--account-id ID')   { |v| opts[:account]  = v }
+  o.on('--region R')        { |v| opts[:region]   = v }
+  o.on('--profile P')       { |v| opts[:profile]  = v }
+  o.on('--from-fixtures D') { |v| opts[:fixtures] = File.expand_path(v) }
+  o.on('--connection ID')   { |v| opts[:conn]     = v }
+  o.on('--database DB')     { |v| opts[:db]       = v }
+  o.on('--schema SCH')      { |v| opts[:schema]   = v }
+  o.on('--folder ID')       { |v| opts[:folder]   = v }
+  o.on('--name NAME')       { |v| opts[:name]     = v }
+  o.on('--out DIR')         { |v| opts[:out]      = File.expand_path(v) }
+  o.on('--answers JSON')    { |v| opts[:answers]  = v }
+  o.on('--yes')             {     opts[:yes]      = true }
+  # converter MCP-gate resume: the convert_quicksight_to_sigma MCP tool result.
+  o.on('--converted PATH')  { |v| opts[:converted] = File.expand_path(v) }
+  o.on('--mcp-dir DIR')     { |v| opts[:mcp_dir]   = File.expand_path(v) }
+  # DM-reuse (Phase 2.5). Default = build new; --reuse-dm attaches to an
+  # existing DM (skips Phase 3); --skip-reuse-check skips the scan entirely.
+  o.on('--reuse-dm ID')     { |v| opts[:reuse_dm] = v }
+  o.on('--skip-reuse-check'){     opts[:skip_reuse] = true }
+  # parity MCP-gate resume inputs (defaults: <out>/parity-expected.json + parity-actuals.json).
+  o.on('--expected PATH')   { |v| opts[:expected] = File.expand_path(v) }
+  o.on('--actuals PATH')    { |v| opts[:actuals]  = File.expand_path(v) }
+  o.on('--extract-mode')    {     opts[:extract]  = true }
+  o.on('--extract-tol F', Float) { |v| opts[:tol] = v }
+end.parse!
+
+abort 'missing --analysis-id (or --from-fixtures)' unless opts[:analysis] || opts[:fixtures]
+abort 'missing --account-id (live discovery)' if opts[:analysis] && !opts[:fixtures] && !opts[:account]
+abort 'missing --connection' unless opts[:conn]
+if opts[:conn] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+  abort "FATAL: --connection must be a FULL Sigma connection UUID (8-4-4-4-12 hex); got #{opts[:conn].inspect}"
+end
+
+# Local converter build. The skill defers DM conversion to the sigma-data-model-mcp
+# `convert_quicksight_to_sigma` tool; that tool is an ESM module not loadable from a
+# plain shell, so we import its exported convertQuickSightToSigma() directly via a tiny
+# node shim. No hardcoded developer paths (mirrors migrate-powerbi.rb): resolve from
+# --mcp-dir / QS_MCP_DIR, else probe common clone locations under $HOME. When NONE is
+# found, Phase 2 does NOT abort — it prints the convert-model.rb --emit-mcp request and
+# gates; resume with --converted <mcp tool result> (the default route without a build).
+MCP_DIR = [opts[:mcp_dir], ENV['QS_MCP_DIR'],
+           File.expand_path('~/Desktop/sigma-data-model-mcp'),
+           File.expand_path('~/sigma-data-model-mcp')]
+          .compact.find { |d| File.exist?(File.join(d, 'build', 'quicksight.js')) }
+
+name_slug = (opts[:analysis] || File.basename(opts[:fixtures].to_s)).gsub(/[^A-Za-z0-9_-]/, '-')
+WORK = opts[:out] || File.expand_path("~/quicksight-migration/#{name_slug}")
+FileUtils.mkdir_p(WORK)
+
+def hdr(n, total, title)
+  puts
+  puts "── Phase #{n}/#{total} · #{title} ──"
+end
+
+def run!(cmd, env: {})
+  out, st = Open3.capture2e(env, *cmd)
+  out.each_line { |l| puts "   #{l.rstrip}" } unless out.strip.empty?
+  abort "FATAL: command failed (#{st.exitstatus}): #{cmd.join(' ')}" unless st.success?
+  out
+end
+
+TOTAL = 6
+
+# ---- parity-resume detection (phases 1-5 already ran; finalize only) -------
+exp_path   = opts[:expected] || File.join(WORK, 'parity-expected.json')
+act_path   = opts[:actuals]  || File.join(WORK, 'parity-actuals.json')
+wb_id_path = File.join(WORK, 'wb-id.txt')
+resume_parity = File.exist?(wb_id_path) && File.exist?(exp_path) && File.exist?(act_path)
+
+dm_id = nil
+wb_id = nil
+
+if resume_parity
+  wb_id = File.read(wb_id_path).strip
+  dm_id = (JSON.parse(File.read(File.join(WORK, 'dm-readback.json')))['dataModelId'] rescue '?')
+  puts "── resuming at Phase 6 (parity finalize) — workbook #{wb_id}, dm #{dm_id} ──"
+else
+
+# ---------------------------------------------------------------------------
+# Phase 1 — Discover (live AWS, --from-fixtures, or reuse of a prior run)
+# ---------------------------------------------------------------------------
+hdr(1, TOTAL, 'Discover')
+# idempotent resume: a prior run's discovery artifacts in WORK are reused
+# (the --converted gate-resume relies on this — don't re-hit AWS).
+if File.exist?(File.join(WORK, 'analysis.json')) && File.exist?(File.join(WORK, 'signals.json')) &&
+   Dir[File.join(WORK, 'datasets', '*.json')].any?
+  puts "   reusing discovery artifacts already in #{WORK}"
+elsif opts[:fixtures]
+  run!(['python3', File.join(HERE, 'quicksight-discover.py'),
+        '--from-fixtures', opts[:fixtures], '--out-dir', WORK])
+else
+  disc_cmd = ['python3', File.join(HERE, 'quicksight-discover.py'),
+              '--account-id', opts[:account], '--region', opts[:region],
+              '--analysis-id', opts[:analysis], '--out-dir', WORK]
+  disc_cmd += ['--profile', opts[:profile]] if opts[:profile]
+  run!(disc_cmd)
+end
+
+signals = JSON.parse(File.read(File.join(WORK, 'signals.json')))
+an_name = signals.dig('source', 'name') || opts[:analysis]
+all_visuals = signals['sheets'].flat_map { |s| s['visuals'] }
+vkinds = all_visuals.map { |v| v['type'].to_s.sub(/Visual$/, '').sub(/Chart$/, '') }
+vcount = vkinds.each_with_object(Hash.new(0)) { |k, h| h[k] += 1 }
+vsumm = vcount.map { |k, c| c > 1 ? "#{k}×#{c}" : k }.join(', ')
+puts "   analysis '#{an_name}': #{signals['datasets'].size} dataset(s), " \
+     "#{all_visuals.size} visual(s) (#{vsumm}), #{signals['parameters'].size} param(s), " \
+     "#{signals['calculatedFields'].size} calc field(s)"
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Convert. Three routes (in priority order):
+#   a) --converted <file>: the convert_quicksight_to_sigma MCP TOOL already ran
+#      (gate-resume — the default route on machines without a local build)
+#   b) a local sigma-data-model-mcp build: run it in-process via a node shim
+#   c) neither: print the exact MCP request (convert-model.rb --emit-mcp) and
+#      GATE — re-run with --converted <the tool's result JSON>.
+# ---------------------------------------------------------------------------
+hdr(2, TOTAL, 'Convert')
+ds_files = Dir[File.join(WORK, 'datasets', '*.json')].sort
+conv_files = [File.join(WORK, 'analysis.json')] + ds_files
+
+if opts[:converted]
+  abort "FATAL: --converted not found: #{opts[:converted]}" unless File.exist?(opts[:converted])
+  FileUtils.cp(opts[:converted], File.join(WORK, 'converter-out.json')) unless
+    File.expand_path(opts[:converted]) == File.join(WORK, 'converter-out.json')
+  puts "   converter output ingested from #{opts[:converted]} (MCP-tool route)"
+elsif MCP_DIR
+  shim = File.join(WORK, '_convert.mjs')
+  File.write(shim, <<~JS)
+    import { readFileSync, writeFileSync } from 'node:fs';
+    import { convertQuickSightToSigma } from #{File.join(MCP_DIR, 'build', 'quicksight.js').to_json};
+    const files = #{conv_files.to_json}.map(p => ({ name: p.split('/').pop(), content: readFileSync(p, 'utf8') }));
+    const out = convertQuickSightToSigma(files, {
+      connectionId: #{opts[:conn].to_json},
+      database: #{(opts[:db] || ENV['QS_DB'] || '').to_json},
+      schema: #{(opts[:schema] || ENV['QS_SCHEMA'] || '').to_json},
+    });
+    writeFileSync(#{File.join(WORK, 'converter-out.json').to_json}, JSON.stringify(out, null, 2));
+    // emit a one-line machine summary on stderr for the orchestrator
+    const w = out.warnings || [];
+    process.stderr.write('CONVSTATS ' + JSON.stringify({ warnings: w, stats: out.stats || {} }) + '\\n');
+  JS
+  c_out, c_err, c_st = Open3.capture3('node', shim)
+  puts "   converter ran (build: #{MCP_DIR})"
+  abort "FATAL: converter failed:\n#{c_err}#{c_out}" unless c_st.success?
+else
+  puts '   no local sigma-data-model-mcp build found (set --mcp-dir / QS_MCP_DIR for the in-process route).'
+  puts
+  emit = ['ruby', File.join(HERE, 'convert-model.rb'), '--emit-mcp',
+          '--discover-dir', WORK, '--connection-id', opts[:conn]]
+  emit += ['--database', opts[:db]] if opts[:db]
+  emit += ['--schema', opts[:schema]] if opts[:schema]
+  run!(emit)
+  puts
+  puts '   >>> GATE: run the convert_quicksight_to_sigma MCP tool exactly as printed'
+  puts '       above, save the tool result JSON to a file, then re-run this command'
+  puts "       with --converted <that file>. No Sigma objects were created."
+  exit 10
+end
+conv = JSON.parse(File.read(File.join(WORK, 'converter-out.json')))
+conv_warnings = conv['warnings'] || []
+# The converter output is {model|sigmaDataModel, warnings, stats}. convert-model.rb
+# --fixup unwraps sigmaDataModel/model itself, so we feed it the raw converter-out.json.
+model = conv['sigmaDataModel'] || conv['model'] || conv
+el_ct = (model['pages'] || []).flat_map { |p| p['elements'] || [] }.size
+puts "   #{el_ct} DM element(s) emitted; #{conv_warnings.size} converter warning(s)"
+
+# ---------------------------------------------------------------------------
+# DECISIONS CHECKPOINT — surface the genuine human questions
+# ---------------------------------------------------------------------------
+questions = []
+
+# (a) calc fields / measures degraded to Null (window / table-calc — no Sigma translation)
+window_warns = conv_warnings.select do |w|
+  w.to_s =~ /window|table-calc|runningSum|percentOfTotal|periodOverPeriod|sumOver|rank|percentile|Null|degrad/i
+end
+window_warns.each do |w|
+  questions << { 'id' => 'calc_degraded', 'severity' => 'review',
+                 'detail' => w.to_s.gsub(/\s+/, ' ').strip,
+                 'options' => ['proceed (column degrades to Null, original expr kept in description)', 'abort and re-author manually'],
+                 'default' => 'proceed' }
+end
+
+# (b) visuals with no NATIVE Sigma kind ((c)-tail). Keep this list in lock-step with
+# build-workbook-from-quicksight.rb's QS_UNSUPPORTED / QS_FALLBACK maps.
+APPROX = {
+  'TreeMapVisual'       => 'approximate-to-bar',
+  'FunnelChartVisual'   => 'approximate-to-bar',
+  'WaterfallVisual'     => 'approximate-to-bar',
+  'HistogramVisual'     => 'approximate-to-bar',
+  'GaugeChartVisual'    => 'approximate-to-kpi',
+  'HeatMapVisual'       => 'data-migrate-as-table',
+  'BoxPlotVisual'       => 'data-migrate-as-table',
+  'SankeyDiagramVisual' => 'data-migrate-as-table',
+  'WordCloudVisual'     => 'data-migrate-as-table',
+  'RadarChartVisual'    => 'data-migrate-as-table'
+}.freeze
+DROP = %w[InsightVisual CustomContentVisual PluginVisual LayerMapVisual EmptyVisual].freeze
+all_visuals.each do |v|
+  t = v['type']
+  if APPROX.key?(t)
+    questions << { 'id' => 'visual_no_native_kind', 'severity' => 'review',
+                   'visual' => v['title'] || v['visualId'], 'qs_type' => t,
+                   'detail' => "#{t} has no native Sigma element kind",
+                   'options' => [APPROX[t], 'skip this visual'], 'default' => APPROX[t] }
+  elsif DROP.include?(t)
+    questions << { 'id' => 'visual_unmigratable', 'severity' => 'review',
+                   'visual' => v['title'] || v['visualId'], 'qs_type' => t,
+                   'detail' => "#{t} has no Sigma equivalent and no field-well to data-migrate",
+                   'options' => ['skip (record in warning manifest)'], 'default' => 'skip (record in warning manifest)' }
+  end
+end
+
+# (c) scatter bubble-size channel dropped
+all_visuals.select { |v| v['type'] == 'ScatterPlotVisual' }.each do |v|
+  inner = nil
+  # cheap detection: a scatter with >2 referenced measures usually carries a Size field
+  if (v['columns'] || []).size > 2
+    questions << { 'id' => 'scatter_bubble_size', 'severity' => 'review',
+                   'visual' => v['title'] || v['visualId'],
+                   'detail' => 'QuickSight scatter bubble-size channel has no Sigma scatter size channel; bubbles render uniform-size (measure still projected as a column)',
+                   'options' => ['proceed (uniform bubbles)', 'skip this visual'], 'default' => 'proceed (uniform bubbles)' }
+  end
+end
+
+# (d) connection / folder not supplied
+unless opts[:conn]
+  questions << { 'id' => 'connection', 'severity' => 'required',
+                 'detail' => 'No Sigma --connection supplied; required to point the DM at the warehouse',
+                 'options' => ['supply --connection <id>'], 'default' => nil }
+end
+unless opts[:folder]
+  questions << { 'id' => 'folder', 'severity' => 'required',
+                 'detail' => 'No Sigma --folder supplied; DM + workbook will land in My Documents',
+                 'options' => ['supply --folder <id>', 'proceed into My Documents'], 'default' => 'proceed into My Documents' }
+end
+
+# RUN-EACH-TIME GAP-SCOUT GATE (bead beads-sigma-5l5e). Degraded calcs are
+# scout-eligible — the gap-scout must ATTEMPT a Sigma translation for each
+# before we accept the Null degradation. --yes does NOT skip this; it only
+# accepts calcs the scout already tried (validated locally, or escalated). The
+# scout records each to <WORK>/scout-ledger.jsonl via scout-validate-and-persist.
+calc_gaps = questions.select { |q| q['id'] == 'calc_degraded' }
+unless calc_gaps.empty?
+  gid = ->(q) { "calc:" + q['detail'].to_s.gsub(/\s+/, ' ').strip[0, 80] }
+  gap_ids = calc_gaps.map { |q| gid.call(q) }.uniq
+  buckets = ScoutGate.classify(WORK, gap_ids)
+  if buckets[:unscouted].any?
+    unattended = opts[:yes] || opts[:answers]
+    if unattended
+      # Regression fix (gap-scout PR #153 made this a hard `exit 11` that overrode
+      # --yes, stalling the unattended/demo path). Under --yes/--answers the gate is
+      # ADVISORY: these calcs take their "proceed" default (already in the decisions
+      # list) and the run flows through. Record as accepted so re-runs don't re-surface
+      # them; recommend the gap-scout for anyone who wants a faithful translation.
+      warn "   gap-scout: #{buckets[:unscouted].size} degraded calc(s) not scouted — proceeding (unattended); recording as accepted degradations."
+      warn '   (optional: run scripts/gap-scout.md on these to persist a faithful Sigma translation)'
+      buckets[:unscouted].each { |id| ScoutGate.record(WORK, gap_id: id, feature: 'calc', status: 'accepted') }
+    else
+      # Interactive: the same calcs already appear as review questions and exit via
+      # the OPEN QUESTIONS block below (exit 10). Just nudge toward the scout.
+      puts
+      puts '-------------------- GAP-SCOUT RECOMMENDED --------------------'
+      puts "#{buckets[:unscouted].size} of #{gap_ids.size} degraded calc(s) have no faithful translation yet:"
+      buckets[:unscouted].each { |id| puts "  --gap-id '#{id}'" }
+      puts ''
+      puts 'Optional: spawn a gap-scout per calc (scripts/gap-scout.md) with the --gap-id above'
+      puts "plus --workdir #{WORK} to persist a translation; or re-run with --yes to accept the"
+      puts 'degradation defaults. These also appear in OPEN QUESTIONS below.'
+      puts '---------------------------------------------------------------'
+    end
+  else
+    puts "   gap-scout: all #{gap_ids.size} degraded calc(s) accounted for (validated or escalated)"
+  end
+end
+
+answers = nil
+if opts[:answers]
+  answers = JSON.parse(opts[:answers]) rescue abort("FATAL: --answers is not valid JSON")
+end
+
+if questions.any? && !opts[:yes] && answers.nil?
+  block = {
+    'status' => 'decisions_needed',
+    'analysis' => an_name,
+    'phases_completed' => ['1 Discover', '2 Convert'],
+    'note' => 'Deterministic mechanical steps (fixup, POST, layout, parity) are NOT asked about. ' \
+              'Re-run with --yes to accept all defaults, or --answers \'{"<id>":"<choice>"}\' to override.',
+    'open_questions' => questions
+  }
+  puts
+  puts '==================== OPEN QUESTIONS ===================='
+  puts JSON.pretty_generate(block)
+  puts '======================================================='
+  puts
+  puts "#{questions.size} decision(s) need a human. No Sigma objects were created."
+  exit 10
+end
+
+if questions.any?
+  puts
+  puts "   decisions auto-resolved (#{opts[:yes] ? '--yes: defaults' : '--answers supplied'}):"
+  questions.each do |q|
+    chosen = (answers && answers[q['id']]) || q['default']
+    puts "     - #{q['id']}#{q['visual'] ? " [#{q['visual']}]" : ''}: #{chosen}"
+  end
+else
+  puts "   no open questions — running straight through"
+end
+
+# ---------------------------------------------------------------------------
+# Phase 2.5 — DM reuse check (qs-dm-signature.py + find-or-pick-dm.rb).
+# DEFAULT = BUILD NEW. The scan is informational: it surfaces a reusable
+# candidate (avoids a 4th near-identical "Orders" DM) and the exact flag to
+# attach to it (--reuse-dm <id>), but never silently reuses.
+# ---------------------------------------------------------------------------
+require 'sigma_rest' # also loads ~/.sigma-migration/env for the child scripts
+
+# --folder accepts a NAME or an id (bead eqom): anything that isn't a UUID is
+# looked up by exact (case-insensitive) folder name via /v2/files.
+if opts[:folder] && opts[:folder] !~ /\A\h{8}-\h{4}-\h{4}-\h{4}-\h{12}\z/
+  want = opts[:folder].strip.downcase
+  entries = (Sigma.request(:get, '/v2/files?typeFilters=folder&limit=500')['entries'] rescue []) || []
+  hits = entries.select { |e| (e['name'] || '').strip.downcase == want }
+  abort "FATAL: --folder #{opts[:folder].inspect} matched no folder by name — list them via GET /v2/files?typeFilters=folder, or pass an id" if hits.empty?
+  abort "FATAL: --folder #{opts[:folder].inspect} is ambiguous (#{hits.size} folders named that): #{hits.map { |h| h['id'] }.join(', ')} — pass an id" if hits.size > 1
+  puts "   --folder resolved by name: '#{hits[0]['name']}' → #{hits[0]['id']}"
+  opts[:folder] = hits[0]['id']
+end
+
+hdr('2.5', TOTAL, 'DM reuse check')
+if opts[:reuse_dm]
+  puts "   --reuse-dm #{opts[:reuse_dm]} — attaching to the existing DM (Phase 3 skipped)"
+elsif opts[:skip_reuse]
+  puts '   skipped (--skip-reuse-check) — building a new DM'
+else
+  begin
+    sig_path = File.join(WORK, 'dm-signature.json')
+    run!(['python3', File.join(HERE, 'qs-dm-signature.py'),
+          '--discover-dir', WORK, '--out', sig_path])
+    match_path = File.join(WORK, 'dm-match.json')
+    fop_out, = Open3.capture2e('ruby', File.join(HERE, 'find-or-pick-dm.rb'),
+                               '--workbook-signature', sig_path, '--out', match_path,
+                               '--auto-pick', '--auto-pick-threshold', '0.5')
+    match = File.exist?(match_path) ? (JSON.parse(File.read(match_path)) rescue {}) : {}
+    # Reuse-first (matches thoughtspot-to-sigma): the picker sets auto_picked only
+    # when the top candidate covers ALL of this analysis's source tables — a safe
+    # reuse that collapses duplicate-DM ties. When it fires, route into the
+    # `elsif opts[:reuse_dm]` branch below (skips the DM POST).
+    if !opts[:reuse_dm] && match['auto_picked'] && match['recommended_dm_id']
+      opts[:reuse_dm] = match['recommended_dm_id']
+      puts "   DM-REUSE (auto): #{match['rationale']}"
+      puts "   WARNING: #{match['warning']}" if match['warning']
+    end
+    best = (match['candidates'] || []).first
+    if opts[:reuse_dm]
+      # auto-reuse fired — candidate hints would be misleading; stay quiet
+    elsif best && best['score'].to_f >= 0.6
+      puts "   candidate: '#{best['dm_name']}' (#{best['dm_id']}) score=#{best['score']} — " \
+           "#{(best['shared_columns'] || []).size} shared column(s), #{best['extra_columns']} inherited extra(s)"
+      puts "   default = BUILD NEW. To reuse it instead, re-run with --reuse-dm #{best['dm_id']}"
+    else
+      puts '   no reusable DM found (score < threshold) — building new'
+    end
+  rescue StandardError => e
+    puts "   reuse scan failed (#{e.message[0, 80]}) — building new (the scan is advisory only)"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Phase 3 — Fixup + POST data model (skipped when --reuse-dm attaches to one)
+# ---------------------------------------------------------------------------
+hdr(3, TOTAL, 'Build data model')
+dm_spec = File.join(WORK, 'dm-spec.json')
+dm_readback = File.join(WORK, 'dm-readback.json')
+# Idempotent resume BEFORE the parity state (bead eqom): a mid-run crash after
+# the DM POST must not create a duplicate DM on re-run. dm-readback.json is
+# written only by a successful post — when this workdir already has one,
+# verify the DM still exists and REUSE it.
+prior_dm = File.exist?(dm_readback) ? (JSON.parse(File.read(dm_readback))['dataModelId'] rescue nil) : nil
+if prior_dm && !opts[:reuse_dm]
+  if (Sigma.request(:get, "/v2/dataModels/#{prior_dm}") rescue nil)
+    dm_id = prior_dm
+    puts "   idempotent resume: dataModelId #{dm_id} was already posted by a prior run of"
+    puts "   this workdir — REUSING it (no duplicate DM). Use a fresh --out for a fresh build."
+  else
+    puts "   prior dataModelId #{prior_dm} in #{dm_readback} no longer exists — rebuilding"
+    prior_dm = nil
+  end
+end
+if dm_id
+  # reused above — nothing to post
+elsif opts[:reuse_dm]
+  # Read the existing DM's spec back and synthesize the dm-readback artifact the
+  # workbook builder consumes (element names/ids). The spec endpoint answers in
+  # YAML even when asked for JSON — parse both.
+  raw = Sigma.request(:get, "/v2/dataModels/#{opts[:reuse_dm]}/spec", binary: true)
+  spec = begin
+    JSON.parse(raw)
+  rescue JSON::ParserError
+    require 'yaml'
+    require 'date'
+    YAML.safe_load(raw, permitted_classes: [Date, Time]) || {}
+  end
+  dm_rb = { 'dataModelId' => opts[:reuse_dm] }.merge(spec)
+  File.write(dm_readback, JSON.pretty_generate(dm_rb))
+  dm_id = opts[:reuse_dm]
+  puts "   reusing dataModelId = #{dm_id} ('#{spec['name']}') — shape preflight: " \
+       "#{(spec['pages'] || []).flat_map { |p| p['elements'] || [] }.size} element(s) read back"
+else
+  fixup = ['ruby', File.join(HERE, 'convert-model.rb'), '--fixup',
+           '--in', File.join(WORK, 'converter-out.json'),
+           '--discover-dir', WORK, '--out', dm_spec]
+  fixup += ['--folder-id', opts[:folder]] if opts[:folder]
+  run!(fixup)
+  if opts[:name]
+    j = JSON.parse(File.read(dm_spec))
+    j['name'] = "#{opts[:name]} DM"
+    File.write(dm_spec, JSON.pretty_generate(j))
+  end
+  run!(['ruby', File.join(HERE, 'validate-spec.rb'), '--type', 'datamodel', dm_spec])
+  run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'datamodel',
+        '--spec', dm_spec, '--out', dm_readback, '--workdir', WORK])
+  dm_id = JSON.parse(File.read(dm_readback))['dataModelId']
+  puts "   dataModelId = #{dm_id}"
+end
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Build workbook
+# ---------------------------------------------------------------------------
+hdr(4, TOTAL, 'Build workbook')
+wb_spec = File.join(WORK, 'wb-spec.json')
+wb_readback = File.join(WORK, 'wb-readback.json')
+# Idempotent resume (bead eqom): a workbook already posted by this workdir is
+# reused — never duplicated. wb-id.txt is the primary record; wb-readback.json
+# still holds workbookId when the crash hit before wb-id.txt was written.
+prior_wb = File.exist?(wb_id_path) ? File.read(wb_id_path).strip : nil
+prior_wb = (JSON.parse(File.read(wb_readback))['workbookId'] rescue nil) if (prior_wb.nil? || prior_wb.empty?) && File.exist?(wb_readback)
+if prior_wb && !prior_wb.empty?
+  if (Sigma.request(:get, "/v2/workbooks/#{prior_wb}") rescue nil)
+    wb_id = prior_wb
+    File.write(wb_id_path, wb_id)
+    puts "   idempotent resume: workbook #{wb_id} was already posted by a prior run of"
+    puts "   this workdir — REUSING it (no duplicate workbook). Use a fresh --out for a fresh build."
+  else
+    puts "   prior workbookId #{prior_wb} no longer exists — rebuilding"
+  end
+end
+unless wb_id
+build = ['ruby', File.join(HERE, 'build-workbook-from-quicksight.rb'),
+         '--analysis', File.join(WORK, 'analysis.json'),
+         '--dm-readback', dm_readback, '--out', wb_spec]
+build += ['--dm-spec', dm_spec] if File.exist?(dm_spec)
+build += ['--discover-dir', WORK]   # datasets/*.json -> boolean-flag predicate rewrite (RCA #3)
+build += ['--folder-id', opts[:folder]] if opts[:folder]
+filters = File.join(WORK, 'dm-filters.json')
+build += ['--filters', filters] if File.exist?(filters)
+run!(build)
+if opts[:name]
+  j = JSON.parse(File.read(wb_spec))
+  j['name'] = opts[:name]
+  File.write(wb_spec, JSON.pretty_generate(j))
+end
+run!(['ruby', File.join(HERE, 'post-and-readback.rb'), '--type', 'workbook',
+      '--spec', wb_spec, '--out', wb_readback, '--workdir', WORK])
+wb_id = JSON.parse(File.read(wb_readback))['workbookId']
+# Phase 6 PASS 1 overwrites wb-readback.json with the live spec (no workbookId
+# key), so persist the id separately — the parity-finalize resume needs it.
+File.write(wb_id_path, wb_id)
+puts "   workbookId = #{wb_id}"
+end # unless wb_id (idempotent resume)
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Layout (build-quicksight-layout.rb infers the QS grid width — the
+# explicit-index 12/18/24/36-col cases — and emits the Sigma layout XML)
+# ---------------------------------------------------------------------------
+hdr(5, TOTAL, 'Layout')
+layout = File.join(WORK, 'layout.xml')
+run!(['ruby', File.join(HERE, 'build-quicksight-layout.rb'),
+      '--analysis', File.join(WORK, 'analysis.json'),
+      '--map', wb_spec.sub(/\.json$/, '') + '.map.json', '--out', layout])
+run!(['ruby', File.join(HERE, 'put-layout.rb'), '--workbook', wb_id, '--layout', layout])
+puts "   layout applied to workbook #{wb_id}"
+
+# ---------------------------------------------------------------------------
+# Phase 5b — Visual QA: render each CONTENT page to a FULL-PAGE PNG so the
+# layout can be reviewed against refs/layout-visual-qa.md AND compared to the
+# source QuickSight sheet — matching the other migration skills' visual-QA gate
+# (tableau/qlik Phase 5b). Render is NON-FATAL (a transient export failure must
+# not sink a green migration); the REVIEW is the gate, not the render.
+# ---------------------------------------------------------------------------
+require 'sigma_rest' # exposes Sigma.auth_token (override → SIGMA_API_TOKEN → refresh)
+vqa = File.join(WORK, 'visual-qa')
+FileUtils.mkdir_p(vqa)
+# Page ids come from the LOCAL spec the builder wrote (<WORK>/wb-spec.json) —
+# deterministic. The live GET /spec readback proved flaky in the pipeline
+# (returns YAML / silently zero pages); POST preserves these ids, so the local
+# copy is authoritative. Exclude any id containing "data" (hidden data pages).
+wbspec = (JSON.parse(File.read(wb_spec)) rescue {})
+content_pages = (wbspec['pages'] || []).reject { |p| p['id'].to_s.downcase.include?('data') }
+tok = (Sigma.auth_token rescue ENV['SIGMA_API_TOKEN'])
+pngs = []
+content_pages.each do |pg|
+  out = File.join(vqa, "#{pg['id']}.png")
+  _o, st = Open3.capture2e({ 'SIGMA_API_TOKEN' => tok.to_s }, 'python3',
+                           File.join(HERE, 'sigma-export-png.py'),
+                           '--workbook', wb_id, '--page', pg['id'], '--out', out,
+                           '--w', '1800', '--h', '1000')
+  st.success? ? (pngs << out) : (puts "   [warn] visual-QA render failed for page #{pg['id']}")
+end
+puts "   rendered #{pngs.size}/#{content_pages.size} full-page PNG(s) for visual QA → #{vqa}"
+if pngs.any?
+  puts '   VISUAL QA (mandatory review — do not skip): open each PNG and check vs'
+  puts '   refs/layout-visual-qa.md AND the source QuickSight sheet — populated controls,'
+  puts '   titles present, right chart kinds, sensible colors/heights, no overlaps/dead zones.'
+end
+
+end # resume_parity skip of phases 1-5
+
+# ---------------------------------------------------------------------------
+# Phase 6 — Parity (two-pass, hard-gated):
+#   guard  — no workbook column resolved to type "error"
+#   PASS 1 — phase6-parity-quicksight.rb emits parity-plan.json + the per-chart
+#            sigma-mcp-v2 query list, then GATES (exit 10): the agent collects
+#            Sigma ACTUAL rows + warehouse EXPECTED rows and re-runs (resume).
+#   PASS 2 — --finalize + assert-phase6-ran.rb --workdir (the hard gate).
+# ---------------------------------------------------------------------------
+hdr(6, TOTAL, 'Parity (two-pass, hard-gated)')
+require 'sigma_rest'
+cols = (Sigma.request(:get, "/v2/workbooks/#{wb_id}/columns") rescue { 'entries' => [] })
+err_cols = (cols['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }
+total_cols = (cols['entries'] || []).size
+unless err_cols.empty?
+  puts "   GUARD FAIL — #{err_cols.size}/#{total_cols} column(s) resolved to type 'error':"
+  err_cols.first(8).each { |c| puts "     [#{c['elementId']}] #{c['label']}: #{c['formula']}" }
+  exit 3
+end
+puts "   guard: #{total_cols} workbook column(s) resolve (0 error-typed)"
+
+have_parity_inputs = File.exist?(exp_path) && File.exist?(act_path)
+unless File.exist?(File.join(WORK, 'parity-plan.json')) && have_parity_inputs
+  run!(['ruby', File.join(HERE, 'phase6-parity-quicksight.rb'),
+        '--workdir', WORK, '--workbook-id', wb_id])
+end
+
+unless have_parity_inputs
+  puts
+  puts '   >>> GATE: collect the Sigma ACTUAL rows (sigma-mcp-v2 queries above) and the'
+  puts '       warehouse EXPECTED rows (same dim+aggregation, type=connection query), write'
+  puts "         #{exp_path}"
+  puts "         #{act_path}"
+  puts '       then RE-RUN THIS SAME COMMAND — phases 1-5 are skipped automatically'
+  puts '       (or pass --expected/--actuals explicitly).'
+  exit 10
+end
+
+fin = ['ruby', File.join(HERE, 'phase6-parity-quicksight.rb'),
+       '--workdir', WORK, '--finalize', '--expected', exp_path, '--actuals', act_path]
+fin += ['--extract-mode', '--extract-tol', (opts[:tol] || 0.30).to_s] if opts[:extract]
+fin_out, fin_st = Open3.capture2e(*fin)
+fin_out.each_line { |l| puts "   #{l.rstrip}" }
+parity_ok = fin_st.success?
+
+# the shared HARD GATE: parity sentinel + orphan + error-column + layout checks.
+gate_out, gate_st = Open3.capture2e('ruby', File.join(HERE, 'assert-phase6-ran.rb'),
+                                    '--workdir', WORK, '--workbook-id', wb_id)
+gate_out.each_line { |l| puts "   #{l.rstrip}" }
+gate_ok = gate_st.success?
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+puts
+puts '================ RESULT ================'
+puts "dataModelId : #{dm_id}"
+puts "workbookId  : #{wb_id}"
+puts "PARITY      : #{parity_ok ? 'PASS' : 'FAIL'} (#{total_cols} cols resolve, 0 error)"
+puts "HARD GATE   : #{gate_ok ? 'PASS' : 'FAIL'} (assert-phase6-ran)"
+wf = File.join(WORK, 'wb-spec.warnings.json')
+if File.exist?(wf)
+  wl = (JSON.parse(File.read(wf))['warnings'] rescue []) || []
+  puts "warnings    : #{wl.size} (see #{wf})" unless wl.empty?
+end
+puts '======================================='
+exit(parity_ok && gate_ok ? 0 : 3)

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/phase6-parity-quicksight.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/phase6-parity-quicksight.rb
@@ -1,0 +1,203 @@
+#!/usr/bin/env ruby
+# Phase 7 (MANDATORY) — verify Sigma chart values match the QuickSight source.
+#
+# QuickSight's describe-*-definition APIs return definitions, not data, so the
+# EXPECTED side comes from the warehouse (the same tables the QS dataset reads):
+# the agent computes each chart's aggregation with a warehouse SQL query
+# (mcp__sigma-mcp-v2__query type=connection) or, when live QS access exists,
+# from a QS export. The ACTUAL side is the built Sigma element. This script
+# orchestrates both passes and writes the parity-final.json sentinel that
+# assert-phase6-ran.rb (the hard gate) requires.
+#
+# PASS 1 — read the workbook spec, enumerate chart elements, emit per-chart
+# fetch instructions:
+#
+#   ruby scripts/phase6-parity-quicksight.rb --workdir /tmp/<name> \
+#     --workbook-id <wb>
+#
+#   Writes <workdir>/parity-plan.json and prints, per chart:
+#     - the mcp__sigma-mcp-v2__query call for the Sigma ACTUAL rows
+#     - a reminder to compute EXPECTED rows from the warehouse with the
+#       same dimension + aggregation
+#
+#   The agent then writes two JSON files keyed by chart name, each
+#   { "<chart name>": [[dim, val], ...], ... } :
+#     <workdir>/parity-expected.json   (warehouse / QS ground truth)
+#     <workdir>/parity-actuals.json    (Sigma element rows)
+#   KPI charts have no dimension — use [[null, <value>]].
+#
+# PASS 2 — finalize:
+#
+#   ruby scripts/phase6-parity-quicksight.rb --workdir /tmp/<name> --finalize \
+#     [--expected <workdir>/parity-expected.json] \
+#     [--actuals  <workdir>/parity-actuals.json] \
+#     [--extract-mode] [--extract-tol 0.30]
+#
+#   Runs verify-parity.rb, prints the pass/fail summary, writes
+#   parity-final.txt + parity-final.json (the hard-gate sentinel).
+#
+# Plain `table` elements aren't auto-planned (no single dim/measure axis) —
+# query-verify those manually and note it in the migration report.
+
+require 'json'
+require 'optparse'
+require 'open3'
+require 'time'
+
+opts = { extract_mode: false, extract_tol: 0.30, finalize: false }
+OptionParser.new do |p|
+  p.on('--workdir DIR')          { |v| opts[:dir] = v }
+  p.on('--workbook-id ID')       { |v| opts[:wb] = v }
+  p.on('--finalize')             { opts[:finalize] = true }
+  p.on('--expected PATH')        { |v| opts[:expected] = v }
+  p.on('--actuals PATH')         { |v| opts[:actuals] = v }
+  p.on('--extract-mode')         { opts[:extract_mode] = true }
+  p.on('--extract-tol F', Float) { |v| opts[:extract_tol] = v }
+end.parse!
+abort('missing --workdir') unless opts[:dir]
+
+plan_path = File.join(opts[:dir], 'parity-plan.json')
+
+def parse_spec(body)
+  JSON.parse(body)
+rescue JSON::ParserError
+  require 'yaml'
+  require 'date'
+  YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+end
+
+# Resolve the (dim, val) columns for a chart element, by kind. Returns
+# [[dim_id, dim_name], [val_id, val_name]] (dim pair nil for KPI) or nil if not
+# plannable. The IDs matter: sigma-mcp-v2 workbook queries resolve COLUMN IDS, not
+# display labels — SQL emitted against display names fails to resolve.
+def chart_columns(el)
+  cols = el['columns'] || []
+  by_id = cols.each_with_object({}) { |c, h| h[c['id']] = c['name'] }
+  case el['kind']
+  when 'kpi-chart'
+    vid = el.dig('value', 'columnId') || el.dig('value', 'id')
+    by_id[vid] && [nil, [vid, by_id[vid]]]
+  when 'pie-chart', 'donut-chart'
+    did = el.dig('color', 'id') || el.dig('color', 'columnId')
+    vid = el.dig('value', 'id') || el.dig('value', 'columnId')
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
+  else # bar-chart, line-chart, combo-chart, scatter-chart, ...
+    did = el.dig('xAxis', 'columnId')
+    vid = Array(el.dig('yAxis', 'columnIds')).first
+    vid = vid['columnId'] if vid.is_a?(Hash) # combo dual-axis object form
+    by_id[did] && by_id[vid] ? [[did, by_id[did]], [vid, by_id[vid]]] : nil
+  end
+end
+
+if !opts[:finalize]
+  abort('--workbook-id required for pass 1') unless opts[:wb]
+  $LOAD_PATH.unshift File.expand_path('lib', __dir__)
+  require 'sigma_rest'
+
+  warn "Phase 7 PASS 1: reading workbook spec #{opts[:wb]}"
+  # binary:true returns the raw body — the spec endpoint answers in YAML even
+  # when asked for JSON, so parse both.
+  raw = Sigma.request(:get, "/v2/workbooks/#{opts[:wb]}/spec", binary: true)
+  spec = parse_spec(raw)
+  File.write(File.join(opts[:dir], 'wb-readback.json'), JSON.pretty_generate(spec))
+
+  charts = []
+  Array(spec['pages']).each do |page|
+    Array(page['elements']).each do |el|
+      next unless el['kind'].to_s.end_with?('-chart')
+      pairs = chart_columns(el)
+      next unless pairs
+      charts << { 'chart' => el['name'], 'sigma_element_id' => el['id'],
+                  'kind' => el['kind'],
+                  'sigma_columns' => pairs.compact.map { |id_name| id_name[1] },
+                  'sigma_column_ids' => pairs.compact.map { |id_name| id_name[0] },
+                  'workbook_id' => opts[:wb] }
+    end
+  end
+  abort('no plannable chart elements found in the workbook spec') if charts.empty?
+
+  File.write(plan_path, JSON.pretty_generate({ 'charts' => charts }))
+
+  puts ''
+  puts '=' * 70
+  puts 'PHASE 7 PASS 1 — fetch ACTUAL (Sigma) and compute EXPECTED (warehouse)'
+  puts '=' * 70
+  puts ''
+  puts 'For each chart: run the mcp__sigma-mcp-v2__query below for the Sigma'
+  puts 'ACTUAL rows, and compute the EXPECTED rows by running the equivalent'
+  puts 'dimension+aggregation against the warehouse tables the QuickSight'
+  puts 'dataset reads (type=connection query, or a live QS export).'
+  puts "Write both files, then re-run with --finalize:"
+  puts "  #{opts[:dir]}/parity-expected.json  { \"<chart>\": [[dim, val], ...] }"
+  puts "  #{opts[:dir]}/parity-actuals.json   { \"<chart>\": [[dim, val], ...] }"
+  puts 'KPI charts: a single row [[null, <value>]].'
+  puts ''
+  charts.each_with_index do |c, i|
+    # Query by COLUMN ID (sigma-mcp-v2 can't resolve display labels in workbook
+    # queries); the display names ride along in a trailing SQL comment for readability.
+    ids = c['sigma_column_ids']
+    names = c['sigma_columns']
+    sql = if ids.length >= 2
+            %(SELECT "#{ids[0]}" AS dim, "#{ids[1]}" AS val FROM "workbook"."#{c['sigma_element_id']}" ORDER BY dim NULLS FIRST -- dim: #{names[0]}, val: #{names[1]})
+          else
+            %(SELECT "#{ids[0]}" AS val FROM "workbook"."#{c['sigma_element_id']}" -- val: #{names[0]})
+          end
+    puts "  [#{i + 1}/#{charts.length}] #{c['chart']} (#{c['kind']})"
+    puts "    mcp__sigma-mcp-v2__query  type=workbook  workbookId=#{opts[:wb]}"
+    puts "    sql=#{sql.inspect}"
+    puts ''
+  end
+  puts '=' * 70
+  exit 0
+end
+
+# PASS 2 — finalize
+abort("plan not found at #{plan_path}; run pass 1 first") unless File.exist?(plan_path)
+opts[:expected] ||= File.join(opts[:dir], 'parity-expected.json')
+opts[:actuals]  ||= File.join(opts[:dir], 'parity-actuals.json')
+abort("expected file missing: #{opts[:expected]}") unless File.exist?(opts[:expected])
+abort("actuals file missing: #{opts[:actuals]}")   unless File.exist?(opts[:actuals])
+
+plan = JSON.parse(File.read(plan_path))
+expected = JSON.parse(File.read(opts[:expected]))
+actuals  = JSON.parse(File.read(opts[:actuals]))
+
+warn "Phase 7 PASS 2: injecting expected (#{expected.size}) + actuals (#{actuals.size}) → #{plan_path}"
+plan['charts'].each do |c|
+  c['expected'] = expected[c['chart']] if expected[c['chart']]
+  c['actual']   = { 'rows' => actuals[c['chart']] } if actuals[c['chart']]
+end
+File.write(plan_path, JSON.pretty_generate(plan))
+
+missing = plan['charts'].reject { |c| c['expected'] && c['actual'] }
+missing.each { |c| warn "WARN: no expected/actual rows supplied for #{c['chart'].inspect} — it will DIVERGE" }
+
+warn "Phase 7 PASS 2: running verifier (#{opts[:extract_mode] ? 'extract-mode' : 'strict'})"
+verifier_args = ['ruby', File.join(__dir__, 'verify-parity.rb'), '--plan', plan_path]
+verifier_args.concat(['--extract-mode', '--extract-tol', opts[:extract_tol].to_s]) if opts[:extract_mode]
+out, err, status = Open3.capture3(*verifier_args)
+puts out
+warn err unless err.empty?
+File.write(File.join(opts[:dir], 'parity-final.txt'), out)
+
+# Hard-gate sentinel consumed by assert-phase6-ran.rb (same contract as the
+# tableau-to-sigma Phase 6 sentinel — see beads-sigma-4pm for why it exists).
+total  = plan['charts'].size
+passed = out.scan(/^PASS\s+\[[^\]]+\]\s+(.+)$/).flatten.map(&:strip)
+failed = out.scan(/^DIVERGE\s+\[[^\]]+\]\s+(.+)$/).flatten.map(&:strip)
+summary = {
+  'workbook_id'  => plan.dig('charts', 0, 'workbook_id'),
+  'ran_at'       => Time.now.utc.iso8601,
+  'mode'         => opts[:extract_mode] ? 'extract' : 'strict',
+  'extract_tol'  => opts[:extract_mode] ? opts[:extract_tol] : nil,
+  'charts_total' => total,
+  'charts_pass'  => passed.size,
+  'charts_fail'  => failed.size,
+  'pass_names'   => passed,
+  'fail_names'   => failed,
+  'status'       => (status.success? && total > 0 && passed.size == total) ? 'PASS' : 'FAIL'
+}
+summary_path = File.join(opts[:dir], 'parity-final.json')
+File.write(summary_path, JSON.pretty_generate(summary))
+warn "wrote #{summary_path} (status=#{summary['status']} #{summary['charts_pass']}/#{summary['charts_total']})"
+exit(status.success? ? 0 : 2)

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/pick-destination.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/pick-destination.rb
@@ -1,0 +1,69 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Shared destination picker for the *-to-sigma migration skills.
+# Produces the folderId where a migrated data model + workbook should land.
+# The SKILL drives the *asking*; this script just lists candidates and creates folders.
+#
+#   ruby pick-destination.rb list
+#       -> JSON { "workspaces":[{id,name}], "folders":[{id,name,parentId,parentName}],
+#                 "myDocuments": "<id>"|null }
+#       Only folders the token can EDIT are returned. folderId in a DM/workbook POST
+#       accepts either a workspace id (lands in the workspace root) or a folder id.
+#
+#   ruby pick-destination.rb create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+#       -> JSON { "id", "name", "parentId" }
+#       Creates a folder. --parent may be a workspace id, a folder id, or omitted
+#       (then it lands in My Documents when resolvable, else org root).
+#
+# Env: SIGMA_BASE_URL + SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (or SIGMA_API_TOKEN).
+require 'json'
+require_relative 'lib/sigma_rest'
+
+def my_documents_id
+  # Only resolvable for a user-bound token; service-account tokens return nil.
+  uid = (Sigma.request(:get, '/v2/whoami') rescue {})&.dig('userId')
+  return nil unless uid && !uid.to_s.empty?
+  entries = ((Sigma.request(:get, "/v2/members/#{uid}/files?typeFilters=folder&limit=500") rescue {}) || {})['entries'] || []
+  hit = entries.find { |e| e['name'] == 'My Documents' || e['path'] == 'My Documents' }
+  hit && hit['id']
+rescue StandardError
+  nil
+end
+
+def cmd_list
+  workspaces = (((Sigma.request(:get, '/v2/workspaces?limit=500') rescue {}) || {})['entries'] || [])
+               .map { |w| { 'id' => w['workspaceId'] || w['id'], 'name' => w['name'] } }
+  ws_name = workspaces.each_with_object({}) { |w, h| h[w['id']] = w['name'] }
+  folders = (((Sigma.request(:get, '/v2/files?typeFilters=folder&limit=500') rescue {}) || {})['entries'] || [])
+            .select { |f| f['permission'] == 'edit' }
+            .map { |f| { 'id' => f['id'], 'name' => f['name'], 'parentId' => f['parentId'],
+                         'parentName' => ws_name[f['parentId']] } }
+  puts JSON.pretty_generate('workspaces' => workspaces, 'folders' => folders,
+                            'myDocuments' => my_documents_id)
+end
+
+def cmd_create(argv)
+  name = nil
+  parent = nil
+  i = 0
+  while i < argv.length
+    case argv[i]
+    when '--name'   then name = argv[i + 1]; i += 2
+    when '--parent' then parent = argv[i + 1]; i += 2
+    else i += 1
+    end
+  end
+  abort('pick-destination create: --name is required') if name.nil? || name.empty?
+  parent ||= my_documents_id
+  body = { 'type' => 'folder', 'name' => name }
+  body['parentId'] = parent if parent && !parent.to_s.empty?
+  res = Sigma.request(:post, '/v2/files', body: JSON.dump(body))
+  puts JSON.pretty_generate('id' => res['id'], 'name' => res['name'], 'parentId' => res['parentId'])
+end
+
+case ARGV[0]
+when 'list', nil then cmd_list
+when 'create'    then cmd_create(ARGV[1..])
+else abort("usage: pick-destination.rb [list | create --name NAME [--parent ID]]")
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/post-and-readback.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/post-and-readback.rb
@@ -1,0 +1,260 @@
+#!/usr/bin/env ruby
+# POST a DM or workbook spec, parse the YAML response, then GET the spec back
+# and emit a clean JSON map of pages → elements with server-assigned IDs.
+#
+# Usage:
+#   ruby post-and-readback.rb --type datamodel|workbook --spec <spec.json> --out <id-map.json>
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'yaml'
+require 'date'
+require 'time'
+require 'optparse'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--type T', %w[datamodel workbook]) { |v| opts[:type] = v }
+  p.on('--spec P')                         { |v| opts[:spec] = v }
+  p.on('--out P')                          { |v| opts[:out]  = v }
+  p.on('--workdir P', 'Per-conversion working dir (default: dir of --spec). Used to track posted workbook IDs across retries.') { |v| opts[:workdir] = v }
+  p.on('--skip-layout-lint') { opts[:skip_lint] = true }
+  p.on('--skip-control-lint') { opts[:skip_control_lint] = true }
+  p.on('--control-scope P', 'control-scope.json sidecar (default: <workdir>/control-scope.json if present)') { |v| opts[:control_scope] = v }
+  p.on('--update-id ID', 'PUT the spec to this existing workbook/DM id instead of POSTing a new one (retry-safe; avoids orphan workbooks). For workbooks, if omitted, the last id in posted-workbooks.jsonl is reused automatically.') { |v| opts[:update_id] = v }
+end.parse!
+%i[type spec out].each { |k| abort("missing --#{k}") unless opts[k] }
+opts[:workdir] ||= File.dirname(File.expand_path(opts[:spec]))
+require 'fileutils'
+FileUtils.mkdir_p(opts[:workdir])
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+
+POST_PATH = opts[:type] == 'datamodel' ? '/v2/dataModels/spec'              : '/v2/workbooks/spec'
+GET_PATH  = opts[:type] == 'datamodel' ? '/v2/dataModels/%s/spec'           : '/v2/workbooks/%s/spec'
+ID_FIELD  = opts[:type] == 'datamodel' ? 'dataModelId'                      : 'workbookId'
+
+# Wraps a single Sigma REST call with automatic 401-retry-after-refresh
+# (tokens last ~1 hour; long conversions outlive a single token). Returns
+# the raw Net::HTTPResponse so existing .body / .is_a?(Net::HTTPSuccess)
+# checks below keep working unchanged.
+def http(method, path, body = nil, accept_json: false)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{BASE}#{path}")
+    req = case method
+          when :post then r = Net::HTTP::Post.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
+          when :put  then r = Net::HTTP::Put.new(uri);  r.body = body; r['Content-Type'] = 'application/json'; r
+          when :get  then Net::HTTP::Get.new(uri)
+          end
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept']        = 'application/json' if accept_json
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      warn '  [auth] Sigma token expired mid-run, refreshing and retrying...'
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+# Orphan-prevention pre-check: workbook POSTs are create-only. If this is a
+# second invocation in the same conversion, the previous workbook is being
+# orphaned in the customer's My Documents. WARN loudly and emit the PUT
+# alternative. Tracked at beads-sigma-38a (3-workbook customer regression).
+posted_log = File.join(opts[:workdir], 'posted-workbooks.jsonl') if opts[:type] == 'workbook'
+prior_ids = []
+if posted_log && File.exist?(posted_log)
+  prior_ids = File.readlines(posted_log).map { |l| JSON.parse(l)['id'] rescue nil }.compact
+end
+# Decide POST (create) vs PUT (update existing). An explicit --update-id always
+# wins; otherwise, for a workbook retry, auto-reuse the last id we posted in this
+# conversion so a re-run UPDATES the workbook in place instead of orphaning it
+# (beads-sigma-38a — the 3-workbook customer regression). DM updates require an
+# explicit --update-id (Phase 3 normally reuses a DM via the ref-dm path).
+update_id = opts[:update_id] || (prior_ids.last if opts[:type] == 'workbook' && prior_ids.any?)
+
+if update_id
+  warn "UPDATE mode: PUT #{opts[:type]} #{update_id} (no new #{opts[:type]} created)"
+  resp = http(:put, format(GET_PATH, update_id), File.read(opts[:spec]))
+  parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+  oid = parsed[ID_FIELD] || update_id
+  abort("PUT failed (HTTP #{resp.code}): #{parsed.inspect}") unless resp.is_a?(Net::HTTPSuccess)
+  warn "PUT ok: #{ID_FIELD}=#{oid}"
+else
+  resp = http(:post, POST_PATH, File.read(opts[:spec]))
+  parsed = YAML.safe_load(resp.body, permitted_classes: [Date, Time])
+  oid = parsed[ID_FIELD] or abort("POST failed: #{parsed.inspect}")
+  warn "POST ok: #{ID_FIELD}=#{oid}"
+
+  # Append the new ID to the per-conversion log. Newline-delimited JSON so
+  # multiple processes can append safely (atomic append on POSIX). Only on
+  # create — a PUT reuses an existing id and adds no orphan to track.
+  if posted_log
+    File.open(posted_log, 'a') do |f|
+      f.puts(JSON.generate({ 'id' => oid, 'ran_at' => Time.now.utc.iso8601 }))
+    end
+  end
+end
+
+# Read back
+spec = JSON.parse(http(:get, format(GET_PATH, oid), accept_json: true).body)
+
+# Fetch the resolved /columns BEFORE writing the id-map so we can attach the
+# AUTHORITATIVE per-element column labels (the suffixed display names Sigma
+# assigns to disambiguate joined-dim columns — e.g. "Customer Id (CUSTOMER_DIM)").
+# derive_master needs these to emit master-column formulas that actually resolve.
+# (Same response is reused below for the error-type guard — one round trip.)
+columns_path = opts[:type] == 'datamodel' ?
+  "/v2/dataModels/#{oid}/columns" :
+  "/v2/workbooks/#{oid}/columns"
+cols_res = http(:get, columns_path, accept_json: true)
+cols_json = cols_res.is_a?(Net::HTTPSuccess) ? (JSON.parse(cols_res.body) rescue { 'entries' => [] }) : nil
+labels_by_el = Hash.new { |h, k| h[k] = [] }
+(cols_json && cols_json['entries'] || []).each do |c|
+  labels_by_el[c['elementId']] << c['label'] if c['elementId'] && c['label']
+end
+
+out = {
+  ID_FIELD => oid,
+  'pages'  => spec.fetch('pages', []).map do |p|
+    {
+      'id'       => p['id'],
+      'name'     => p['name'],
+      'visibility' => p['visibility'],
+      'elements' => (p['elements'] || []).map do |e|
+        el = { 'id' => e['id'], 'kind' => e['kind'], 'name' => e['name'] }
+        el['columnLabels'] = labels_by_el[e['id']] if labels_by_el.key?(e['id'])
+        el
+      end
+    }
+  end
+}
+File.write(opts[:out], JSON.pretty_generate(out))
+puts JSON.pretty_generate(out)
+
+# Universal silent-error guard: scan every column's resolved type via the
+# `/columns` endpoint and fail loudly on any column with type `error`.
+#
+# A column ends up "error" when the formula compiles successfully against the
+# validator but fails at runtime. Typical causes:
+#   - Referenced column doesn't exist (typo)
+#   - Function doesn't exist in Sigma (e.g., IsIn — see memory feedback_sigma_formula_isin.md)
+#   - Window aggregate used in calc-column context (validate-spec catches the known
+#     function names; this catches anything else that produces an error type)
+#   - Cross-element ref without a Lookup wrapper (compiles, returns NULL forever — actually
+#     resolves as the column's declared type, not "error", so this guard misses it; that's
+#     why refs/data-model-spec.md has its own callout)
+#
+# Endpoint: GET /v2/{dataModels|workbooks}/<id>/columns — returns one entry per
+# column with `type.type` resolved. Scan for type == "error".
+
+res = cols_res
+if res.is_a?(Net::HTTPSuccess)
+  error_columns = (cols_json['entries'] || []).select { |c| c.dig('type', 'type') == 'error' }
+  if error_columns.any?
+    warn "\n========================================"
+    warn "FAIL — #{error_columns.size} column(s) compiled to type \"error\":"
+    error_columns.each do |c|
+      warn "  [element=#{c['elementId']}] #{c['label']} (#{c['columnId']}):"
+      warn "    formula: #{c['formula']}"
+    end
+    warn 'Fix these formulas before continuing — Phase 6 parity would fail downstream.'
+    warn 'Common causes: typo in a column ref, IsIn() / non-existent function, window'
+    warn 'aggregate in a calc column (use a Custom SQL element instead — see Phase 3).'
+    warn '========================================'
+    exit(2)
+  else
+    total = (cols_json['entries'] || []).size
+    warn "column-type guard: #{total} columns clean (no `error` types)"
+  end
+else
+  warn "WARN: could not fetch /columns for type guard (got HTTP #{res.code}); skipping"
+end
+
+# Layout-quality lint (shared scripts/lib/layout_lint.rb — vendored byte-
+# identical, md5 discipline): fails loudly on raw-id element display names,
+# input controls outside the GridContainer bands of a banded page, and dead
+# zones (>25% empty grid rows between a page's first and last element). The
+# "PHASEE PBI Employee Dashboard" regression shipped a parity-green workbook
+# that was a visual mess — every data gate passed. Escape: --skip-layout-lint
+# (legacy/intentional layouts only; name the reason in your report).
+if opts[:type] == 'workbook' && !opts[:skip_lint]
+  require_relative 'lib/layout_lint'
+  violations = LayoutLint.lint(spec)
+  if violations.any?
+    warn "\n========================================"
+    warn "FAIL — layout lint: #{violations.size} violation(s):"
+    violations.each { |v| warn "  - #{v}" }
+    warn 'Fix the spec/layout and re-PUT before continuing: raw-id names -> derive human'
+    warn 'titles; loose controls -> control band or the chart container; dead zones ->'
+    warn 're-band the page. The workbook DID post — fix with PUT /v2/workbooks/<id>/spec'
+    warn '(re-POSTing creates an orphan).'
+    warn '========================================'
+    exit(3)
+  end
+  warn 'layout lint: clean (raw-id names / orphan controls / dead zones)'
+end
+
+# Control-wiring lint (shared scripts/lib/control_lint.rb — vendored byte-
+# identical, md5 discipline): fails loudly on dead controls (no resolving
+# filter target AND no [controlId] formula reference — the "Orders Overview
+# (from Looker)" estate escape), ghost filter targets, and controls whose
+# source-closure misses same-page queryable elements (the PHASEE
+# "Action(Region) -> Monthly Revenue Trend" escape). If the builder emitted a
+# control-scope sidecar (<workdir>/control-scope.json — see the lib header
+# CONTRACT), it also fails when the source artifact had filter signals but the
+# spec shipped zero controls (the Qlik class), and honors per-control
+# scope:[...] allowlists for intentional single-chart switchers (grain
+# controls). Escape: --skip-control-lint (name the reason in your report).
+if opts[:type] == 'workbook' && !opts[:skip_control_lint]
+  require_relative 'lib/control_lint'
+  scope_path = opts[:control_scope] || File.join(opts[:workdir], 'control-scope.json')
+  scope = nil
+  if File.exist?(scope_path)
+    scope = JSON.parse(File.read(scope_path)) rescue nil
+    warn "WARN: #{scope_path} is not valid JSON — control lint runs without source scope" if scope.nil?
+  end
+  violations = ControlLint.lint(spec, scope: scope)
+  if violations.any?
+    warn "\n========================================"
+    warn "FAIL — control lint: #{violations.size} violation(s):"
+    violations.each { |v| warn "  - #{v}" }
+    warn 'Fix the control wiring and re-PUT before continuing: dead controls -> add'
+    warn 'filters targets ({source:{elementId}, columnId}) or remove the control;'
+    warn 'partial reach -> wire the uncovered elements or annotate controlScope in'
+    warn 'control-scope.json (see scripts/lib/control_lint.rb CONTRACT). The workbook'
+    warn 'DID post — fix with PUT /v2/workbooks/<id>/spec (re-POSTing creates an orphan).'
+    warn '========================================'
+    exit(4)
+  end
+  n = ControlLint.controls_report(spec).length
+  warn "control lint: clean (#{n} control(s); dead / ghost-target / reach#{scope ? ' / source-scope' : ''})"
+end
+
+# Phase 6 nag — column-type guard catches formula-resolution errors but does
+# NOT compare data values to Tableau. Phase 6 (mandatory per SKILL.md) is the
+# ONLY thing that confirms the chart actually reproduces the source. Emit a
+# clear next-step prompt so the agent (or human) doesn't silently skip it.
+if opts[:type] == 'workbook'
+  warn ""
+  warn "================================================================"
+  warn "NEXT STEP — Phase 7 (MANDATORY): verify data parity vs the source"
+  warn "================================================================"
+  warn "Column-type guard PASSES means formulas RESOLVE. It does NOT mean"
+  warn "the chart values match QuickSight's. Run this BEFORE declaring done:"
+  warn ""
+  warn "  ruby scripts/phase6-parity-quicksight.rb \\"
+  warn "    --workdir <your work dir> \\"
+  warn "    --workbook-id #{oid}"
+  warn ""
+  warn "then collect expected/actual rows and re-run with --finalize, and"
+  warn "finish with: ruby scripts/assert-phase6-ran.rb --workdir <your work dir>"
+  warn "================================================================"
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/probe-controls.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/probe-controls.rb
@@ -1,0 +1,236 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# probe-controls.rb — live flip test proving a workbook's controls actually
+# filter what they claim to. OPTIONAL Phase 6 step (not the mandatory inner
+# loop): run it after the control lint (gate 7) passes when you want runtime
+# evidence, after repairing control wiring on a live workbook, or whenever a
+# control's reach was wired by hand.
+#
+# SHARED script, vendored byte-identical into every covered plugin's scripts/
+# (md5 discipline — same as scripts/lib/control_lint.rb, which it reuses).
+#
+# What it does, per control:
+#   1. computes the control's reach (filter targets + [controlId] formula
+#      references, expanded through source.elementId chains —
+#      ControlLint.controls_report)
+#   2. exports one IN-closure queryable element as CSV twice via
+#      POST /v2/workbooks/{id}/export — once with no `parameters` (the saved
+#      control defaults) and once with parameters:{<controlId>: <flip value>}.
+#      The two CSVs MUST differ, or the control is wired but inert -> FAIL.
+#   3. with --check-out-of-closure: also exports one same-page queryable
+#      element OUTSIDE the closure with and without the parameter — those
+#      MUST be identical (the flip must not leak) -> FAIL if they differ
+#      (the closure walk missed an edge; fix control_lint, not the workbook).
+#
+# Flip-value selection ("first non-default value"):
+#   --value <controlId>=<value> beats everything (repeatable).
+#   Otherwise: the control's value-source column (source.columnId, falling
+#   back to the first filter target's columnId) is resolved to its display
+#   label via GET /v2/workbooks/{id}/columns, that element is exported once,
+#   and the first distinct value of that column NOT in the control's saved
+#   defaults (`values`) is used. switch controls flip true<->false. Controls
+#   whose value cannot be auto-picked (date ranges, numeric sliders, missing
+#   labels) are SKIPped with a NOTE — pass --value for those.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query / claude.ai Sigma MCP)
+# evaluates workbook elements WITH the saved control defaults applied and
+# exposes NO parameter mechanism to set a control value. The REST export API
+# (POST /v2/workbooks/{id}/export with "parameters": {"<controlId>": "<val>"})
+# is the ONLY programmatic way to exercise a non-default control value —
+# which is why this probe is built on export, not MCP. (MCP is still fine for
+# default-state parity checks — Phase 6 uses it for exactly that.)
+#
+# Usage:
+#   ruby scripts/probe-controls.rb --workbook-id <id> \
+#     [--control <controlId>]        # probe just one control (repeatable)
+#     [--value <controlId>=<value>]  # explicit flip value (repeatable)
+#     [--check-out-of-closure]       # also assert the flip does NOT leak
+#     [--out DIR]                    # CSV evidence dir (default /tmp/probe-controls-<id>)
+#     [--timeout SECS]               # export poll timeout per CSV (default 90)
+#
+# Exit codes: 0 = every probed control flips correctly (skips allowed);
+#             1 = at least one FAIL; 2 = no control could be probed at all.
+require 'json'
+require 'csv'
+require 'optparse'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+require 'control_lint'
+
+opts = { values: {}, controls: [], timeout: 90 }
+OptionParser.new do |p|
+  p.on('--workbook-id ID')        { |v| opts[:wb] = v }
+  p.on('--control CID')           { |v| opts[:controls] << v }
+  p.on('--value SPEC', '<controlId>=<value>') do |v|
+    cid, val = v.split('=', 2)
+    abort "bad --value #{v.inspect} (want <controlId>=<value>)" unless cid && val
+    opts[:values][cid] = val
+  end
+  p.on('--check-out-of-closure')  { opts[:check_out] = true }
+  p.on('--out DIR')               { |v| opts[:out] = v }
+  p.on('--timeout SECS', Integer) { |v| opts[:timeout] = v }
+end.parse!
+abort('--workbook-id required') unless opts[:wb]
+WB = opts[:wb]
+OUT = opts[:out] || "/tmp/probe-controls-#{WB}"
+FileUtils.mkdir_p(OUT)
+
+# --- Sigma plumbing ---------------------------------------------------------
+
+def fetch_spec(wb)
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'application/json')
+  return body if body.is_a?(Hash)
+  require 'yaml'
+  require 'date'
+  YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {}
+end
+
+# Export an element as CSV (optionally with control parameters), poll the
+# query download until ready, return the CSV text. Raises on timeout/error.
+def export_csv(wb, element_id, params, timeout)
+  body = { 'elementId' => element_id, 'format' => { 'type' => 'csv' } }
+  body['parameters'] = params if params && !params.empty?
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+  qid = res.is_a?(Hash) && res['queryId']
+  raise "export request failed: #{res.inspect}" unless qid
+  deadline = Time.now + timeout
+  loop do
+    uri = URI("#{Sigma.base_url}/v2/query/#{qid}/download")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    r = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 60) { |h| h.request(req) }
+    return r.body if r.code.to_i == 200
+    raise "export download failed: HTTP #{r.code} #{r.body.to_s[0, 300]}" if r.code.to_i >= 400 && r.code.to_i != 404
+    raise "export timed out after #{timeout}s (queryId=#{qid})" if Time.now > deadline
+    sleep 2
+  end
+end
+
+# Row-order-insensitive CSV signature (filters change row SETS; ordering noise
+# must not mask or fake a flip).
+def csv_sig(text)
+  text.to_s.lines.map(&:chomp).sort
+end
+
+# --- reach + element metadata ------------------------------------------------
+
+spec  = fetch_spec(WB)
+elems = ControlLint.elements(spec)
+rows  = ControlLint.controls_report(spec)
+rows.select! { |r| opts[:controls].include?(r[:control_id]) } if opts[:controls].any?
+abort "no controls found in workbook #{WB}#{opts[:controls].any? ? " matching #{opts[:controls].inspect}" : ''}" if rows.empty?
+
+cols = Sigma.request(:get, "/v2/workbooks/#{WB}/columns")
+col_label = {} # [elementId, columnId] -> display label
+(cols && cols['entries'] || []).each do |c|
+  col_label[[c['elementId'], c['columnId']]] = c['label'] if c['elementId'] && c['columnId']
+end
+
+baseline_cache = {}
+get_baseline = lambda do |eid|
+  baseline_cache[eid] ||= export_csv(WB, eid, nil, opts[:timeout])
+end
+
+# Pick the flip value for a control (returns [value, note] — value nil = skip).
+pick_value = lambda do |r|
+  el = elems[r[:control_element_id]][:el]
+  cid = r[:control_id]
+  return [opts[:values][cid], 'explicit --value'] if opts[:values].key?(cid)
+  defaults = Array(el['values']).map(&:to_s)
+  case el['controlType'].to_s
+  when 'switch'
+    return [(defaults.first.to_s.downcase == 'true' ? 'false' : 'true'), 'switch flip']
+  when 'list', 'segmented', 'text'
+    src = el['source']
+    src = src['source'].merge('columnId' => src['columnId']) if src.is_a?(Hash) && src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src = (el['filters'] || []).map { |f| f.is_a?(Hash) ? (f['source'] || {}).merge('columnId' => f['columnId']) : nil }.compact.first if !src.is_a?(Hash) || !src['columnId']
+    return [nil, 'no value-source column resolvable — pass --value'] unless src.is_a?(Hash) && src['elementId'] && src['columnId']
+    label = col_label[[src['elementId'], src['columnId']]]
+    return [nil, "no /columns label for #{src['elementId']}/#{src['columnId']} — pass --value"] unless label
+    csv = CSV.parse(get_baseline.call(src['elementId']), headers: true)
+    return [nil, "column #{label.inspect} not in export of #{src['elementId']} — pass --value"] unless csv.headers.include?(label)
+    distinct = csv.map { |row| row[label] }.compact.map(&:to_s).reject(&:empty?).uniq
+    val = distinct.find { |v| !defaults.include?(v) }
+    val ? [val, "auto-picked from #{label.inspect}"] : [nil, 'no non-default value found — pass --value']
+  else
+    [nil, "controlType=#{el['controlType'].inspect} has no auto flip value — pass --value"]
+  end
+end
+
+# --- probe loop ----------------------------------------------------------------
+
+failures = 0
+probed = 0
+results = []
+rows.each do |r|
+  cid = r[:control_id]
+  ctl = "#{r[:name].inspect} [#{cid}]"
+  if r[:reach].empty?
+    results << { control: cid, result: 'FAIL', note: 'dead control — empty reach (run the control lint)' }
+    failures += 1
+    next
+  end
+
+  in_el = (r[:reach] & r[:page_queryable]).first ||
+          r[:reach].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if in_el.nil?
+    results << { control: cid, result: 'SKIP', note: 'no queryable element in closure' }
+    next
+  end
+
+  val, note = pick_value.call(r)
+  if val.nil?
+    results << { control: cid, result: 'SKIP', note: note }
+    next
+  end
+
+  probed += 1
+  base = get_baseline.call(in_el)
+  flip = export_csv(WB, in_el, { cid => val }, opts[:timeout])
+  File.write(File.join(OUT, "#{cid}--#{in_el}--base.csv"), base)
+  File.write(File.join(OUT, "#{cid}--#{in_el}--flip.csv"), flip)
+  changed = csv_sig(base) != csv_sig(flip)
+  if changed
+    results << { control: cid, result: 'PASS', element: in_el, value: val,
+                 note: "#{note}; in-closure export differs (#{base.lines.count - 1} -> #{flip.lines.count - 1} rows)" }
+  else
+    failures += 1
+    results << { control: cid, result: 'FAIL', element: in_el, value: val,
+                 note: "#{note}; in-closure export IDENTICAL with #{cid}=#{val.inspect} — control is wired but inert" }
+  end
+
+  next unless opts[:check_out]
+  out_el = r[:uncovered].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if out_el.nil?
+    results << { control: cid, result: 'OK', note: 'out-of-closure: none on page (full reach) — nothing to check' }
+  else
+    obase = get_baseline.call(out_el)
+    oflip = export_csv(WB, out_el, { cid => val }, opts[:timeout])
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-base.csv"), obase)
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-flip.csv"), oflip)
+    if csv_sig(obase) == csv_sig(oflip)
+      results << { control: cid, result: 'OK', element: out_el, note: 'out-of-closure export unchanged (no leak)' }
+    else
+      failures += 1
+      results << { control: cid, result: 'FAIL', element: out_el,
+                   note: 'out-of-closure export CHANGED — the closure walk missed an edge (fix control_lint, not the workbook)' }
+    end
+  end
+end
+
+puts format('%-22s %-6s %-34s %s', 'CONTROL', 'RESULT', 'ELEMENT', 'NOTE')
+results.each do |x|
+  puts format('%-22s %-6s %-34s %s', x[:control], x[:result], x[:element] || '-', [x[:value] && "flip=#{x[:value].inspect}", x[:note]].compact.join('; '))
+end
+File.write(File.join(OUT, 'probe-results.json'), JSON.pretty_generate(results))
+puts "evidence: #{OUT}/ (CSVs + probe-results.json)"
+
+exit 1 if failures.positive?
+exit 2 if probed.zero?
+exit 0

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/put-layout.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/put-layout.rb
@@ -1,0 +1,77 @@
+#!/usr/bin/env ruby
+# GET a workbook spec, replace per-page layouts with a single top-level layout
+# XML (provided), strip read-only fields, PUT back.
+#
+# Container layouts: a <GridContainer> in the layout XML must be paired with a
+# `kind: container` placeholder element in the spec (else it is silently
+# dropped — layout-playbook.md). Layout builders that emit GridContainers
+# write a sidecar `<layout>.elements.json` ({pageId: [element, ...]}) next to
+# the layout XML; this script injects those elements (containers + header
+# text) into the matching pages before the PUT. Pass --elements to override
+# the sidecar path. Injection is idempotent (existing element ids are kept).
+#
+# Usage:
+#   ruby put-layout.rb --workbook <wbId> --layout <layout.xml> \
+#     [--elements <elements.json>]
+
+require 'json'
+require 'yaml'
+require 'date'
+require 'optparse'
+# sigma_rest self-exchanges SIGMA_CLIENT_ID/SECRET (auto-loading
+# ~/.sigma-migration/env) exactly like the phase 1-4 scripts — SIGMA_API_TOKEN
+# is optional, not a hard requirement (bead eqom).
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+opts = {}
+OptionParser.new do |p|
+  p.on('--workbook ID') { |v| opts[:wb] = v }
+  p.on('--layout PATH') { |v| opts[:layout] = v }
+  p.on('--elements PATH', 'spec elements to inject (default: <layout>.elements.json if present)') { |v| opts[:elements] = v }
+end.parse!
+%i[wb layout].each { |k| abort("missing --#{k}") unless opts[k] }
+
+def http(method, path, body = nil)
+  Sigma.request(method, path, body: body, binary: true)
+end
+
+xml = File.read(opts[:layout])
+abort "FATAL: empty elementId in layout XML" if xml.match?(/elementId=""/)
+
+spec = JSON.parse(http(:get, "/v2/workbooks/#{opts[:wb]}/spec"))
+spec['pages'].each { |p| p.delete('layout') }
+spec['layout'] = xml
+
+# Inject container/header-text spec elements (see header comment).
+elements_path = opts[:elements] || "#{opts[:layout]}.elements.json"
+if File.exist?(elements_path)
+  inject = JSON.parse(File.read(elements_path))
+  injected = 0
+  inject.each do |page_id, els|
+    page = spec['pages'].find { |p| p['id'] == page_id }
+    unless page
+      warn "WARN: elements sidecar references unknown page #{page_id.inspect} — skipped"
+      next
+    end
+    page['elements'] ||= []
+    existing = page['elements'].map { |e| e['id'] }
+    els.each do |el|
+      next if existing.include?(el['id'])
+      page['elements'] << el
+      injected += 1
+    end
+  end
+  puts "injected #{injected} container/header element(s) from #{elements_path}"
+end
+%w[workbookId url ownerId createdBy updatedBy createdAt updatedAt latestDocumentVersion].each { |k| spec.delete(k) }
+
+begin
+  resp_body = http(:put, "/v2/workbooks/#{opts[:wb]}/spec", JSON.pretty_generate(spec))
+rescue Sigma::Error => e
+  puts "ERROR: #{e.message}"
+  exit 1
+end
+parsed = YAML.safe_load(resp_body, permitted_classes: [Date, Time])
+puts parsed['workbookId'] ? "PUT ok: workbookId=#{parsed['workbookId']}" : "ERROR: #{parsed.inspect}"
+exit(parsed['workbookId'] ? 0 : 1)

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/qs-dm-signature.py
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/qs-dm-signature.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""qs-dm-signature.py — build a DM-reuse signature from QuickSight dataset JSON.
+
+Feeds scripts/find-or-pick-dm.rb (Phase 3.5) so the migration REUSES an existing
+Sigma data model that already covers the same warehouse tables instead of
+creating a 4th near-identical one. Mirrors powerbi-to-sigma's
+pbi-dm-signature.py. Emits the signature shape find-or-pick-dm expects:
+
+  { "tableau_workbook": "<dataset name(s)>",      # label only
+    "warehouse_tables":   ["DB.SCHEMA.TABLE", ...],
+    "referenced_columns": ["COL", ...],
+    "measures":           [] }                     # QS aggs live per-visual; omitted
+
+Input = the Phase-2 discovery output: either --discover-dir (reads datasets/*.json)
+or explicit dataset JSON paths (DescribeDataSet responses — fixtures/ shape).
+Tables: RelationalTable Catalog.Schema.Name; CustomSql tables are lifted from the
+SQL's FROM/JOIN clauses (3-part names only — else the element is CUSTOM_SQL, the
+same sentinel the picker uses). Columns: physical InputColumns/Columns plus
+CreateColumnsOperation calc columns. Pure (no network).
+
+Usage: python3 scripts/qs-dm-signature.py --discover-dir ~/quicksight-migration/<name> \
+         --out dm-signature.json
+       python3 scripts/qs-dm-signature.py fixtures/dataset-orders-enriched.json --out sig.json
+"""
+import argparse, glob, json, os, re, sys
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("datasets", nargs="*", help="dataset JSON file(s) (DescribeDataSet shape)")
+    ap.add_argument("--discover-dir", help="Phase-2 discovery dir (reads datasets/*.json)")
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+
+    paths = list(a.datasets)
+    if a.discover_dir:
+        paths += sorted(glob.glob(os.path.join(a.discover_dir, "datasets", "*.json")))
+    if not paths:
+        sys.exit("[qs-dm-signature] no dataset JSON given (positional or --discover-dir)")
+
+    names, tables, cols = [], [], []
+    for path in paths:
+        doc = json.load(open(path))
+        ds = doc.get("DataSet", doc)
+        if ds.get("Name"):
+            names.append(ds["Name"])
+        for pt in (ds.get("PhysicalTableMap") or {}).values():
+            rel = pt.get("RelationalTable")
+            if rel:
+                fqn = ".".join(p for p in [rel.get("Catalog"), rel.get("Schema"), rel.get("Name")] if p)
+                tables.append(fqn.upper())
+                cols += [c["Name"].upper() for c in rel.get("InputColumns", []) if c.get("Name")]
+            sql = pt.get("CustomSql")
+            if sql:
+                found = re.findall(r'\b(?:from|join)\s+"?(\w+)"?\."?(\w+)"?\."?(\w+)"?',
+                                   sql.get("SqlQuery", ""), re.I)
+                tables += [".".join(g).upper() for g in found] or ["CUSTOM_SQL"]
+                cols += [c["Name"].upper() for c in sql.get("Columns", []) if c.get("Name")]
+        for lt in (ds.get("LogicalTableMap") or {}).values():
+            for tr in lt.get("DataTransforms", []):
+                for cc in tr.get("CreateColumnsOperation", {}).get("Columns", []):
+                    if cc.get("ColumnName"):
+                        cols.append(cc["ColumnName"].upper())
+
+    sig = {"tableau_workbook": ", ".join(names) or "QuickSight dataset",
+           "warehouse_tables": sorted(set(tables)),
+           "referenced_columns": sorted(set(cols)),
+           "measures": []}
+    json.dump(sig, open(a.out, "w"), indent=2)
+    print(f"[qs-dm-signature] {len(paths)} dataset(s): {len(sig['warehouse_tables'])} table(s), "
+          f"{len(sig['referenced_columns'])} col(s) -> {a.out}", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/quicksight-discover.py
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/quicksight-discover.py
@@ -1,0 +1,560 @@
+#!/usr/bin/env python3
+"""Phase 1 discovery for quicksight-to-sigma.
+
+Pulls a QuickSight analysis (or dashboard) definition + its datasets + data sources
+and writes a normalized signals.json the convert + workbook phases consume.
+
+FAST DISCOVERY (customer scale: 20-40 dashboard estates sharing datasets):
+  * in-process boto3 client when available (one session for the whole run)
+    instead of one `aws` CLI subprocess per call (0.4-0.6s interpreter startup
+    tax EACH — a 1-analysis/2-dataset/1-source discovery paid it 4-5x, an
+    estate re-paid it per dashboard). Falls back to the aws CLI automatically
+    when boto3 isn't installed (same call shapes; boto3 is NOT a hard dep).
+  * estate-level dataset cache (/tmp/qs-estate-cache/<acct>__<region>/) keyed
+    DataSetArn + LastUpdatedTime: shared datasets are described ONCE per
+    estate, not once per dashboard. Freshness is validated against ONE
+    list-data-sets call per process; any LastUpdatedTime mismatch re-describes.
+  * data sources are described once, LAZILY (first dashboard that needs one
+    pays; the rest read the cache — sources change far less often than sets).
+  * batch mode (--analysis-ids a,b,c --pool 4): per-analysis discovery runs
+    4-8 wide; each analysis lands in <out-dir>/<id>/ with its own signals.json.
+  * timings.json (per-call wall clock) is ALWAYS written to --out-dir.
+
+Enterprise edition required for the *-definition calls (Standard edition rejects them).
+QuickSight's identity region (often us-east-1) is where the resources live — pass --region accordingly.
+
+Usage (single analysis — unchanged interface):
+  python3 scripts/quicksight-discover.py \
+    --account-id 153722385948 --region us-east-1 --profile pivot \
+    --analysis-id orders-overview --out-dir ~/quicksight-migration/orders-overview
+
+Batch (estate) mode:
+  python3 scripts/quicksight-discover.py \
+    --account-id ... --region ... --analysis-ids id1,id2,id3 --pool 4 \
+    --out-dir /tmp/qs-estate
+
+Offline / fixture mode (no AWS account or CLI needed):
+  python3 scripts/quicksight-discover.py \
+    --from-fixtures plugins/.../fixtures --out-dir /tmp/qs-orders
+
+Cache controls: --no-cache bypasses the estate cache entirely; --refresh-cache
+forces re-describe (and rewrites the cache). QS_ESTATE_CACHE overrides the root.
+QS_FORCE_CLI=1 forces the aws-CLI transport even when boto3 is importable.
+"""
+import argparse
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+
+CACHE_ROOT = os.environ.get("QS_ESTATE_CACHE", "/tmp/qs-estate-cache")
+MAX_POOL = 8  # batch fan-out cap
+
+
+def _jsonable(o):
+    """boto3 responses carry datetime objects; the CLI emits ISO strings.
+    Normalize so cached/written JSON is transport-independent."""
+    if isinstance(o, dict):
+        return {k: _jsonable(v) for k, v in o.items() if k != "ResponseMetadata"}
+    if isinstance(o, list):
+        return [_jsonable(v) for v in o]
+    if isinstance(o, (datetime.datetime, datetime.date)):
+        return o.isoformat()
+    return o
+
+
+class Timings:
+    """Per-call wall-clock evidence trail; ALWAYS written (timings.json)."""
+
+    def __init__(self):
+        self._t0 = time.monotonic()
+        self._lock = threading.Lock()
+        self.tasks = []
+
+    def record(self, name, seconds, **extra):
+        with self._lock:
+            self.tasks.append({"task": name, "seconds": round(seconds, 3), **extra})
+
+    def write(self, path, **meta):
+        body = {"totalSeconds": round(time.monotonic() - self._t0, 2),
+                "tasks": self.tasks, **meta}
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        json.dump(body, open(path, "w"), indent=2)
+        return body
+
+
+class QSApi:
+    """One QuickSight transport for the whole run.
+
+    boto3 (in-process, one session) when importable; aws CLI subprocess
+    otherwise. Both paths take/return the same shapes: ops are CLI-style
+    ("describe-data-set"), params are boto-style PascalCase kwargs
+    ({"DataSetId": ...}); AwsAccountId is injected automatically."""
+
+    def __init__(self, acct, region, profile=None, timings=None, force_cli=None):
+        self.acct, self.region, self.profile = acct, region, profile
+        self.timings = timings
+        self.boto = None
+        if force_cli is None:
+            force_cli = os.environ.get("QS_FORCE_CLI", "") not in ("", "0")
+        if not force_cli:
+            try:
+                import boto3  # optional — NOT a hard dependency
+                session = boto3.Session(profile_name=profile, region_name=region)
+                self.boto = session.client("quicksight")
+            except Exception:  # noqa: BLE001 — any failure -> CLI fallback
+                self.boto = None
+
+    @property
+    def transport(self):
+        return "boto3" if self.boto is not None else "aws-cli"
+
+    @staticmethod
+    def _kebab(name):
+        return re.sub(r"(?<!^)(?=[A-Z])", "-", name).lower()
+
+    def call(self, op, **params):
+        t = time.monotonic()
+        try:
+            if self.boto is not None:
+                fn = getattr(self.boto, op.replace("-", "_"))
+                return _jsonable(fn(AwsAccountId=self.acct, **params))
+            cmd = ["aws", "quicksight", op, "--aws-account-id", self.acct,
+                   "--region", self.region, "--output", "json"]
+            for k, v in params.items():
+                cmd += [f"--{self._kebab(k)}", str(v)]
+            if self.profile:
+                cmd += ["--profile", self.profile]
+            p = subprocess.run(cmd, capture_output=True, text=True)
+            if p.returncode != 0:
+                raise RuntimeError(p.stderr.strip() or f"aws call failed: {op}")
+            return json.loads(p.stdout)
+        finally:
+            if self.timings:
+                self.timings.record(f"{op}", time.monotonic() - t, transport=self.transport)
+
+
+class EstateCache:
+    """Estate-level dataset/datasource describe cache.
+
+    Datasets are keyed DataSetArn + LastUpdatedTime: cached entries are valid
+    only while the estate's list-data-sets summary (fetched ONCE per process)
+    reports the same LastUpdatedTime. Data sources are cached without a
+    freshness probe (described once, lazily — they change rarely); use
+    --refresh-cache to force. Thread-safe for batch mode."""
+
+    def __init__(self, api, enabled=True, refresh=False):
+        self.api = api
+        self.enabled = enabled
+        self.refresh = refresh
+        self.dir = os.path.join(CACHE_ROOT, f"{api.acct}__{api.region}")
+        self._lock = threading.Lock()
+        self._listing = None  # DataSetArn -> LastUpdatedTime (one call per process)
+        self._mem = {}        # in-process memo: "kind/id" -> describe response
+        self._inflight = {}   # single-flight per key (batch threads share one describe)
+
+    def _listing_map(self):
+        with self._lock:
+            if self._listing is None:
+                out, token = {}, None
+                while True:
+                    params = {"NextToken": token} if token else {}
+                    try:
+                        r = self.api.call("list-data-sets", **params)
+                    except Exception:  # listing denied -> cache validates by presence only
+                        self._listing = {}
+                        return self._listing
+                    for s in r.get("DataSetSummaries", []):
+                        out[s.get("Arn")] = str(s.get("LastUpdatedTime") or "")
+                    token = r.get("NextToken")
+                    if not token:
+                        break
+                self._listing = out
+            return self._listing
+
+    def _path(self, kind, rid):
+        return os.path.join(self.dir, kind, rid + ".json")
+
+    def _read(self, kind, rid):
+        try:
+            return json.load(open(self._path(kind, rid)))
+        except (OSError, ValueError):
+            return None
+
+    def _write(self, kind, rid, body):
+        try:
+            os.makedirs(os.path.dirname(self._path(kind, rid)), exist_ok=True)
+            json.dump(body, open(self._path(kind, rid), "w"), indent=2)
+        except OSError:
+            pass  # cache is best-effort
+
+    def _key_lock(self, key):
+        with self._lock:
+            return self._inflight.setdefault(key, threading.Lock())
+
+    def dataset(self, ds_id):
+        key = f"datasets/{ds_id}"
+        with self._key_lock(key):  # single-flight: batch threads share one describe
+            with self._lock:
+                if key in self._mem:
+                    return self._mem[key], "memo"
+            how = "describe"
+            ds = None
+            if self.enabled and not self.refresh:
+                cached = self._read("datasets", ds_id)
+                if cached:
+                    arn = cached.get("DataSet", {}).get("Arn")
+                    cached_lut = str(cached.get("DataSet", {}).get("LastUpdatedTime") or "")
+                    live_lut = self._listing_map().get(arn)
+                    # valid when the estate listing reports the same LastUpdatedTime
+                    # (listing unavailable/empty -> treat presence as a miss, not a hit)
+                    if live_lut is not None and live_lut == cached_lut:
+                        ds, how = cached, "cache"
+            if ds is None:
+                ds = self.api.call("describe-data-set", DataSetId=ds_id)
+                if self.enabled:
+                    self._write("datasets", ds_id, ds)
+            with self._lock:
+                self._mem[key] = ds
+            return ds, how
+
+    def datasource(self, src_id):
+        key = f"datasources/{src_id}"
+        with self._key_lock(key):  # single-flight
+            with self._lock:
+                if key in self._mem:
+                    return self._mem[key], "memo"
+            how = "describe"
+            s = None
+            if self.enabled and not self.refresh:
+                cached = self._read("datasources", src_id)
+                if cached:
+                    s, how = cached, "cache"
+            if s is None:
+                s = self.api.call("describe-data-source", DataSourceId=src_id)
+                if self.enabled:
+                    self._write("datasources", src_id, s)
+            with self._lock:
+                self._mem[key] = s
+            return s, how
+
+
+def arn_id(arn):
+    return arn.rsplit("/", 1)[-1]
+
+
+def field_columns(inner):
+    """Shallow-walk a visual's ChartConfiguration collecting referenced ColumnNames."""
+    cols = []
+    def walk(o):
+        if isinstance(o, dict):
+            col = o.get("Column")
+            if isinstance(col, dict) and "ColumnName" in col:
+                cols.append(col["ColumnName"])
+            for v in o.values():
+                walk(v)
+        elif isinstance(o, list):
+            for v in o:
+                walk(v)
+    walk(inner.get("ChartConfiguration", {}))
+    # dedupe, preserve order
+    seen, out = set(), []
+    for c in cols:
+        if c not in seen:
+            seen.add(c); out.append(c)
+    return out
+
+
+def visual_reference_lines(inner):
+    """ChartConfiguration.ReferenceLines[] -> a compact signal list (A-gap).
+    Captures axis binding + static value / dynamic aggregation + label so the
+    builder can emit Sigma refMarks faithfully."""
+    cc = inner.get("ChartConfiguration", {}) or {}
+    out = []
+    for rl in (cc.get("ReferenceLines") or []):
+        if str(rl.get("Status", "")).upper() == "DISABLED":
+            continue
+        dc = rl.get("DataConfiguration", {}) or {}
+        axis = "x" if "XAXIS" in str(dc.get("AxisBinding", "")).upper() else "y"
+        rec = {"axis": axis,
+               "label": (rl.get("LabelConfiguration", {})
+                         .get("CustomLabelConfiguration", {}) or {}).get("CustomLabel"),
+               "color": (rl.get("StyleConfiguration", {}) or {}).get("Color")}
+        sc = dc.get("StaticConfiguration") or {}
+        dyn = dc.get("DynamicConfiguration") or {}
+        if sc.get("Value") is not None:
+            rec["value"] = sc["Value"]
+        elif dyn:
+            rec["dynamicColumn"] = (dyn.get("Column", {}) or {}).get("ColumnName") \
+                or (dyn.get("MeasureAggregationFunction", {}).get("Column", {}) or {}).get("ColumnName")
+            rec["aggregation"] = (dyn.get("Calculation", {}) or {}).get("SimpleNumericalAggregation") \
+                or (dyn.get("MeasureAggregationFunction", {}) or {}).get("SimpleNumericalAggregation")
+        out.append(rec)
+    return out
+
+
+def visual_color(inner):
+    """Chart color encoding (B-gap). by-dimension = a Colors well holding a
+    categorical field; by-measure = a ColorScale gradient (Colors[] stops)."""
+    cc = inner.get("ChartConfiguration", {}) or {}
+    wells = cc.get("FieldWells", {}) or {}
+    agg = next((v for v in wells.values() if isinstance(v, dict)), wells)
+    color_fields = agg.get("Colors") or []
+    for f in color_fields:
+        if isinstance(f, dict) and ("CategoricalDimensionField" in f or "DateDimensionField" in f):
+            cdf = f.get("CategoricalDimensionField") or f.get("DateDimensionField") or {}
+            return {"by": "dimension", "column": (cdf.get("Column", {}) or {}).get("ColumnName")}
+    cs = agg.get("ColorScale") or cc.get("ColorScale")
+    if isinstance(cs, dict):
+        stops = [s.get("Color") if isinstance(s, dict) else s for s in (cs.get("Colors") or [])]
+        return {"by": "measure", "scheme": [c for c in stops if c]}
+    return None
+
+
+def sheet_controls(sh):
+    """QuickSight sheet FilterControls + ParameterControls (C-gap). Each becomes
+    a Sigma list control; the builder resolves the target column through the
+    analysis FilterGroups (FilterControl.SourceFilterId)."""
+    out = []
+    for kind, wraps in (("filter", sh.get("FilterControls") or []),
+                        ("parameter", sh.get("ParameterControls") or [])):
+        for w in wraps:
+            if not isinstance(w, dict):
+                continue
+            wtype, body = next(iter(w.items()), (None, {}))
+            body = body or {}
+            out.append({"kind": kind, "controlType": wtype,
+                        "controlId": body.get("FilterControlId") or body.get("ParameterControlId"),
+                        "title": body.get("Title"),
+                        "sourceFilterId": body.get("SourceFilterId"),
+                        "sourceParameterName": body.get("SourceParameterName")})
+    return out
+
+
+def filter_group_columns(defn):
+    """FilterId -> filtered ColumnName across the analysis FilterGroups, so a
+    FilterControl's SourceFilterId resolves to the column the control drives."""
+    out = {}
+    for fg in (defn.get("FilterGroups") or []):
+        for flt in (fg.get("Filters") or []):
+            if not isinstance(flt, dict):
+                continue
+            body = next(iter(flt.values()), {}) or {}
+            fid = body.get("FilterId")
+            col = (body.get("Column", {}) or {}).get("ColumnName") or body.get("ColumnName")
+            if fid and col:
+                out[fid] = col
+    return out
+
+
+def load_fixtures(fdir):
+    """Read describe-shaped JSONs from a dir: one analysis/dashboard definition
+    (top-level "Definition") + one or more datasets (top-level "DataSet")."""
+    analysis, datasets = None, []
+    for fn in sorted(os.listdir(fdir)):
+        if not fn.endswith(".json"):
+            continue
+        try:
+            j = json.load(open(os.path.join(fdir, fn)))
+        except (ValueError, OSError):
+            continue
+        if isinstance(j, dict) and "Definition" in j:
+            analysis = j
+        elif isinstance(j, dict) and "DataSet" in j:
+            datasets.append(j)
+    if analysis is None:
+        sys.exit(f"--from-fixtures: no analysis/dashboard definition JSON (top-level 'Definition') in {fdir}")
+    return analysis, datasets
+
+
+def discover_one(out, cache, fixture_dir=None, analysis_id=None, dashboard_id=None,
+                 log=print):
+    """One analysis/dashboard -> analysis.json + datasets/ + datasources/ +
+    signals.json under `out`. Shared `cache` makes repeated datasets free."""
+    os.makedirs(os.path.join(out, "datasets"), exist_ok=True)
+    os.makedirs(os.path.join(out, "datasources"), exist_ok=True)
+    offline = bool(fixture_dir)
+
+    fixture_ds = []
+    # 1. the analysis / dashboard definition
+    if offline:
+        d, fixture_ds = load_fixtures(os.path.expanduser(fixture_dir))
+        src_kind = "dashboard" if d.get("DashboardId") else "analysis"
+        src_id = d.get("AnalysisId") or d.get("DashboardId") or "fixture"
+    elif analysis_id:
+        d = cache.api.call("describe-analysis-definition", AnalysisId=analysis_id)
+        src_kind, src_id = "analysis", analysis_id
+    else:
+        d = cache.api.call("describe-dashboard-definition", DashboardId=dashboard_id)
+        src_kind, src_id = "dashboard", dashboard_id
+    name = d.get("Name")
+    defn = d["Definition"]
+    json.dump(d, open(os.path.join(out, "analysis.json"), "w"), indent=2)
+
+    # 2. datasets referenced by the definition — via the ESTATE CACHE (shared
+    #    datasets are described once per estate, not once per dashboard)
+    ds_meta, src_arns = [], set()
+    fixture_by_id = {ds["DataSet"].get("DataSetId"): ds for ds in fixture_ds}
+    for decl in defn.get("DataSetIdentifierDeclarations", []):
+        ident, ds_id = decl["Identifier"], arn_id(decl["DataSetArn"])
+        if offline:
+            ds = fixture_by_id.get(ds_id)
+            if ds is None:
+                log(f"  WARN: no fixture dataset JSON for '{ds_id}' — skipping")
+                continue
+        else:
+            ds, how = cache.dataset(ds_id)
+            if how != "describe":
+                log(f"  dataset {ds_id}: estate-cache {how} (no describe round-trip)")
+        json.dump(ds, open(os.path.join(out, "datasets", ds_id + ".json"), "w"), indent=2)
+        dso = ds["DataSet"]
+        for ptv in (dso.get("PhysicalTableMap") or {}).values():
+            for v in ptv.values():
+                if isinstance(v, dict) and v.get("DataSourceArn"):
+                    src_arns.add(v["DataSourceArn"])
+        ds_meta.append({"identifier": ident, "dataSetId": ds_id, "name": dso.get("Name"),
+                        "importMode": dso.get("ImportMode"),
+                        "columns": [c.get("Name") for c in dso.get("OutputColumns", [])]})
+
+    # 3. data sources (type tells us Snowflake/Redshift/S3/etc.) — once, lazily
+    src_meta = []
+    for arn in sorted(src_arns):
+        sid = arn_id(arn)
+        if offline:
+            src_meta.append({"dataSourceId": sid, "name": None, "type": "OFFLINE-FIXTURE"})
+            continue
+        try:
+            s, how = cache.datasource(sid)
+            if how != "describe":
+                log(f"  datasource {sid}: estate-cache {how}")
+            json.dump(s, open(os.path.join(out, "datasources", sid + ".json"), "w"), indent=2)
+            so = s["DataSource"]
+            src_meta.append({"dataSourceId": sid, "name": so.get("Name"), "type": so.get("Type")})
+        except Exception as e:  # noqa: BLE001 — datasource describe is best-effort
+            src_meta.append({"dataSourceId": sid, "name": None, "type": "UNKNOWN", "error": str(e)[:120]})
+
+    # 4. signals: per-sheet visuals + calc fields + params
+    fg_cols = filter_group_columns(defn)
+    sheets = []
+    for sh in defn.get("Sheets", []):
+        vis = []
+        for v in sh.get("Visuals", []):
+            (vtype, inner), = v.items()
+            t = inner.get("Title", {})
+            title = (t.get("FormatText") or {}).get("PlainText") if isinstance(t, dict) else None
+            rec = {"type": vtype, "visualId": inner.get("VisualId"),
+                   "title": title, "columns": field_columns(inner)}
+            # chart-fidelity signals: reference lines (A), color encoding (B)
+            refs = visual_reference_lines(inner)
+            if refs:
+                rec["referenceLines"] = refs
+            color = visual_color(inner)
+            if color:
+                rec["color"] = color
+            vis.append(rec)
+        # interactive controls (C): resolve each control's target column now so the
+        # signal is self-contained (the builder still resolves independently from
+        # analysis.json, but signals.json carries the resolved column for visibility).
+        ctls = sheet_controls(sh)
+        for c in ctls:
+            if c.get("sourceFilterId"):
+                c["targetColumn"] = fg_cols.get(c["sourceFilterId"])
+        srec = {"sheetId": sh.get("SheetId"), "name": sh.get("Name"), "visuals": vis}
+        if ctls:
+            srec["controls"] = ctls
+        sheets.append(srec)
+
+    calc = [{"name": c.get("Name"), "expression": c.get("Expression"), "dataset": c.get("DataSetIdentifier")}
+            for c in defn.get("CalculatedFields", [])]
+    params = [{"name": (list(p.values())[0] or {}).get("Name")} for p in defn.get("ParameterDeclarations", [])]
+
+    signals = {"source": {"kind": src_kind, "id": src_id, "name": name},
+               "datasets": ds_meta, "dataSources": src_meta,
+               "calculatedFields": calc, "parameters": params, "sheets": sheets}
+    json.dump(signals, open(os.path.join(out, "signals.json"), "w"), indent=2)
+
+    # summary
+    log(f"Discovered {src_kind} '{name}' → {out}")
+    log(f"  datasets: {len(ds_meta)}  | data sources: {[s['type'] for s in src_meta]}")
+    log(f"  calc fields: {len(calc)} | parameters: {len(params)}")
+    for s in sheets:
+        kinds = ", ".join(v["type"] for v in s["visuals"])
+        log(f"  sheet '{s['name']}': {len(s['visuals'])} visuals — {kinds}")
+    return signals
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--account-id")
+    ap.add_argument("--region")
+    ap.add_argument("--profile")
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--analysis-id")
+    g.add_argument("--dashboard-id")
+    g.add_argument("--analysis-ids", help="comma-separated — BATCH mode; each lands in <out-dir>/<id>/")
+    ap.add_argument("--from-fixtures", help="dir of describe-shaped JSONs — offline mode, no AWS calls")
+    ap.add_argument("--out-dir", required=True)
+    ap.add_argument("--pool", type=int, default=4,
+                    help=f"batch-mode parallel discoveries (default 4, cap {MAX_POOL})")
+    ap.add_argument("--no-cache", action="store_true", help="bypass the estate dataset/datasource cache")
+    ap.add_argument("--refresh-cache", action="store_true", help="force re-describe (and rewrite the cache)")
+    a = ap.parse_args(argv)
+    offline = bool(a.from_fixtures)
+    batch = [s.strip() for s in (a.analysis_ids or "").split(",") if s.strip()]
+    if not offline and not (a.analysis_id or a.dashboard_id or batch):
+        ap.error("need --analysis-id / --dashboard-id / --analysis-ids (or --from-fixtures)")
+    if not offline and not (a.account_id and a.region):
+        ap.error("--account-id and --region are required for live discovery")
+
+    out = os.path.expanduser(a.out_dir)
+    tm = Timings()
+    api = None
+    if not offline:
+        api = QSApi(a.account_id, a.region, a.profile, timings=tm)
+        print(f"[transport] {api.transport}"
+              + ("" if api.transport == "boto3" else " (boto3 not importable — per-call subprocess fallback)"))
+    cache = EstateCache(api, enabled=not a.no_cache, refresh=a.refresh_cache) if api else None
+
+    if batch:
+        pool = max(1, min(a.pool, MAX_POOL))
+        print(f"[batch] {len(batch)} analyses, pool={pool}, estate cache "
+              f"{'OFF' if a.no_cache else cache.dir}")
+        lock = threading.Lock()
+        def log(s):
+            with lock:
+                print(s)
+        def one(aid):
+            t = time.monotonic()
+            try:
+                discover_one(os.path.join(out, aid), cache, analysis_id=aid, log=log)
+                return aid, None, time.monotonic() - t
+            except Exception as e:  # noqa: BLE001 — batch keeps going
+                return aid, str(e)[:200], time.monotonic() - t
+        results = []
+        with ThreadPoolExecutor(max_workers=pool) as ex:
+            results = list(ex.map(one, batch))
+        failed = [(aid, err) for aid, err, _ in results if err]
+        for aid, err, secs in results:
+            tm.record(f"analysis:{aid}", secs, ok=err is None)
+            print(f"  {aid}: {'OK' if not err else 'FAIL — ' + err} ({secs:.1f}s)")
+        t = tm.write(os.path.join(out, "timings.json"), mode="batch",
+                     transport=api.transport, pool=pool,
+                     analyses=len(batch), failed=len(failed))
+        print(f"TIMINGS total={t['totalSeconds']}s -> {os.path.join(out, 'timings.json')}")
+        sys.exit(1 if failed else 0)
+
+    discover_one(out, cache, fixture_dir=a.from_fixtures,
+                 analysis_id=a.analysis_id, dashboard_id=a.dashboard_id)
+    t = tm.write(os.path.join(out, "timings.json"), mode="offline" if offline else "single",
+                 transport=api.transport if api else "none")
+    print(f"TIMINGS total={t['totalSeconds']}s "
+          + "  ".join(f"{x['task']}={x['seconds']}s" for x in t["tasks"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/scout-validate-and-persist.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/scout-validate-and-persist.rb
@@ -1,0 +1,168 @@
+#!/usr/bin/env ruby
+# Scout's terminal step: given a candidate Sigma formula + the gap context,
+# validate against the customer's Sigma site and persist the rule on success
+# or escalate on failure.
+#
+# This is what the gap-scout subagent invokes via Bash. The subagent does the
+# Claude-reasoning side (proposing the candidate); this script does the
+# deterministic side (POST, validate, write yaml).
+#
+# Usage:
+#   ruby scripts/scout-validate-and-persist.rb \
+#     --feature 'WINDOW_AVG' \
+#     --pattern '\bWINDOW_AVG\s*\(\s*SUM\s*\(\[([^\]]+)\]\)\s*\)' \
+#     --template 'MovingAvg(Sum([Master/\1]), -10, 10)' \
+#     --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+#     --data-model-id <dm-id> \
+#     --master-element-id master \
+#     [--folder-id <folder-id>] \
+#     [--description "..."] \
+#     [--hint "Sigma window functions silently error in grouping-table charts"] \
+#     [--example-from "workbook.twb line 123"] \
+#     [--max-attempts 3]
+#
+# Output (JSON to stdout):
+#   {
+#     "status": "validated" | "escalated",
+#     "rule_path": "~/.quicksight-to-sigma/learned-rules.yaml",  // on success
+#     "workbook_id": "...",                                       // on success
+#     "escalation_path": "~/.quicksight-to-sigma/escalations/...",// on failure
+#     "escalation": { "dry_run_cmd": "...", "file_cmd": "..." },  // on failure
+#     "attempts": [...]
+#   }
+#
+# Escalation is OPT-IN. On failure this script records the gap locally and
+# returns a ready-to-run `escalate-gap.py` command. It does NOT file anything.
+# The main agent shows the user the dry-run draft and only files (--yes) if the
+# user accepts. See scripts/gap-scout.md.
+
+require 'json'
+require 'optparse'
+require 'open3'
+require 'shellwords'
+require 'time'
+require_relative 'learned-rules'
+require_relative 'lib/scout_gate'
+
+opts = { max_attempts: 1 }
+OptionParser.new do |p|
+  p.on('--feature S')              { |v| opts[:feature] = v }
+  p.on('--pattern S')              { |v| opts[:pattern] = v }
+  p.on('--template S')             { |v| opts[:template] = v }
+  p.on('--test-formula S')         { |v| opts[:test_formula] = v }
+  p.on('--data-model-id S')        { |v| opts[:dm_id] = v }
+  p.on('--master-element-id S')    { |v| opts[:el_id] = v }
+  p.on('--folder-id S')            { |v| opts[:folder_id] = v }
+  p.on('--description S')          { |v| opts[:description] = v }
+  p.on('--hint S')                 { |v| opts[:hint] = v }
+  p.on('--example-from S')         { |v| opts[:example_from] = v }
+  p.on('--max-attempts N', Integer){ |v| opts[:max_attempts] = v }
+  p.on('--chart-kind S')           { |v| opts[:chart_kind] = v }
+  # Run-each-time gate (bead 5l5e) — see scout_gate.rb.
+  p.on('--gap-id S')               { |v| opts[:gap_id] = v }
+  p.on('--workdir S')              { |v| opts[:workdir] = v }
+end.parse!
+
+%i[feature pattern template test_formula dm_id el_id].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+def record_ledger(opts, status)
+  ScoutGate.record(opts[:workdir], gap_id: opts[:gap_id], feature: opts[:feature], status: status)
+end
+
+VALIDATE = File.join(__dir__, 'validate-sigma-formula.rb')
+
+attempt = {
+  'sigma_formula' => opts[:test_formula],
+  'tested_at'     => Time.now.utc.iso8601
+}
+
+# Run validate-sigma-formula.rb
+cmd = ['ruby', VALIDATE,
+       '--formula',           opts[:test_formula],
+       '--data-model-id',     opts[:dm_id],
+       '--master-element-id', opts[:el_id],
+       '--label',             "scout:#{opts[:feature]}"]
+cmd << '--folder-id'  << opts[:folder_id]  if opts[:folder_id]
+cmd << '--chart-kind' << opts[:chart_kind] if opts[:chart_kind]
+
+stdout, stderr, status = Open3.capture3(*cmd)
+result = (JSON.parse(stdout) rescue { 'status' => 'error', 'raw' => stdout, 'stderr' => stderr })
+attempt['result'] = result
+
+if result['status'] == 'ok'
+  rule = {
+    'feature'            => opts[:feature],
+    'description'        => opts[:description],
+    'tableau_pattern'    => opts[:pattern],
+    'sigma_template'     => opts[:template],
+    'hint'               => opts[:hint],
+    'validated_at'       => Time.now.utc.iso8601,
+    'validated_workbook' => result['workbook_id'],
+    'example_from'       => opts[:example_from],
+    'confidence'         => 'validated'
+  }
+  path = LearnedRules.append(rule)
+  record_ledger(opts, 'validated')
+  puts JSON.pretty_generate({
+    'status'      => 'validated',
+    'rule_path'   => path,
+    'workbook_id' => result['workbook_id'],
+    'attempts'    => [attempt],
+    'rule'        => rule
+  })
+  exit 0
+else
+  payload = {
+    'feature'         => opts[:feature],
+    'description'     => opts[:description],
+    'tableau_pattern' => opts[:pattern],
+    'tableau_template_attempted' => opts[:template],
+    'test_formula'    => opts[:test_formula],
+    'example_from'    => opts[:example_from],
+    'attempts'        => [attempt],
+    'escalated_at'    => Time.now.utc.iso8601
+  }
+  esc_path = LearnedRules.escalate(payload)
+  record_ledger(opts, 'escalated')
+
+  # Opt-in escalation (NOT automatic). We record the gap locally and hand the
+  # main agent a ready-to-run command for the shared filer. The agent shows the
+  # user the draft (dry run) and only files if they say yes (--yes). QuickSight
+  # calc-field gaps are converter gaps → mirror to the converter repos.
+  escalate = File.join(__dir__, 'escalate-gap.py')
+  # Trim the validator output to the error verdict — never forward spec_used /
+  # all_columns into the issue body (it bloats the command + issue to KBs).
+  res = attempt['result'] || {}
+  resp_summary = {
+    'status'        => res['status'],
+    'phase'         => res['phase'],
+    'error_columns' => res['error_columns']
+  }.compact
+  esc_cmd = [
+    'python3', escalate,
+    '--skill',              'quicksight-to-sigma',
+    '--category',           'converter',
+    '--feature',            opts[:feature],
+    '--description',        (opts[:description] || ''),
+    '--source-pattern',     (opts[:pattern] || ''),
+    '--template-attempted', (opts[:template] || ''),
+    '--test-formula',       (opts[:test_formula] || ''),
+    '--sigma-response',     JSON.generate(resp_summary),
+    '--example-from',       (opts[:example_from] || ''),
+    '--escalation-yaml',    esc_path
+  ]
+  suggested = esc_cmd.map { |a| Shellwords.escape(a) }.join(' ')
+
+  puts JSON.pretty_generate({
+    'status'          => 'escalated',
+    'escalation_path' => esc_path,
+    'attempts'        => [attempt],
+    'escalation' => {
+      'note'         => 'Gap recorded locally. To offer the user a tracking issue, ' \
+                        'run the dry-run command (shows the draft + dedupe), then re-run with --yes if they accept.',
+      'dry_run_cmd'  => suggested,
+      'file_cmd'     => "#{suggested} --yes"
+    }
+  })
+  exit 2
+end

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/setup.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/setup.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+print "Client ID: "
+cid = $stdin.noecho(&:gets).chomp
+puts
+
+print "Client Secret: "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/sigma-export-png.py
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/sigma-export-png.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""sigma-export-png.py — render a Sigma workbook page or element to PNG via the
+REST export API, for VISUAL QA of a migrated workbook (Phase 4: side-by-side
+against the source Looker dashboard).
+
+A PNG is more reliable than an MCP SQL query for catching LAYOUT/render problems —
+hidden KPI titles, orphaned filters, overlapping tiles, wrong chart kinds — that a
+numeric parity check can't see.
+
+POST /v2/workbooks/{id}/export {pageId|elementId, format:{type:"png",pixelWidth,pixelHeight}}
+  -> {queryId, jobComplete}; then GET /v2/query/{queryId}/download until the PNG is ready.
+
+Env: SIGMA_BASE_URL + SIGMA_API_TOKEN (eval "$(scripts/get-token.sh)").
+Usage:
+  python3 sigma-export-png.py --workbook <id> --page <pageId> --out /tmp/x.png
+  python3 sigma-export-png.py --workbook <id> --element <elId> --out /tmp/x.png [--w 1600 --h 900]
+"""
+import argparse, os, sys, time, requests
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--workbook", required=True)
+    ap.add_argument("--page"); ap.add_argument("--element")
+    ap.add_argument("--out", required=True)
+    ap.add_argument("--w", type=int, default=1600); ap.add_argument("--h", type=int, default=900)
+    a = ap.parse_args()
+    base = os.environ["SIGMA_BASE_URL"]; tok = os.environ["SIGMA_API_TOKEN"]
+    h = {"Authorization": f"Bearer {tok}", "Content-Type": "application/json"}
+    fmt = {"type": "png", "pixelWidth": a.w, "pixelHeight": a.h}
+    body = {"format": fmt}
+    if a.element: body["elementId"] = a.element
+    elif a.page:  body["pageId"] = a.page
+    else: sys.exit("need --page or --element")
+    r = requests.post(f"{base}/v2/workbooks/{a.workbook}/export", headers=h, json=body)
+    if r.status_code != 200: sys.exit(f"export POST {r.status_code}: {r.text[:300]}")
+    qid = r.json()["queryId"]
+    dl = f"{base}/v2/query/{qid}/download"
+    for i in range(60):
+        g = requests.get(dl, headers={"Authorization": f"Bearer {tok}"})
+        ct = g.headers.get("Content-Type", "")
+        if g.status_code == 200 and ("image" in ct or g.content[:8] == b"\x89PNG\r\n\x1a\n"):
+            open(a.out, "wb").write(g.content)
+            print(f"[png] {len(g.content)} bytes -> {a.out}"); return
+        time.sleep(3)
+    sys.exit("timed out waiting for PNG")
+
+if __name__ == "__main__":
+    main()

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/tests/test-quicksight-discover.py
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/tests/test-quicksight-discover.py
@@ -1,0 +1,274 @@
+#!/usr/bin/env python3
+"""Unit tests + mocked/recorded-response harness for the fast-discovery layer
+of quicksight-discover.py (boto3-in-process transport, aws-CLI fallback,
+estate-level dataset/datasource cache, batch mode).
+
+Live AWS is not required (and is currently IAM-blocked): the boto3 path is
+proven with an injected fake boto3 module replaying RECORDED describe-shaped
+responses (sourced from the skill's fixtures), and the CLI path with a stubbed
+subprocess.run. What still awaits live AWS validation is listed in SKILL.md.
+
+Run:  python3 scripts/tests/test-quicksight-discover.py
+"""
+import datetime
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SCRIPT = os.path.join(HERE, "..", "quicksight-discover.py")
+FIXTURES = os.path.join(HERE, "..", "..", "fixtures")
+
+spec = importlib.util.spec_from_file_location("qsdisc", SCRIPT)
+qsdisc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(qsdisc)
+
+ACCT, REGION = "123456789012", "us-east-1"
+
+
+def recorded():
+    """Recorded describe-shaped responses, anchored on the skill's real fixtures."""
+    analysis = json.load(open(os.path.join(FIXTURES, "orders-overview-analysis.json")))
+    dataset = json.load(open(os.path.join(FIXTURES, "dataset-orders-enriched.json")))
+    ds_id = dataset["DataSet"]["DataSetId"]
+    arn = dataset["DataSet"].get("Arn") or f"arn:aws:quicksight:{REGION}:{ACCT}:dataset/{ds_id}"
+    dataset["DataSet"]["Arn"] = arn
+    # pin the LastUpdatedTime so the recorded estate listing agrees with the
+    # describe response (the cache key is DataSetArn + LastUpdatedTime)
+    dataset["DataSet"]["LastUpdatedTime"] = "2026-06-01T00:00:00"
+    # ensure the dataset points at a datasource so the lazy datasource path runs
+    src_arn = f"arn:aws:quicksight:{REGION}:{ACCT}:datasource/snowflake-src"
+    ptm = dataset["DataSet"].setdefault("PhysicalTableMap", {})
+    if not any(v.get("DataSourceArn") for t in ptm.values() for v in t.values() if isinstance(v, dict)):
+        ptm["pt1"] = {"RelationalTable": {"DataSourceArn": src_arn, "Name": "ORDERS",
+                                          "InputColumns": []}}
+    datasource = {"DataSource": {"DataSourceId": "snowflake-src", "Arn": src_arn,
+                                 "Name": "Snowflake", "Type": "SNOWFLAKE"}}
+    return analysis, dataset, datasource
+
+
+class FakeQSClient:
+    """Replays recorded responses; counts every call (the harness assertions)."""
+
+    def __init__(self, analysis, dataset, datasource, listing_lut="2026-06-01T00:00:00"):
+        self.analysis, self.dataset, self.datasource = analysis, dataset, datasource
+        self.listing_lut = listing_lut
+        self.calls = []
+
+    def describe_analysis_definition(self, AwsAccountId=None, AnalysisId=None):
+        self.calls.append(("describe-analysis-definition", AnalysisId))
+        out = dict(self.analysis)
+        out["AnalysisId"] = AnalysisId
+        # boto3 returns datetimes — prove the normalization path
+        out["ResponseMetadata"] = {"RequestId": "x"}
+        out["LastUpdatedTime"] = datetime.datetime(2026, 6, 1, 12, 0, 0)
+        return out
+
+    def describe_data_set(self, AwsAccountId=None, DataSetId=None):
+        self.calls.append(("describe-data-set", DataSetId))
+        return json.loads(json.dumps(self.dataset))
+
+    def describe_data_source(self, AwsAccountId=None, DataSourceId=None):
+        self.calls.append(("describe-data-source", DataSourceId))
+        return json.loads(json.dumps(self.datasource))
+
+    def list_data_sets(self, AwsAccountId=None, **kw):
+        self.calls.append(("list-data-sets", None))
+        return {"DataSetSummaries": [{"Arn": self.dataset["DataSet"]["Arn"],
+                                      "LastUpdatedTime": self.listing_lut}]}
+
+    def count(self, op):
+        return sum(1 for o, _ in self.calls if o == op)
+
+
+def fake_boto3(client):
+    mod = types.ModuleType("boto3")
+    class Session:  # noqa: D401
+        def __init__(self, profile_name=None, region_name=None):
+            pass
+        def client(self, name):
+            assert name == "quicksight"
+            return client
+    mod.Session = Session
+    return mod
+
+
+class Base(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp(prefix="qsdisc-test-")
+        self._cache_root = qsdisc.CACHE_ROOT
+        qsdisc.CACHE_ROOT = os.path.join(self.tmp, "estate-cache")
+        self._boto3 = sys.modules.pop("boto3", None)
+        self._run = subprocess.run
+
+    def tearDown(self):
+        qsdisc.CACHE_ROOT = self._cache_root
+        subprocess.run = self._run
+        if self._boto3 is not None:
+            sys.modules["boto3"] = self._boto3
+        else:
+            sys.modules.pop("boto3", None)
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def api_with(self, client):
+        sys.modules["boto3"] = fake_boto3(client)
+        api = qsdisc.QSApi(ACCT, REGION, force_cli=False)
+        self.assertEqual(api.transport, "boto3")
+        return api
+
+    def quiet(self, *_a, **_k):
+        pass
+
+
+class TestTransport(Base):
+    def test_boto3_in_process_no_subprocess(self):
+        analysis, dataset, datasource = recorded()
+        client = FakeQSClient(analysis, dataset, datasource)
+        def boom(*a, **k):
+            raise AssertionError("subprocess used despite boto3 transport")
+        subprocess.run = boom
+        api = self.api_with(client)
+        out = api.call("describe-data-set", DataSetId=dataset["DataSet"]["DataSetId"])
+        self.assertEqual(out["DataSet"]["Name"], dataset["DataSet"]["Name"])
+        self.assertEqual(client.count("describe-data-set"), 1)
+
+    def test_cli_fallback_when_boto3_absent(self):
+        sys.modules.pop("boto3", None)
+        sys.modules["boto3"] = None  # import boto3 -> ImportError (None module)
+        captured = {}
+        def fake_run(cmd, capture_output=None, text=None):
+            captured["cmd"] = cmd
+            return types.SimpleNamespace(returncode=0, stdout=json.dumps({"ok": True}), stderr="")
+        subprocess.run = fake_run
+        api = qsdisc.QSApi(ACCT, REGION, profile="pivot", force_cli=False)
+        self.assertEqual(api.transport, "aws-cli")
+        out = api.call("describe-data-set", DataSetId="abc")
+        self.assertTrue(out["ok"])
+        cmd = captured["cmd"]
+        self.assertEqual(cmd[:3], ["aws", "quicksight", "describe-data-set"])
+        self.assertIn("--data-set-id", cmd)       # PascalCase -> kebab
+        self.assertIn("--aws-account-id", cmd)
+        self.assertIn("--profile", cmd)
+
+    def test_force_cli_env_wins_over_boto3(self):
+        analysis, dataset, datasource = recorded()
+        sys.modules["boto3"] = fake_boto3(FakeQSClient(analysis, dataset, datasource))
+        api = qsdisc.QSApi(ACCT, REGION, force_cli=True)
+        self.assertEqual(api.transport, "aws-cli")
+
+    def test_datetime_normalization_strips_response_metadata(self):
+        analysis, dataset, datasource = recorded()
+        client = FakeQSClient(analysis, dataset, datasource)
+        api = self.api_with(client)
+        out = api.call("describe-analysis-definition", AnalysisId="a1")
+        self.assertNotIn("ResponseMetadata", out)
+        self.assertEqual(out["LastUpdatedTime"], "2026-06-01T12:00:00")
+        json.dumps(out)  # fully serializable
+
+
+class TestEstateCache(Base):
+    def discover(self, cache, aid, client):
+        out = os.path.join(self.tmp, aid)
+        return qsdisc.discover_one(out, cache, analysis_id=aid, log=self.quiet)
+
+    def test_shared_dataset_described_once_per_estate(self):
+        analysis, dataset, datasource = recorded()
+        client = FakeQSClient(analysis, dataset, datasource)
+        api = self.api_with(client)
+        cache = qsdisc.EstateCache(api)
+        self.discover(cache, "a1", client)   # describes the dataset
+        self.discover(cache, "a2", client)   # same dataset -> memo, no describe
+        self.assertEqual(client.count("describe-data-set"), 1)
+        # a NEW process (new cache instance) with an unchanged estate -> disk
+        # cache hit validated against ONE list-data-sets, still no re-describe
+        cache2 = qsdisc.EstateCache(api)
+        self.discover(cache2, "a3", client)
+        self.assertEqual(client.count("describe-data-set"), 1)
+        self.assertEqual(client.count("list-data-sets"), 1)
+
+    def test_cache_invalidated_on_lastupdatedtime_change(self):
+        analysis, dataset, datasource = recorded()
+        client = FakeQSClient(analysis, dataset, datasource)
+        api = self.api_with(client)
+        self.discover(qsdisc.EstateCache(api), "a1", client)
+        self.assertEqual(client.count("describe-data-set"), 1)
+        # unchanged estate -> disk hit (proves the hit BEFORE proving the miss)
+        self.discover(qsdisc.EstateCache(api), "a2", client)
+        self.assertEqual(client.count("describe-data-set"), 1)
+        client.listing_lut = "2026-06-09T09:00:00"  # dataset changed upstream
+        self.discover(qsdisc.EstateCache(api), "a3", client)
+        self.assertEqual(client.count("describe-data-set"), 2)
+
+    def test_datasource_described_once_lazily(self):
+        analysis, dataset, datasource = recorded()
+        client = FakeQSClient(analysis, dataset, datasource)
+        api = self.api_with(client)
+        cache = qsdisc.EstateCache(api)
+        self.discover(cache, "a1", client)
+        self.discover(cache, "a2", client)
+        self.assertEqual(client.count("describe-data-source"), 1)
+        # new process: datasource comes from disk cache, no probe call at all
+        self.discover(qsdisc.EstateCache(api), "a3", client)
+        self.assertEqual(client.count("describe-data-source"), 1)
+
+    def test_no_cache_flag_bypasses(self):
+        analysis, dataset, datasource = recorded()
+        client = FakeQSClient(analysis, dataset, datasource)
+        api = self.api_with(client)
+        self.discover(qsdisc.EstateCache(api, enabled=False), "a1", client)
+        self.discover(qsdisc.EstateCache(api, enabled=False), "a2", client)
+        self.assertEqual(client.count("describe-data-set"), 2)
+
+    def test_signals_shape_matches_offline_run(self):
+        analysis, dataset, datasource = recorded()
+        client = FakeQSClient(analysis, dataset, datasource)
+        api = self.api_with(client)
+        sig = self.discover(qsdisc.EstateCache(api), "a1", client)
+        self.assertEqual(sig["source"]["kind"], "analysis")
+        self.assertEqual(len(sig["datasets"]), 1)
+        self.assertEqual(sig["dataSources"][0]["type"], "SNOWFLAKE")
+        self.assertTrue(all("visuals" in s for s in sig["sheets"]))
+        self.assertTrue(os.path.exists(os.path.join(self.tmp, "a1", "signals.json")))
+
+
+class TestBatchMode(Base):
+    def test_batch_parallel_discovery(self):
+        analysis, dataset, datasource = recorded()
+        client = FakeQSClient(analysis, dataset, datasource)
+        sys.modules["boto3"] = fake_boto3(client)
+        out = os.path.join(self.tmp, "estate")
+        with self.assertRaises(SystemExit) as cm:
+            qsdisc.main(["--account-id", ACCT, "--region", REGION,
+                         "--analysis-ids", "a1,a2,a3", "--pool", "4",
+                         "--out-dir", out])
+        self.assertEqual(cm.exception.code, 0)
+        for aid in ("a1", "a2", "a3"):
+            self.assertTrue(os.path.exists(os.path.join(out, aid, "signals.json")), aid)
+        # the shared estate cache held: 3 analyses, ONE dataset describe
+        self.assertEqual(client.count("describe-data-set"), 1)
+        self.assertEqual(client.count("describe-analysis-definition"), 3)
+        t = json.load(open(os.path.join(out, "timings.json")))
+        self.assertEqual(t["mode"], "batch")
+        self.assertEqual(t["analyses"], 3)
+        self.assertTrue(any(x["task"].startswith("analysis:") for x in t["tasks"]))
+
+
+class TestFixturePath(Base):
+    def test_offline_fixture_run_stays_green(self):
+        out = os.path.join(self.tmp, "fixture-run")
+        qsdisc.main(["--from-fixtures", FIXTURES, "--out-dir", out])
+        sig = json.load(open(os.path.join(out, "signals.json")))
+        self.assertEqual(sig["source"]["name"], "Orders Overview")
+        self.assertEqual(len(sig["sheets"][0]["visuals"]), 5)
+        self.assertEqual(sig["dataSources"][0]["type"], "OFFLINE-FIXTURE")
+        self.assertTrue(os.path.exists(os.path.join(out, "timings.json")))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/validate-sigma-formula.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/validate-sigma-formula.rb
@@ -1,0 +1,199 @@
+#!/usr/bin/env ruby
+# Validate that a candidate Sigma formula resolves cleanly against a given
+# Sigma data-model context. The primitive used by the gap-scout subagent to
+# decide whether a proposed translation actually works.
+#
+# Usage:
+#   ruby scripts/validate-sigma-formula.rb \
+#     --formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+#     --data-model-id <dm-id> \
+#     --master-element-id <element-id>  \
+#     [--folder-id <folder-id>] \
+#     [--chart-kind bar-chart|line-chart|table]
+#
+# What it does:
+#   1. Builds a tiny Sigma workbook spec with:
+#      - Data page: a master table pulling from the supplied DM element
+#      - Test page: a single chart that uses the candidate formula as a column
+#   2. POSTs to /v2/workbooks/spec
+#   3. Reads /v2/workbooks/{id}/elements/{el}/columns and checks for
+#      type.type == "error"
+#   4. Emits a JSON result to stdout (machine-parseable):
+#        { "status": "ok" | "error",
+#          "workbook_id": "...",
+#          "error_columns": [{ "label": "...", "err": {...} }],
+#          "spec_used": {...} }
+#
+# Env: requires SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET
+# (the same as post-and-readback.rb)
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'yaml'
+require 'base64'
+require 'optparse'
+
+opts = {
+  chart_kind: 'table',
+  folder_id: nil
+}
+OptionParser.new do |p|
+  p.on('--formula F')             { |v| opts[:formula] = v }
+  p.on('--data-model-id ID')      { |v| opts[:dm_id] = v }
+  p.on('--master-element-id ID')  { |v| opts[:el_id] = v }
+  p.on('--folder-id ID')          { |v| opts[:folder_id] = v }
+  p.on('--chart-kind K')          { |v| opts[:chart_kind] = v }
+  p.on('--label L')               { |v| opts[:label] = v }
+  p.on('--keep-workbook')         { opts[:keep] = true }
+end.parse!
+%i[formula dm_id el_id].each { |k| abort("missing --#{k.to_s.tr('_','-')}") unless opts[k] }
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+CID  = ENV.fetch('SIGMA_CLIENT_ID')
+CSEC = ENV.fetch('SIGMA_CLIENT_SECRET')
+
+# --- Auth -----------------------------------------------------------------
+def get_token
+  uri = URI("#{BASE}/v2/auth/token")
+  req = Net::HTTP::Post.new(uri)
+  req['Authorization'] = "Basic #{Base64.strict_encode64("#{CID}:#{CSEC}")}"
+  req['Content-Type']  = 'application/x-www-form-urlencoded'
+  req.body = 'grant_type=client_credentials'
+  resp = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
+  JSON.parse(resp.body).fetch('access_token')
+end
+BASE; TOK = get_token
+
+def http(method, path, body: nil, accept_json: true)
+  uri = URI("#{BASE}#{path}")
+  req = case method
+        when :post   then r = Net::HTTP::Post.new(uri); r.body = body; r['Content-Type'] = 'application/json'; r
+        when :get    then Net::HTTP::Get.new(uri)
+        when :delete then Net::HTTP::Delete.new(uri)
+        end
+  req['Authorization'] = "Bearer #{TOK}"
+  req['Accept']        = 'application/json' if accept_json
+  Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
+end
+
+# --- Build the test spec ---------------------------------------------------
+formula = opts[:formula]
+label   = opts[:label] || 'scout-test-col'
+
+# Master needs at least one column to be valid — use a passthrough on whatever
+# the DM element exposes. We don't know its specific columns up front; the
+# scout caller should already know that [Master/X] refs in the formula resolve
+# against the DM's columns. To validate, we POST and read back the chart's
+# column types.
+
+# Auto-discover the DM element's columns so test formulas that reference real
+# data columns (e.g., `[Master/Gross Revenue]`) resolve cleanly. Without this,
+# the test master only exposes a synthetic PassThrough column and any candidate
+# touching real data fails with a misleading "dependency not found" error.
+dm_spec_resp = http(:get, "/v2/dataModels/#{opts[:dm_id]}/spec")
+dm_spec      = JSON.parse(dm_spec_resp.body) rescue {}
+dm_element   = (dm_spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+                                       .find { |e| e['id'] == opts[:el_id] }
+dm_element_name = dm_element && dm_element['name']
+dm_cols = (dm_element && dm_element['columns']) || []
+
+# Build passthrough master columns from the DM element. Prefer the element-
+# level `name` (which respects any renames the DM author did) over parsing
+# the underlying-table name out of `[SOURCE/Col]` formulas — those two can
+# differ when the DM renames a column.
+master_columns = []
+dm_cols.each do |c|
+  display_name = c['name']
+  if (display_name.nil? || display_name.empty?) && (m = c['formula'].to_s.match(/^\[[^\/]+\/([^\]]+)\]$/))
+    display_name = m[1]
+  end
+  next if display_name.nil? || display_name.empty?
+  next unless dm_element_name
+  slug = display_name.downcase.gsub(/\W+/, '-').sub(/-$/, '')
+  master_columns << {
+    'id'      => "m-#{slug}",
+    'name'    => display_name,
+    'formula' => "[#{dm_element_name}/#{display_name}]"
+  }
+end
+master_columns << { 'id' => 'm-passthrough', 'name' => 'PassThrough', 'formula' => 'RowNumber()' } if master_columns.empty?
+
+master_el = {
+  'id'              => 'master',
+  'kind'            => 'table',
+  'name'            => 'Master',
+  'source'          => { 'kind' => 'data-model', 'dataModelId' => opts[:dm_id], 'elementId' => opts[:el_id] },
+  'columns'         => master_columns,
+  'visibleAsSource' => false
+}
+
+test_el = {
+  'id'   => 'el-scout-test',
+  'kind' => opts[:chart_kind],
+  'name' => 'Scout test',
+  'source' => { 'kind' => 'table', 'elementId' => 'master' },
+  'columns' => [
+    { 'id' => 'col-scout-test', 'name' => label, 'formula' => formula }
+  ]
+}
+
+spec = {
+  'name'           => "[scout-test] #{label}-#{Time.now.to_i}",
+  'schemaVersion'  => 1,
+  'pages' => [
+    { 'id' => 'page-data', 'name' => 'Data', 'elements' => [master_el] },
+    { 'id' => 'page-test', 'name' => 'Test', 'elements' => [test_el] }
+  ]
+}
+spec['folderId'] = opts[:folder_id] if opts[:folder_id]
+
+# --- POST + readback -------------------------------------------------------
+resp = http(:post, '/v2/workbooks/spec', body: JSON.generate(spec))
+parsed = (YAML.safe_load(resp.body, permitted_classes: [Date, Time]) rescue nil)
+parsed ||= (JSON.parse(resp.body) rescue { 'raw' => resp.body })
+
+wb_id = parsed.is_a?(Hash) && parsed['workbookId']
+unless wb_id
+  puts JSON.pretty_generate({
+    'status' => 'error',
+    'phase'  => 'post',
+    'workbook_id' => nil,
+    'error'  => parsed,
+    'spec_used' => spec
+  })
+  exit 1
+end
+
+# Walk both elements; we mostly care about the test element
+cols_resp = http(:get, "/v2/workbooks/#{wb_id}/elements/el-scout-test/columns")
+cols_data = JSON.parse(cols_resp.body)
+entries = cols_data['entries'] || []
+error_cols = entries.select do |c|
+  t = c['type']
+  tt = t.is_a?(Hash) ? t['type'] : t
+  tt == 'error'
+end
+
+status = error_cols.empty? ? 'ok' : 'error'
+
+# Clean up the throwaway test workbook (unless --keep-workbook). The scout only
+# needs the column-type verdict; leaving the workbook behind orphans one file per
+# attempt in the customer's folder.
+cleaned = false
+unless opts[:keep]
+  del = http(:delete, "/v2/files/#{wb_id}")
+  cleaned = del.code.to_i.between?(200, 299)
+end
+
+puts JSON.pretty_generate({
+  'status'        => status,
+  'phase'         => 'columns',
+  'workbook_id'   => wb_id,
+  'workbook_cleaned' => cleaned,
+  'error_columns' => error_cols.map { |c| { 'label' => c['label'], 'formula' => c['formula'], 'err' => c['type'] } },
+  'all_columns'   => entries.map { |c| { 'label' => c['label'], 'type' => (c['type'].is_a?(Hash) ? c['type']['type'] : c['type']) } },
+  'spec_used'     => spec
+})
+
+exit(status == 'ok' ? 0 : 2)

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/validate-spec.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/validate-spec.rb
@@ -1,0 +1,259 @@
+#!/usr/bin/env ruby
+# Validate a DM or workbook spec before POST/PUT.
+# Encapsulates the embedded Python validator from SKILL.md (in Ruby), and adds
+# cross-source ref support for workbook specs that reference DM elements.
+#
+# Usage:
+#   ruby validate-spec.rb --type datamodel <spec.json>
+#   ruby validate-spec.rb --type workbook  --dm-context <dm-id-map.json> <spec.json>
+#
+#   <dm-id-map.json> is the output of post-and-readback.rb for the DM:
+#     { dataModelId: "...", pages: [{ id, name, elements: [{id, name}] }] }
+
+require 'json'
+require 'optparse'
+require 'set'
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_functions'
+
+opts = { type: nil, dm_context: nil }
+op = OptionParser.new do |p|
+  p.on('--type T', %w[datamodel workbook]) { |v| opts[:type] = v }
+  p.on('--dm-context PATH')                { |v| opts[:dm_context] = v }
+end
+op.parse!
+abort('--type required (datamodel|workbook)') unless opts[:type]
+abort('usage: validate-spec.rb --type T [--dm-context P] <spec.json>') if ARGV.empty?
+
+spec = JSON.parse(File.read(ARGV[0]))
+
+# Known prefixes the validator considers valid for cross-element refs
+external_names = []  # element names that are sources OUTSIDE this spec (e.g., DM elements when validating a workbook)
+if opts[:type] == 'workbook' && opts[:dm_context]
+  ctx = JSON.parse(File.read(opts[:dm_context]))
+  # Accept both shapes:
+  #   - post-and-readback.rb output: { pages: [{ elements: [...] }] }
+  #   - flat element list:           { elements: [...] }   (legacy / hand-written)
+  if ctx['pages'].is_a?(Array)
+    external_names.concat(ctx['pages'].flat_map { |p| p.fetch('elements', []).map { |e| e['name'] } }.compact)
+  elsif ctx['elements'].is_a?(Array)
+    external_names.concat(ctx['elements'].map { |e| e['name'] }.compact)
+  end
+  if external_names.empty?
+    abort "validate-spec.rb: --dm-context loaded 0 element names from #{opts[:dm_context]}. " \
+          "Expected either {pages:[{elements:[...]}]} (post-and-readback output) or {elements:[...]} (flat). " \
+          "Re-run post-and-readback.rb --type datamodel and pass its --out file."
+  end
+end
+
+errors = []
+all_element_names = []
+spec.fetch('pages', []).each do |page|
+  page.fetch('elements', []).each { |el| all_element_names << el['name'] if el['name'] }
+end
+all_known_prefixes = (all_element_names + external_names).to_set rescue (all_element_names + external_names)
+require 'set' rescue nil
+all_known_set = all_known_prefixes.is_a?(Set) ? all_known_prefixes : Set.new(all_known_prefixes)
+
+errors << 'spec contains rgb(...) color strings (Cloudflare WAF blocks)' if JSON.generate(spec).include?('rgb(')
+
+spec.fetch('pages', []).each do |page|
+  page.fetch('elements', []).each do |el|
+    kind = el['kind'] || ''
+    name = el['name'] || el['id'] || '?'
+    cols = (el['columns'] || []) + (el['metrics'] || [])
+    sibling_names = Set.new(cols.map { |c| c['name'] }.compact)
+
+    src = el['source'] || {}
+    own_prefixes = Set.new
+    if src['kind'] == 'warehouse-table' && src['path']
+      own_prefixes << src['path'].last
+    end
+    own_prefixes << 'Custom SQL' if src['kind'] == 'sql'
+    # bead 1t6c: a master sourcing a DM element (kind: data-model) carries
+    # pass-through column formulas like [EMPLOYEES/Department] whose prefix is the
+    # DM element's source-table name — that lives INSIDE the data model, not this
+    # spec, so it can't be cross-checked here and was false-flagged "unknown
+    # prefix". The DM post already validated these columns; trust the prefixes the
+    # element's own formulas use.
+    if src['kind'] == 'data-model'
+      cols.each do |c|
+        (c['formula'] || '').to_s.scan(/\[([^\]\/]+)\//).flatten.each { |p| own_prefixes << p }
+      end
+    end
+
+    cols.each do |col|
+      f = (col['formula'] || '').to_s
+
+      # ---- Whitelist enforcement: every function call name must be in the
+      # canonical Sigma function library. Anything else is a Tableau-syntax
+      # leak, an imagined helper (IsIn / ToText), or a typo. Rewrite using a
+      # documented function OR move the logic into a Custom SQL element.
+      unknown = SigmaFunctions.unknown_functions(f) - [name, col['name']].compact
+      # Tableau formula refs use lots of identifiers that look like fn calls
+      # but are bracket-delimited (e.g., `[ORDERS/Sales]`). The regex already
+      # only matches identifiers followed by `(`, so this is the cleanup set.
+      # Skip the IF chain on uppercase Tableau identifiers like `IF`, `THEN`,
+      # `END`, `WHEN`, which the agent may slip through inadvertently.
+      reserved_tableau = %w[IF THEN ELSE ELSEIF END WHEN CASE AND OR NOT]
+      unknown.reject! { |n| reserved_tableau.include?(n.upcase) }
+      unless unknown.empty?
+        errors << "#{name}.#{col['name']}: formula references function(s) not in Sigma's library: #{unknown.join(', ')}. Either rewrite using a documented function (see scripts/lib/sigma_functions.rb) OR move the logic into a Custom SQL data-model element (kind: \"sql\")."
+      end
+      # ---- Tableau-syntax leak detection. Catches IIF / COUNTD / WINDOW_* /
+      # RUNNING_* / RANK_* / LOD braces / IsIn / ToText / etc. with explicit
+      # translation hints.
+      SigmaFunctions.tableau_leaks(f).each do |hint|
+        errors << "#{name}.#{col['name']}: #{hint}"
+      end
+
+      f.scan(/\[([^\]]+)\]/).flatten.each do |ref|
+        if ref.include?('/')
+          prefix = ref.split('/', 1)[0] # bug-fix: split with limit 2
+          prefix = ref.split('/', 2)[0]
+          unless own_prefixes.include?(prefix) || all_known_set.include?(prefix)
+            errors << "#{name}.#{col['name']}: ref [#{ref}] — prefix \"#{prefix}\" unknown " \
+                      "(known: #{(own_prefixes + all_known_set).to_a.sort.join(', ')})"
+          end
+        else
+          unless sibling_names.include?(ref)
+            errors << "#{name}.#{col['name']}: bare ref [#{ref}] not a sibling column"
+          end
+        end
+      end
+
+      if f =~ /\b(Weekday|Month|Year|Quarter|Day|Hour|Minute)\s*\(/i
+        if f.include?('If(') && !f.include?('IsNull(') && !f.include?('Coalesce(')
+          errors << "#{name}.#{col['name']}: nested-If on date function without IsNull/Coalesce guard"
+        end
+      end
+    end
+
+    errors << "#{name}: invalid kind \"kpi\" — must be \"kpi-chart\"" if kind == 'kpi'
+    errors << "#{name}: invalid kind \"pie\" — must be \"pie-chart\"" if kind == 'pie'
+    errors << "#{name}: invalid kind \"donut\" — must be \"donut-chart\"" if kind == 'donut'
+    errors << "#{name}: kpi-chart missing value" if kind == 'kpi-chart' && !el['value']
+    # Breaking-change-2026-06-11: kpi-chart value binding moved id -> columnId
+    # (matching the 2026-05-21 chart axis change).
+    # OLD (now rejected): value: {id: ...}   NEW (required): value: {columnId: ...}
+    if kind == 'kpi-chart' && (v = el['value']).is_a?(Hash) && v['id'] && !v['columnId']
+      errors << "#{name}: kpi-chart value uses old shape {id: ...} — must be {columnId: ...} (breaking change 2026-06-11)"
+    end
+
+    if %w[pie-chart donut-chart].include?(kind)
+      errors << "#{name}: #{kind} missing color" unless el['color']
+      errors << "#{name}: #{kind} missing value" unless el['value']
+    end
+
+    if kind == 'donut-chart' && el['holeValue']
+      hv = el['holeValue']
+      if !hv.is_a?(Hash) || !hv['id']
+        errors << "#{name}: donut-chart holeValue must be {\"id\":...}"
+      elsif hv['id'] == el.dig('value', 'id')
+        errors << "#{name}: donut-chart holeValue.id equals value.id — element silently dropped"
+      end
+    end
+
+    # --- Color-channel shape — cartesian + map charts use {by, column}, NOT {id}.
+    # Pie/donut use {id}. Caught 2 of Superstore's HTTP 400s (area + region-map).
+    if %w[bar-chart line-chart area-chart combo-chart scatter-chart region-map point-map].include?(kind)
+      if (color = el['color']).is_a?(Hash) && color['id'] && !color['by'] && !color['column']
+        errors << "#{name}: #{kind} color uses pie/donut shape {id: ...} — must be {by: \"category\"|\"scale\", column: \"...\"} for cartesian + map charts (API rejects with `Invalid value: object`)"
+      end
+    end
+
+    # --- Axis sort direction — must be "ascending"/"descending", NOT "asc"/"desc".
+    # Caught 1 of Superstore's HTTP 400s.
+    %w[xAxis yAxis].each do |axis_key|
+      ax = el[axis_key]
+      ax = ax.first if ax.is_a?(Array) && ax.first.is_a?(Hash)
+      next unless ax.is_a?(Hash)
+      next unless (sort = ax['sort']).is_a?(Hash)
+      dir = sort['direction']
+      if %w[asc desc].include?(dir)
+        errors << "#{name}: #{axis_key}.sort.direction \"#{dir}\" — must be \"ascending\" or \"descending\" (API rejects abbreviations)"
+      end
+    end
+
+    if %w[bar-chart line-chart area-chart combo-chart scatter-chart].include?(kind)
+      errors << "#{name}: use yAxis not measures for #{kind}" if el['measures']
+      errors << "#{name}: #{kind} missing yAxis" unless el['yAxis']
+      # Breaking-change-2026-05-21: xAxis / yAxis took new shape.
+      # OLD (now rejected): xAxis: {id: ...}, yAxis: [{id: ...}]
+      # NEW (required):     xAxis: {columnId: ...}, yAxis: {columnIds: [...]}
+      if (xa = el['xAxis']).is_a?(Hash) && xa['id'] && !xa['columnId']
+        errors << "#{name}: xAxis uses old shape {id: ...} — must be {columnId: ...} (breaking change 2026-05-21)"
+      end
+      if (ya = el['yAxis']).is_a?(Array)
+        errors << "#{name}: yAxis uses old shape [{id: ...}] — must be {columnIds: [...]} (breaking change 2026-05-21)"
+      elsif ya.is_a?(Hash) && !ya['columnIds']
+        errors << "#{name}: yAxis missing columnIds array"
+      end
+    end
+
+    if kind == 'pivot-table'
+      errors << "#{name}: pivot-table must use rowsBy/columnsBy" if el['rows'] || el['columnGroups']
+      errors << "#{name}: pivot-table without rowsBy renders only a grand-total row" if (el['rowsBy'] || []).empty?
+      # Wrong-field-name: agents often write `valuesBy` because rowsBy/columnsBy
+      # exist. The right field is bare `values`. Caught 1 of Superstore's HTTP 400s.
+      if el['valuesBy'] && !el['values']
+        errors << "#{name}: pivot-table field is `values` (bare string array), not `valuesBy` — rename `valuesBy` → `values`"
+      end
+      # Month-name string dimension on a pivot sorts alphabetically (Apr / Aug /
+      # Dec / Feb...). Catch the common MonthName(...) formula on a rowsBy /
+      # columnsBy column. Suggest Month(...) (returns 1-12) or a pre-computed
+      # Month Num column.
+      pivot_dim_ids = (el['rowsBy'].to_a + el['columnsBy'].to_a)
+                      .select { |x| x.is_a?(Hash) }.map { |x| x['id'] }.compact.to_set
+      cols.each do |col|
+        next unless pivot_dim_ids.include?(col['id'])
+        f = col['formula'].to_s
+        if f =~ /\bMonthName\s*\(/i || f =~ /\bDayName\s*\(/i
+          errors << "#{name}.#{col['name']}: pivot-table dim uses MonthName/DayName (string) — sorts alphabetically (Apr/Aug/Dec/Feb...). Use Month(...) (1-12) / Weekday(...) (1-7) for chronological order, then format the label downstream."
+        end
+      end
+      # Shape: values is a flat string-array of column IDs; rowsBy/columnsBy are {id: "..."} object arrays.
+      # Mixing these up costs multiple POST iterations because the API rejects with a generic Invalid array message.
+      if (vals = el['values']).is_a?(Array)
+        bad_val = vals.find { |v| v.is_a?(Hash) }
+        errors << "#{name}: pivot-table values must be a flat string array like [\"col-id\"], not [{id:...}] (got #{bad_val.inspect})" if bad_val
+      end
+      %w[rowsBy columnsBy].each do |key|
+        next unless (entries = el[key]).is_a?(Array)
+        bad = entries.find { |e| e.is_a?(String) || (e.is_a?(Hash) && !e['id']) }
+        if bad.is_a?(String)
+          errors << "#{name}: pivot-table #{key} must be objects like [{id: \"col-id\"}], not bare strings (got #{bad.inspect})"
+        elsif bad.is_a?(Hash) && bad['columnId']
+          errors << "#{name}: pivot-table #{key} entries use {id: ...}, not {columnId: ...} (got #{bad.inspect})"
+        elsif bad
+          errors << "#{name}: pivot-table #{key} entry missing id key (got #{bad.inspect})"
+        end
+      end
+    end
+  end
+end
+
+if opts[:type] == 'workbook'
+  spec.fetch('pages', []).each do |page|
+    els = page.fetch('elements', [])
+    masters = els.select do |e|
+      e['kind'] == 'table' &&
+        e['visibleAsSource'] == false &&
+        e.dig('source', 'kind') == 'data-model'
+    end
+    next if masters.empty?
+
+    others = els.reject { |e| masters.include?(e) }
+    unless others.empty?
+      master_names = masters.map { |m| m['name'] || m['id'] }.join(', ')
+      kind_counts = Hash.new(0)
+      others.each { |o| kind_counts[o['kind']] += 1 }
+      other_kinds = kind_counts.map { |k, n| "#{n} #{k}" }.join(', ')
+      errors << "page \"#{page['name'] || page['id']}\" mixes master table(s) [#{master_names}] with #{other_kinds}. Move the master to a dedicated \"Data\" page; charts on content pages reference it via cross-page elementId."
+    end
+  end
+end
+
+errors.each { |e| puts "ERROR: #{e}" }
+puts "--- #{errors.size} errors"
+exit(errors.empty? ? 0 : 1)

--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/verify-parity.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/verify-parity.rb
@@ -1,0 +1,237 @@
+#!/usr/bin/env ruby
+# Parity verification: compare expected (from Tableau CSVs) vs actual
+# (from Sigma queries) for each chart in a plan.
+#
+# Plan format (JSON array):
+#   [{ "chart": "...",
+#      "expected": [[dim, val], ...],
+#      "actual":   { "rows": [[dim, val], ...] },
+#      "extract":  true|false   # optional per-chart override
+#   }]
+#
+# A top-level wrapper is also accepted:
+#   { "extract": true, "charts": [ ... ] }
+# in which case `extract` propagates to every chart.
+#
+# --strict      value-exact comparison (default)
+# --extract-mode  structural comparison only — when Tableau view CSVs come from
+#                 a workbook with hasExtracts=true, the absolute values can drift
+#                 from Sigma (live warehouse) while the chart shape is correct.
+#                 Extract-mode checks:
+#                   - same number of buckets (rows)
+#                   - same set of dimension values
+#                   - same sort order on the dimension column
+#                   - measure values within `--extract-tol` relative tolerance
+#                     (default 0.30 = 30%) IF both are non-null, otherwise skipped
+#
+# Usage:
+#   ruby verify-parity.rb --plan plan.json
+#   ruby verify-parity.rb --plan plan.json --extract-mode
+#   ruby verify-parity.rb --plan plan.json --extract-mode --extract-tol 0.50
+
+require 'json'
+require 'set'
+require 'optparse'
+
+opts = { mode: :strict, tol: 0.30 }
+OptionParser.new do |p|
+  p.on('--plan P')              { |v| opts[:plan] = v }
+  p.on('--extract-mode')        {     opts[:mode] = :extract }
+  p.on('--extract-tol TOL', Float) { |v| opts[:tol] = v }
+end.parse!
+abort('--plan required') unless opts[:plan]
+
+MONTH_NUM = {
+  'january' => 1, 'february' => 2, 'march' => 3, 'april' => 4, 'may' => 5, 'june' => 6,
+  'july' => 7, 'august' => 8, 'september' => 9, 'october' => 10, 'november' => 11, 'december' => 12,
+  'jan' => 1, 'feb' => 2, 'mar' => 3, 'apr' => 4, 'jun' => 6,
+  'jul' => 7, 'aug' => 8, 'sep' => 9, 'sept' => 9, 'oct' => 10, 'nov' => 11, 'dec' => 12
+}.freeze
+
+# Canonicalize date-like dimension values to a DAY-grain key so buckets compare
+# equal across representations:
+#   Sigma raw SQL "2026-01-04T00:00:00.000"   → "2026-01-04"
+#   Tableau weekly label "February 4, 2024"   → "2024-02-04"
+#   Tableau monthly label "January 2026"      → "2026-01"
+# Weekly grains MUST keep the underlying date value (bead s6fo) — the old
+# collapse-day-1-to-month rule turned the "January 1" WEEK bucket into a month
+# bucket and every weekly chart diverged. Month-label vs first-of-month is
+# reconciled by strict_compare's month-grain fallback, not here.
+def canonicalize_dim(v)
+  return v unless v.is_a?(String)
+  s = v.strip
+  # ISO datetime at midnight → day bucket (T or space separator)
+  if (m = s.match(/\A(\d{4})-(\d{2})-(\d{2})[T ]00:00:00(?:\.0+)?(?:Z|[+-]\d{2}:?\d{2})?\z/))
+    return "#{m[1]}-#{m[2]}-#{m[3]}"
+  end
+  # ISO date stays a day bucket
+  return s if s.match?(/\A\d{4}-\d{2}-\d{2}\z/)
+  # "February 4, 2024" / "Feb 4, 2024" (Tableau day/week labels)
+  if (m = s.match(/\A([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
+    return format('%s-%02d-%02d', m[3], mnum, m[2].to_i)
+  end
+  # "January 2026" / "Jan 2026" → month bucket
+  if (m = s.match(/\A([A-Za-z]+)\s+(\d{4})\z/)) && (mnum = MONTH_NUM[m[1].downcase])
+    return format('%s-%02d', m[2], mnum)
+  end
+  # "2024 Q1" (Tableau quarter label) → first-of-quarter DAY bucket so it
+  # compares equal to Sigma's DateTrunc("quarter") value ("2024-01-01T00:00:00"
+  # canonicalizes to "2024-01-01" above). Added for window-function pivots
+  # (WINPROBE MaxMin: Region × Quarter grid).
+  if (m = s.match(/\A(\d{4})\s+Q([1-4])\z/i))
+    return format('%s-%02d-01', m[1], ((m[2].to_i - 1) * 3) + 1)
+  end
+  # Already-canonical "YYYY-MM"
+  return s if s.match?(/\A\d{4}-\d{2}\z/)
+  v
+end
+
+# Truncate a canonical day key to its month bucket (month-grain fallback).
+def month_grain(v)
+  v.is_a?(String) && v.match?(/\A\d{4}-\d{2}-\d{2}\z/) ? v[0, 7] : v
+end
+
+def round_row(row)
+  # Convert all numerics to Float-rounded so Integer 11 and Float 11.0 compare equal in the set,
+  # canonicalize date-like dim strings so equivalent monthly buckets match, and
+  # coerce purely-numeric STRINGS to floats (a scatter x-axis value reads back as a
+  # string in the workbook query and must compare equal to the numeric expected side).
+  row.map do |v|
+    if v.is_a?(Numeric)
+      v.to_f.round(2)
+    elsif v.is_a?(String) && v.strip.match?(/\A-?\d+(\.\d+)?\z/)
+      v.strip.to_f.round(2)   # numeric-string (e.g. a scatter x-axis value) -> float, so it compares equal to the numeric side
+    else
+      canonicalize_dim(v)
+    end
+  end
+end
+
+def strict_compare(exp, act)
+  # Compare the FULL tuple width the plan carries (bead s6fo): 3-channel charts
+  # (stacked color / pivot row+col+value / scatter dim+x+y) must compare every
+  # channel — the old first(2) slice compared two dims and ignored the measure.
+  width = [(exp.map(&:size) + act.map(&:size)).max || 2, 2].max
+  exp_set = Set.new(exp.map { |r| r.first(width) })
+  act_set = Set.new(act.map { |r| r.first(width) })
+  return { status: 'PASS', only_in_tableau: [], only_in_sigma: [] } if exp_set == act_set
+
+  # Month-grain fallback — REPRESENTATION mismatches only: a monthly chart's
+  # Tableau label ("January 2026" → "2026-01") vs Sigma's DateTrunc value
+  # ("2026-01-01"). Applies ONLY when one side carries month-form keys and the
+  # other day-form keys — two day-form sides (e.g. weekly buckets shifted a
+  # day) must keep diverging.
+  month_form = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}\z/) } }
+  day_form   = ->(set) { set.any? { |r| r[0].is_a?(String) && r[0].match?(/\A\d{4}-\d{2}-\d{2}\z/) } }
+  if (month_form.call(exp_set) && day_form.call(act_set)) ||
+     (day_form.call(exp_set) && month_form.call(act_set))
+    to_month = ->(set) { Set.new(set.map { |r| [month_grain(r[0]), *r[1..]] }) }
+    if to_month.call(exp_set) == to_month.call(act_set)
+      return { status: 'PASS', only_in_tableau: [], only_in_sigma: [],
+               notes: ['matched at month grain (label vs first-of-month representation)'] }
+    end
+  end
+
+  { status: 'DIVERGE',
+    only_in_tableau: (exp_set - act_set).to_a,
+    only_in_sigma:   (act_set - exp_set).to_a }
+end
+
+# Extract-mode: same row count + same dim set + same dim sort. Measure values
+# only flagged if they're WILDLY off (beyond extract_tol) — small drift is
+# expected because Sigma reads live warehouse while extracts are frozen snapshots.
+def extract_compare(exp, act, tol:)
+  exp_dims = exp.map { |r| r[0] }
+  act_dims = act.map { |r| r[0] }
+  exp_set  = Set.new(exp_dims)
+  act_set  = Set.new(act_dims)
+
+  notes = []
+  status = 'PASS'
+
+  if exp.size != act.size
+    status = 'DIVERGE'
+    notes << "bucket count differs: tableau=#{exp.size} sigma=#{act.size}"
+  end
+
+  unless exp_set == act_set
+    status = 'DIVERGE'
+    notes << "dim set differs: tableau-only=#{(exp_set - act_set).to_a[0..3].inspect}, sigma-only=#{(act_set - exp_set).to_a[0..3].inspect}"
+  end
+
+  # If dim sets match, check sort order on the dimension
+  if exp_set == act_set && exp_dims != act_dims
+    notes << "dim sort order differs (extract-mode flags only — not a failure)"
+  end
+
+  # Wild-divergence check on measures (10x or more drift = probably a real bug,
+  # not just extract staleness)
+  if exp.size == act.size && exp_set == act_set
+    exp_h = exp.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+    act_h = act.each_with_object({}) { |r, h| h[r[0]] = r[1] }
+    big_drifts = []
+    exp_h.each do |k, v|
+      a = act_h[k]
+      next if v.nil? || a.nil?
+      next unless v.is_a?(Numeric) && a.is_a?(Numeric)
+      denom = [v.abs.to_f, a.abs.to_f, 1.0].max
+      drift = (v - a).abs.to_f / denom
+      big_drifts << [k, v, a, drift] if drift > tol
+    end
+    if big_drifts.any?
+      notes << "#{big_drifts.size} measure value(s) drift > #{(tol * 100).to_i}% — review:"
+      big_drifts.first(3).each do |k, v, a, d|
+        notes << "    #{k.inspect} tableau=#{v} sigma=#{a} drift=#{(d * 100).round}%"
+      end
+    end
+  end
+
+  { status: status, notes: notes,
+    only_in_tableau: (exp_set - act_set).to_a,
+    only_in_sigma:   (act_set - exp_set).to_a }
+end
+
+raw = JSON.parse(File.read(opts[:plan]))
+default_extract = false
+if raw.is_a?(Hash) && raw['charts']
+  default_extract = !!raw['extract']
+  plan = raw['charts']
+else
+  plan = raw
+end
+
+# Top-level --extract-mode overrides default
+mode_forced = opts[:mode] == :extract
+
+results = plan.map do |p|
+  exp = (p['expected'] || []).map { |r| round_row(r) }
+  act = (p.dig('actual', 'rows') || []).map { |r| round_row(r) }
+
+  this_extract = if p.key?('extract')
+                   p['extract']
+                 elsif mode_forced
+                   true
+                 else
+                   default_extract
+                 end
+
+  result = this_extract ? extract_compare(exp, act, tol: opts[:tol]) : strict_compare(exp, act)
+  result.merge(chart: p['chart'], extract: this_extract)
+end
+
+results.each do |r|
+  tag = r[:extract] ? '[extract]' : '[strict] '
+  printf "%-7s  %s  %s\n", r[:status], tag, r[:chart]
+  if r[:status] != 'PASS' || (r[:notes] && r[:notes].any?)
+    Array(r[:notes]).each { |n| puts "    #{n}" }
+    if r[:only_in_tableau].any? || r[:only_in_sigma].any?
+      puts "    Tableau-only: #{r[:only_in_tableau].inspect[0..200]}"
+      puts "    Sigma-only:   #{r[:only_in_sigma].inspect[0..200]}"
+    end
+  end
+end
+
+failed = results.count { |r| r[:status] != 'PASS' }
+puts '---'
+puts "#{results.size - failed}/#{results.size} pass" + (mode_forced ? '  (extract-mode)' : '')
+exit(failed.zero? ? 0 : 1)


### PR DESCRIPTION
## Summary
- Adds `quicksight-migration-skills/quicksight-to-sigma/` and `quicksight-migration-skills/quicksight-assessment/`, vendored from `twells89/sigma-migration-skills` upstream.
- Includes `setup.rb` (the standard Sigma cred-capture script shipped by every vendored migration mirror).
- Excludes the upstream `QUICKSTART.md` — Sigma-side QuickStart prose lives in `sigmaquickstarts` instead.

These files back the upcoming "Migrating From QuickSight Made Easy" QuickStart. The QS Install section references `~/.claude/skills/quicksight-to-sigma/scripts/setup.rb` — that path resolves once a reader runs the QS Install steps (sparse-checkout + symlink) against this vendor.

## QuickSight specifics
- AWS auth runs through standard AWS CLI v2 (SSO / named profile / `gimme-aws-creds`). No per-source `setup-quicksight.rb` — AWS handles its own auth.
- **Enterprise edition required.** Standard editions reject the `describe-analysis-definition` / `describe-dashboard-definition` / `describe-data-set` APIs the converter depends on.
- Identity region defaults to `us-east-1`.

## Test plan
- [ ] `git sparse-checkout set quicksight-migration-skills` resolves the folder cleanly.
- [ ] Symlinking `~/.claude/skills/quicksight-to-sigma` to the vendored folder allows `ruby ~/.claude/skills/quicksight-to-sigma/scripts/setup.rb` to run.
- [ ] `python3 ~/.claude/skills/quicksight-to-sigma/scripts/quicksight-discover.py --account-id <...> --analysis-id <...> --region us-east-1 --profile <...>` returns a valid analysis dump for an Enterprise-edition QuickSight account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)