### PR TITLE
qlik-to-sigma: add on-prem (client-managed) Qlik Sense support to the bundle

### DIFF
--- a/qlik-migration-skills/qlik-to-sigma/SKILL.md
+++ b/qlik-migration-skills/qlik-to-sigma/SKILL.md
@@ -68,6 +68,13 @@ qlik-cli context (OAuth M2M or API key). `qlik context use <ctx>`.
 > data-connection ("Connector not found"). Reload as a real user or via M2M
 > impersonation. (Discovery/extraction works fine under M2M.)
 
+> **CLIENT-MANAGED (on-prem) Qlik Sense?** qlik-cli is Cloud-only. Use the
+> bundled shim instead — same pipeline, different transport (QRS + Engine
+> WebSocket): set up auth per `refs/connection-onprem.md` (certs or JWT virtual
+> proxy), then `export QLIK_BIN="$PWD/scripts/qlik-onprem-shim.py"` before
+> Phase 1. Everything else below is unchanged. QlikView is NOT covered —
+> confirm the product first.
+
 ### Sigma access
 ```bash
 bash -c 'eval "$(scripts/vendor/get-token.sh)"; <cmd>'   # sets SIGMA_BASE_URL + SIGMA_API_TOKEN
@@ -77,7 +84,7 @@ The verified CSA.TJ connection is `cb2f5180-641f-47bd-8efa-da9d590d855a` (Snowfl
 
 ---
 
-## Phase 1 — Discover (qlik-cli)
+## Phase 1 — Discover (qlik-cli, or the on-prem shim via `QLIK_BIN`)
 `scripts/qlik-discover.py --app <id> --context <ctx> --out WORK` extracts:
 - **Data model** — tables + fields. Source of truth = the **load script** (`qlik app script get`); it encodes renames/joins/drops. Capture the effective table→field map (post-rename).
 - **Master measures** — `qMeasure.qDef` (Qlik expressions) + label. (List via the engine; for known ids `qlik app object get <id>`.)

--- a/qlik-migration-skills/qlik-to-sigma/refs/connection-onprem.md
+++ b/qlik-migration-skills/qlik-to-sigma/refs/connection-onprem.md
@@ -1,0 +1,108 @@
+# Qlik connection — CLIENT-MANAGED (on-prem Qlik Sense Enterprise on Windows)
+
+qlik-cli only speaks Qlik **Cloud**. For client-managed Sense, the skill ships
+`scripts/qlik-onprem-shim.py` — a qlik-cli-compatible shim backed by the on-prem
+APIs (QRS REST + Engine/QIX JSON-RPC over WebSocket). It accepts the exact
+command subset discovery uses and emits the **same output shapes**, so the whole
+pipeline runs unchanged:
+
+```bash
+pip3 install websocket-client            # the Engine transport (PEP 668 machines:
+                                         #   pip3 install --user websocket-client, or use a venv)
+source ~/.sigma-migration/qlik-onprem.env
+export QLIK_BIN="$PWD/scripts/qlik-onprem-shim.py"   # qlik-discover.py honors QLIK_BIN
+python3 scripts/qlik-discover.py --app <appId> --out extract/
+```
+
+Everything downstream (converter, DM/workbook build, parity) is identical to Cloud.
+
+> **Validation status:** the shim's Engine/QIX layer is **live-verified** — a full
+> discovery run through the shim produced output **identical (order-insensitive)**
+> to a qlik-cli run on the same app (script, charts, master items, layout, KPI/
+> bucket snapshot values). The QIX protocol is the same on-prem and Cloud. The
+> **QRS layer and on-prem auth bootstrap are code-complete but not yet live-run**
+> (Cloud has no QRS) — on your first on-prem engagement, expect to debug there
+> first, not in discovery/conversion. Without QRS, only `appName`/`lastReloadTime`
+> metadata degrade — discovery still completes.
+
+> **QlikView is NOT covered.** It's a different product (.qvw + the old QMS API,
+> no QIX engine surface in this form). If the customer says "Qlik on-prem",
+> confirm Sense Enterprise on Windows vs QlikView before scoping.
+
+## First: which product / what to ask the customer
+
+- Product + version: **Qlik Sense Enterprise on Windows** (this doc) vs QlikView (out of scope).
+- Server hostname; which ports are reachable (443 always; 4242/4747 for the certs path).
+- Auth path: can they export certificates from the QMC, or would they rather add a
+  JWT virtual proxy? (Ranked below.)
+- A **service account in their user directory** with read access to the streams
+  being migrated.
+- Are app data sources warehouse-backed, or QVD/file-fed? (See "Data reality" below.)
+
+## Auth path 1 — certificates (best for automation, zero proxy config)
+
+1. QMC → **Certificates** → export for the machine running the skill (PEM format)
+   → you get `client.pem`, `client_key.pem`, `root.pem`.
+2. Firewall: the skill machine must reach **4242** (QRS) and **4747** (Engine).
+3. Env (`~/.sigma-migration/qlik-onprem.env`):
+
+```bash
+export QLIK_ONPREM_SERVER=qlik.example.com
+export QLIK_ONPREM_AUTH=certs
+export QLIK_ONPREM_CERTS=/path/to/exported/certs     # client.pem, client_key.pem, root.pem
+export QLIK_ONPREM_USER_DIRECTORY=ACME               # the service account
+export QLIK_ONPREM_USER_ID=svc_migration
+# optional: QLIK_ONPREM_QRS_PORT (4242), QLIK_ONPREM_ENGINE_PORT (4747)
+```
+
+Certificate auth sends `X-Qlik-User: UserDirectory=<dir>; UserId=<user>` — the
+calls run **as that user**, so stream/Section Access visibility applies. Use a
+service account with read access to everything in scope (not sa_repository).
+
+## Auth path 2 — JWT virtual proxy (everything over 443)
+
+1. Admin: QMC → Virtual proxies → add one with **JWT** authentication, upload the
+   JWT-signing cert, set a prefix (e.g. `jwt`), attribute mappings for
+   userId/userDirectory. Mint a JWT signed with the matching key.
+2. Env:
+
+```bash
+export QLIK_ONPREM_SERVER=qlik.example.com
+export QLIK_ONPREM_AUTH=jwt
+export QLIK_ONPREM_VPROXY=jwt          # the virtual proxy prefix ('' if mounted at root)
+export QLIK_ONPREM_JWT=<token>
+```
+
+(Header-auth virtual proxies also work mechanically — same env shape with the
+proxy trusting a header — but they're impersonation-by-header; only on locked-down
+networks. NTLM/Windows auth is not supported by the shim: fine for curl, miserable
+for WebSockets.)
+
+`QLIK_ONPREM_INSECURE=1` skips TLS verification — common with self-signed
+QRS/proxy certs; prefer pointing at `root.pem` when you have it.
+
+## What the shim supports (and deliberately doesn't)
+
+Supported (the discovery surface): `item ls` (QRS `/qrs/app/full`, mapped to the
+Cloud item shape — `stream` ≈ `space`), `app script get`, `app object ls`,
+`app object properties` (resolves generic objects AND master measures/dimensions),
+`app measure|dimension ls/properties`, `app eval`.
+
+Not supported, loudly:
+- `raw get` — Cloud REST only; `qlik-screenshot.py` is a Cloud nicety, skip it
+  on-prem (grab screenshots from the Hub manually for the visual gate).
+- `app object set/rm` — the **assessment** skill's temp-object trick would require
+  `DoSave` WRITES to the customer app. The assessment inventory is Cloud-only for
+  now; converter-side discovery gets master items via `measure|dimension ls`,
+  which doesn't need it.
+
+## Data reality on-prem (read before promising parity)
+
+On-prem apps are far more often **QVD/file-fed** than Cloud apps. Sigma reads a
+warehouse live, so the repoint step (load script `LIB CONNECT` → warehouse, or
+landing the QVD data into the warehouse) is usually the bigger share of on-prem
+work — the API plumbing above is the easy part. Same principle as Cloud: feed the
+converter the **Qlik model** (the load script is extracted either way), then make
+sure the data exists in the warehouse Sigma queries. Reloads on-prem are triggered
+via QMC tasks (no impersonated-reload gotcha like Cloud M2M, but reload rights on
+the service account are still needed if you repoint the app itself).

--- a/qlik-migration-skills/qlik-to-sigma/refs/connection-onprem.md
+++ b/qlik-migration-skills/qlik-to-sigma/refs/connection-onprem.md
@@ -16,14 +16,22 @@ python3 scripts/qlik-discover.py --app <appId> --out extract/
 
 Everything downstream (converter, DM/workbook build, parity) is identical to Cloud.
 
-> **Validation status:** the shim's Engine/QIX layer is **live-verified** — a full
-> discovery run through the shim produced output **identical (order-insensitive)**
-> to a qlik-cli run on the same app (script, charts, master items, layout, KPI/
-> bucket snapshot values). The QIX protocol is the same on-prem and Cloud. The
-> **QRS layer and on-prem auth bootstrap are code-complete but not yet live-run**
-> (Cloud has no QRS) — on your first on-prem engagement, expect to debug there
-> first, not in discovery/conversion. Without QRS, only `appName`/`lastReloadTime`
-> metadata degrade — discovery still completes.
+> **Validation status — read before promising on-prem.** The shim's command/output
+> layer is verified **output-identical to qlik-cli** — a full discovery run through
+> the shim produced output **identical (order-insensitive)** to a qlik-cli run on the
+> same app (script, charts, master items, layout, KPI/bucket snapshot values).
+> **Important: that run was against a live Qlik _Cloud_ tenant, not an on-prem
+> server.** The QIX protocol is identical on-prem and Cloud, so the command-parsing
+> and output-shaping logic carries over — but the **on-prem-specific path has not yet
+> been run live anywhere:** certificate/JWT auth, the QRS layer (Cloud has no QRS),
+> and the Engine transport *against an on-prem server* (WebSocket to :4747 with
+> `X-Qlik-User`, or through a virtual proxy) are all **code-complete but unproven
+> end-to-end**. Your first on-prem engagement is the first live test — expect to
+> debug there (auth / ports / proxy), not in discovery or conversion. Failure is
+> bounded, though: a QRS failure is non-fatal (the shim warns and continues), so only
+> `appName`/`lastReloadTime`/Section-Access metadata degrade — discovery still
+> completes off the Engine layer. Only an empty load script (an Engine-layer read)
+> hard-fails.
 
 > **QlikView is NOT covered.** It's a different product (.qvw + the old QMS API,
 > no QIX engine surface in this form). If the customer says "Qlik on-prem",

--- a/qlik-migration-skills/qlik-to-sigma/scripts/qlik-onprem-shim.py
+++ b/qlik-migration-skills/qlik-to-sigma/scripts/qlik-onprem-shim.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""qlik-onprem-shim.py — qlik-cli-compatible shim for CLIENT-MANAGED Qlik Sense
+(Enterprise on Windows). qlik-cli only speaks Qlik Cloud; this shim accepts the
+exact qlik-cli command subset the discovery scripts use and backs it with the
+on-prem APIs (QRS REST + Engine/QIX JSON-RPC over WebSocket), emitting the SAME
+output shapes — so qlik-discover.py runs unchanged:
+
+    export QLIK_BIN="$PWD/scripts/qlik-onprem-shim.py"     # discover honors QLIK_BIN
+    python3 scripts/qlik-discover.py --app <appId> --out extract/
+
+Supported commands (the discovery surface — anything else exits 2 loudly):
+    item ls --resourceType app [--limit N]      QRS /qrs/app/full → Cloud item shape
+    app script get -a <app>                     Engine GetScript
+    app object ls -a <app> --json               Engine GetAllInfos
+    app object properties <qId> -a <app>        Engine GetObject→GetProperties
+    app measure ls -a <app> --json              Engine MeasureList session object
+    app dimension ls -a <app> --json            Engine DimensionList session object
+    app measure properties <qId> -a <app>       Engine GetMeasure→GetProperties
+    app dimension properties <qId> -a <app>     Engine GetDimension→GetProperties
+    app eval <expr> -a <app>                    Engine Evaluate
+
+NOT supported on-prem (clear error, never silent): `raw get` (Cloud REST only —
+qlik-screenshot.py is a Cloud nicety, skip it), `app object set/rm` (the
+assessment temp-object trick would require DoSave WRITES to the customer app).
+
+Config — environment (put these in ~/.sigma-migration/qlik-onprem.env and
+`source` it; see refs/connection-onprem.md for the QMC setup on each path):
+
+  QLIK_ONPREM_SERVER=qlik.example.com          # host only, no scheme
+  QLIK_ONPREM_AUTH=certs | jwt
+
+  # certs mode (QMC → Certificates export; PEM format):
+  QLIK_ONPREM_CERTS=/path/to/certs             # client.pem, client_key.pem, root.pem
+  QLIK_ONPREM_USER_DIRECTORY=ACME              # service user with read access
+  QLIK_ONPREM_USER_ID=svc_migration
+  # ports (defaults): QRS 4242, Engine 4747
+
+  # jwt mode (JWT virtual proxy on the central proxy, everything over 443):
+  QLIK_ONPREM_VPROXY=jwt                       # virtual proxy prefix
+  QLIK_ONPREM_JWT=<token>
+
+  QLIK_ONPREM_INSECURE=1                       # skip TLS verify (self-signed QRS/proxy)
+
+Engine transport needs the `websocket-client` package: pip3 install websocket-client
+(stdlib has no WebSocket). Each invocation is one engine session, mirroring
+qlik-cli — the caller's retry/backoff semantics still apply.
+"""
+import json
+import os
+import ssl
+import sys
+import urllib.request
+
+XRF = "abcdefghij123456"  # QRS CSRF pair — any 16 chars, query param must match header
+
+
+def die(msg, code=2):
+    sys.stderr.write(f"qlik-onprem-shim: {msg}\n")
+    sys.exit(code)
+
+
+def env(name, default=None, required=False):
+    v = os.environ.get(name, default)
+    if required and not v:
+        die(f"missing env {name} — see refs/connection-onprem.md")
+    return v
+
+
+SERVER = env("QLIK_ONPREM_SERVER", required=True)
+AUTH = env("QLIK_ONPREM_AUTH", "certs")
+INSECURE = env("QLIK_ONPREM_INSECURE") == "1"
+
+
+def ssl_ctx(with_client_cert):
+    ctx = ssl.create_default_context()
+    if INSECURE:
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+    elif AUTH == "certs":
+        root = os.path.join(env("QLIK_ONPREM_CERTS", required=True), "root.pem")
+        if os.path.exists(root):
+            ctx.load_verify_locations(root)
+    if with_client_cert and AUTH == "certs":
+        d = env("QLIK_ONPREM_CERTS", required=True)
+        ctx.load_cert_chain(os.path.join(d, "client.pem"), os.path.join(d, "client_key.pem"))
+    return ctx
+
+
+def auth_headers():
+    if AUTH == "certs":
+        ud = env("QLIK_ONPREM_USER_DIRECTORY", required=True)
+        uid = env("QLIK_ONPREM_USER_ID", required=True)
+        return {"X-Qlik-User": f"UserDirectory={ud}; UserId={uid}"}
+    if AUTH == "jwt":
+        return {"Authorization": f"Bearer {env('QLIK_ONPREM_JWT', required=True)}"}
+    die(f"QLIK_ONPREM_AUTH must be certs or jwt (got {AUTH!r})")
+
+
+# ── QRS (Repository Service) ──────────────────────────────────────────────────
+
+def qrs_get(path):
+    if AUTH == "certs":
+        base = f"https://{SERVER}:{env('QLIK_ONPREM_QRS_PORT', '4242')}"
+    else:
+        vp = env("QLIK_ONPREM_VPROXY", "")
+        base = f"https://{SERVER}/{vp}" if vp else f"https://{SERVER}"
+    sep = "&" if "?" in path else "?"
+    url = f"{base}{path}{sep}xrfkey={XRF}"
+    req = urllib.request.Request(url, headers={"X-Qlik-Xrfkey": XRF, **auth_headers()})
+    with urllib.request.urlopen(req, context=ssl_ctx(with_client_cert=True)) as r:
+        return json.loads(r.read())
+
+
+# ── Engine (QIX) JSON-RPC over WebSocket ──────────────────────────────────────
+
+class Engine:
+    def __init__(self, app_id):
+        try:
+            import websocket  # websocket-client
+        except ImportError:
+            die("the Engine transport needs websocket-client: pip3 install websocket-client")
+        if AUTH == "certs":
+            url = f"wss://{SERVER}:{env('QLIK_ONPREM_ENGINE_PORT', '4747')}/app/{app_id}"
+        else:
+            vp = env("QLIK_ONPREM_VPROXY", "")  # empty = proxy mounted at root
+            url = f"wss://{SERVER}/{vp}/app/{app_id}" if vp else f"wss://{SERVER}/app/{app_id}"
+        sslopt = {}
+        if INSECURE:
+            sslopt = {"cert_reqs": ssl.CERT_NONE, "check_hostname": False}
+        elif AUTH == "certs":
+            d = env("QLIK_ONPREM_CERTS", required=True)
+            sslopt = {"certfile": os.path.join(d, "client.pem"),
+                      "keyfile": os.path.join(d, "client_key.pem")}
+            if os.path.exists(os.path.join(d, "root.pem")):
+                sslopt["ca_certs"] = os.path.join(d, "root.pem")
+        if AUTH == "certs":
+            d = env("QLIK_ONPREM_CERTS", required=True)
+            sslopt.setdefault("certfile", os.path.join(d, "client.pem"))
+            sslopt.setdefault("keyfile", os.path.join(d, "client_key.pem"))
+        headers = [f"{k}: {v}" for k, v in auth_headers().items()]
+        self.ws = websocket.create_connection(url, sslopt=sslopt, header=headers, timeout=60)
+        self._id = 0
+        self.app_handle = None
+        self._open(app_id)
+
+    def call(self, handle, method, params=None):
+        self._id += 1
+        self.ws.send(json.dumps({"jsonrpc": "2.0", "id": self._id, "handle": handle,
+                                 "method": method, "params": params or []}))
+        while True:  # skip engine push notifications (no id / other ids)
+            msg = json.loads(self.ws.recv())
+            if msg.get("id") == self._id:
+                if "error" in msg:
+                    die(f"engine {method}: {msg['error'].get('message')} "
+                        f"(code {msg['error'].get('code')})", code=1)
+                return msg.get("result", {})
+
+    def _open(self, app_id):
+        r = self.call(-1, "OpenDoc", {"qDocName": app_id})
+        self.app_handle = r["qReturn"]["qHandle"]
+
+    def obj_handle(self, getter, q_id, required=True):
+        r = self.call(self.app_handle, getter, {"qId": q_id})
+        h = r.get("qReturn", {}).get("qHandle")
+        if h is None or h < 0:
+            if required:
+                die(f"{getter}({q_id}): not found", code=1)
+            return None
+        return h
+
+    def any_handle(self, q_id):
+        """qlik-cli resolves `app object properties` for ANY object kind —
+        GetAllInfos includes master measures/dimensions, whose ids only resolve
+        via their own getters."""
+        for getter in ("GetObject", "GetMeasure", "GetDimension", "GetVariableById"):
+            h = self.obj_handle(getter, q_id, required=False)
+            if h is not None:
+                return h
+        die(f"object {q_id}: not found via GetObject/GetMeasure/GetDimension/GetVariableById", code=1)
+
+    def session_list(self, list_def_key, q_type, items_key):
+        props = {"qInfo": {"qType": f"{q_type}List"},
+                 list_def_key: {"qType": q_type, "qData": {"title": "/qMetaDef/title"}}}
+        h = self.call(self.app_handle, "CreateSessionObject", {"qProp": props})["qReturn"]["qHandle"]
+        layout = self.call(h, "GetLayout")["qLayout"]
+        items = (layout.get(items_key) or {}).get("qItems") or []
+        return [{"qId": it.get("qInfo", {}).get("qId"),
+                 "title": (it.get("qData") or {}).get("title")
+                          or (it.get("qMeta") or {}).get("title")} for it in items]
+
+    def close(self):
+        try:
+            self.ws.close()
+        except Exception:
+            pass
+
+
+# ── command dispatch (argv-compatible with the qlik-cli subset) ───────────────
+
+def parse(argv):
+    """Split argv into positional words and the flags we honor; swallow
+    qlik-cli flags that don't apply on-prem (--context/-c, --json, --limit…)."""
+    words, flags, i = [], {}, 0
+    swallow_with_value = {"--context", "-c", "--limit", "--resourceType"}
+    bare = {"--json", "-q", "--quiet"}
+    while i < len(argv):
+        a = argv[i]
+        if a in ("-a", "--app"):
+            flags["app"] = argv[i + 1]; i += 2
+        elif a in swallow_with_value:
+            flags[a.lstrip("-")] = argv[i + 1]; i += 2
+        elif a in bare or a.startswith("--"):
+            i += 1
+        else:
+            words.append(a); i += 1
+    return words, flags
+
+
+def main():
+    words, flags = parse(sys.argv[1:])
+    if not words:
+        die("no command")
+
+    if words[0] == "item" and words[1:2] == ["ls"]:
+        apps = qrs_get("/qrs/app/full")
+        out = [{"resourceId": a.get("id"), "name": a.get("name"), "resourceType": "app",
+                "resourceAttributes": {
+                    "name": a.get("name"), "description": a.get("description"),
+                    "ownerName": (a.get("owner") or {}).get("name"),
+                    "publishTime": a.get("publishTime"),
+                    "spaceName": (a.get("stream") or {}).get("name"),  # stream ≈ space
+                    "lastReloadTime": a.get("lastReloadTime"),
+                }} for a in apps]
+        limit = int(flags.get("limit") or 0)
+        print(json.dumps(out[:limit] if limit else out))
+        return
+
+    if words[0] != "app":
+        die(f"unsupported command: {' '.join(words)} (on-prem shim covers the discovery surface only)")
+
+    sub = words[1:]
+    KNOWN = (["script", "get"], ["object", "ls"], ["object", "properties"],
+             ["measure", "ls"], ["dimension", "ls"], ["measure", "properties"],
+             ["dimension", "properties"], ["eval"])
+    if sub[:2] in (["object", "set"], ["object", "rm"]):
+        die("app object set/rm not supported on-prem (would require DoSave WRITES "
+            "to the customer app) — the assessment temp-object flow is Cloud-only.")
+    if not any(sub[:len(k)] == k for k in KNOWN):
+        die(f"unsupported command: app {' '.join(sub)}")
+    app = flags.get("app") or die("missing -a <appId>")
+    eng = Engine(app)
+    try:
+        if sub[:2] == ["script", "get"]:
+            print(eng.call(eng.app_handle, "GetScript")["qScript"])
+        elif sub[:2] == ["object", "ls"]:
+            infos = eng.call(eng.app_handle, "GetAllInfos")["qInfos"]
+            # GetAllInfos includes master measures/dimensions/variables; qlik-cli's
+            # `app object ls` lists generic objects only — match it (verified by
+            # diffing a full discovery run against qlik-cli on the same app).
+            skip = {"measure", "dimension", "variable"}
+            print(json.dumps([{"qId": i["qId"], "qType": i["qType"]}
+                              for i in infos if i["qType"] not in skip]))
+        elif sub[:2] == ["object", "properties"]:
+            h = eng.any_handle(sub[2])
+            print(json.dumps(eng.call(h, "GetProperties")["qProp"]))
+        elif sub[:2] == ["measure", "ls"]:
+            print(json.dumps(eng.session_list("qMeasureListDef", "measure", "qMeasureList")))
+        elif sub[:2] == ["dimension", "ls"]:
+            print(json.dumps(eng.session_list("qDimensionListDef", "dimension", "qDimensionList")))
+        elif sub[:2] == ["measure", "properties"]:
+            h = eng.obj_handle("GetMeasure", sub[2])
+            print(json.dumps(eng.call(h, "GetProperties")["qProp"]))
+        elif sub[:2] == ["dimension", "properties"]:
+            h = eng.obj_handle("GetDimension", sub[2])
+            print(json.dumps(eng.call(h, "GetProperties")["qProp"]))
+        elif sub[:1] == ["eval"]:
+            # qlik-cli format: line 1 = the expression echoed, line 2 = the value
+            # (qlik_eval in discover/migrate parses lines[1])
+            val = eng.call(eng.app_handle, "Evaluate", {"qExpression": sub[1]}).get("qReturn", "")
+            print(sub[1])
+            print(val)
+    finally:
+        eng.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Why
The `qlik-migration-skills` bundle was vendored from `twells89/sigma-migration-skills` on **2026-06-15 16:05 UTC** — **32 minutes before** the upstream on-prem support PR (#70) merged at 16:37 UTC. As a result, this published copy has **no on-prem path at all**:

| On-prem artifact | This bundle (before) |
|---|---|
| `scripts/qlik-onprem-shim.py` | ❌ missing |
| `refs/connection-onprem.md` | ❌ missing |
| `SKILL.md` on-prem guidance | ❌ none |

A customer migrating a **client-managed Qlik Sense Enterprise (on-Windows)** instance follows the QuickStart, looks for `scripts/qlik-onprem-shim.py`, and correctly finds it "not in the repo" — because in the published bundle, it genuinely isn't. (This surfaced from a live customer engagement.)

## What this changes (on-prem catch-up only — no unrelated re-vendor)
- **add `scripts/qlik-onprem-shim.py`** — a qlik-cli-compatible shim backed by the on-prem APIs (QRS REST + Engine/QIX JSON-RPC over WebSocket). `qlik-discover.py` already honors `QLIK_BIN`, so the entire downstream pipeline (convert → build → parity) runs unchanged.
- **add `refs/connection-onprem.md`** — certificate-export vs JWT-virtual-proxy auth setup (ports 4242/4747 vs 443), service-account guidance, and the data-reality notes for on-prem (QVD/file-fed apps).
- **`SKILL.md`** — add the `CLIENT-MANAGED` callout under Qlik access prereqs and tag the Phase 1 heading.

Scoped deliberately tight to on-prem so it's easy to review; matches the upstream files verbatim. QlikView remains out of scope (different product).

**Honest status:** the shim's Engine/QIX layer is live-verified (output-identical to qlik-cli on the same app); the QRS layer + on-prem auth bootstrap are code-complete but newer — expect first-connection debugging to land in auth/ports, not discovery/conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)