### PR TITLE
Align QuickSight setup.rb with the Looker QS setup.rb

### DIFF
--- a/quicksight-migration-skills/quicksight-to-sigma/scripts/setup.rb
+++ b/quicksight-migration-skills/quicksight-to-sigma/scripts/setup.rb
@@ -1,35 +1,10 @@
 #!/usr/bin/env ruby
-# Store Sigma credentials so any coding agent can load them:
-#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
-#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
-#                                 (Cursor, Cortex Code, plain shell) can use
-# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
-# env vars aren't already set, so the skill works under any agent.
+# Store Sigma credentials in ~/.claude/settings.json so Claude Code loads them automatically.
 
 require 'io/console'
 require 'json'
-require 'fileutils'
 
 SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
-NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
-
-# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
-# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
-def upsert_neutral_env(pairs)
-  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
-  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
-  pairs.each do |k, v|
-    line = "export #{k}='#{v}'"
-    if body =~ /^export #{Regexp.escape(k)}=.*$/
-      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
-    else
-      body += "\n" unless body.empty? || body.end_with?("\n")
-      body += line + "\n"
-    end
-  end
-  File.write(NEUTRAL_PATH, body)
-  File.chmod(0o600, NEUTRAL_PATH)
-end
 
 puts "Sigma credential setup"
 puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
@@ -39,42 +14,32 @@ print "Base URL [https://aws-api.sigmacomputing.com]: "
 base = $stdin.gets.chomp
 base = "https://aws-api.sigmacomputing.com" if base.empty?
 
-print "Client ID: "
-cid = $stdin.noecho(&:gets).chomp
-puts
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
 
-print "Client Secret: "
+print "Client Secret (hidden): "
 sec = $stdin.noecho(&:gets).chomp
 puts
 
-# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
-# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
-# known) saves an export step on every run. Optional — Enter to skip.
-print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
-conn = $stdin.gets.chomp
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
 
 settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
 settings["env"] ||= {}
 settings["env"]["SIGMA_BASE_URL"]      = base
 settings["env"]["SIGMA_CLIENT_ID"]     = cid
 settings["env"]["SIGMA_CLIENT_SECRET"] = sec
-settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
 
 File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
 
-pairs = {
-  "SIGMA_BASE_URL"      => base,
-  "SIGMA_CLIENT_ID"     => cid,
-  "SIGMA_CLIENT_SECRET" => sec,
-}
-pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
-upsert_neutral_env(pairs)
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
 
 puts
-puts "Credentials saved to:"
-puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
-puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts "Saved to #{SETTINGS_PATH}:"
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
 puts
-puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
-puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
-puts "though get-token.sh and the Ruby scripts auto-source it for you."
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
+puts "Open a new Claude Code session (or run `! source ~/.claude/settings.json`) to pick them up."


### PR DESCRIPTION
## Summary
Initial QuickSight vendor (PR #111) brought over the Tableau-shaped \`setup.rb\` from upstream — hidden Client ID and an optional Connection ID prompt. That mismatches the Looker / MSTR-aligned variant the other vendored migration mirrors use, and produces the same confusing paste experience Phil reported on the MSTR QS.

Replaces \`quicksight-migration-skills/quicksight-to-sigma/scripts/setup.rb\` with the Looker version verbatim: visible Client ID prompt (\`Client ID (not a secret — will echo):\`), no Connection ID prompt, redacted-secret echo at the end so the user can verify the paste landed correctly.

Identical fix to the MSTR setup.rb alignment that landed via PR #108.

## Test plan
- [ ] Pull both \`~/GitHub/quickstarts-public\` and \`~/quickstarts-public\` after merge.
- [ ] Re-run \`ruby ~/.claude/skills/quicksight-to-sigma/scripts/setup.rb\` — Client ID prompt should now show what you type/paste, and the Connection ID prompt should not appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)