### PR TITLE
Vendor metabase-migration-skills from twells89 upstream

### DIFF
--- a/metabase-migration-skills/metabase-assessment/PRIVACY.md
+++ b/metabase-migration-skills/metabase-assessment/PRIVACY.md
@@ -1,0 +1,58 @@
+# Metabase Assessment — privacy disclosure
+
+Share this with the customer's privacy / security reviewer before running the
+skill against a live Metabase instance.
+
+## What this skill does
+
+It issues **read-only `GET` requests** to the Metabase REST API (`/api`) to
+inventory the collection tree and fetch the definitions of models, questions
+(cards), and dashboards, then scores them locally for migration readiness and
+renders an HTML report. It **never** POSTs, modifies, runs, or deletes
+anything in Metabase — it never executes a query against the warehouse
+(`/api/card/{id}/query` and `/api/dataset` are never called) — and it never
+touches Sigma.
+
+## What crosses the LLM (Anthropic) API
+
+Like every Claude Code skill, the content it reads is sent through the
+Anthropic API to Claude so the assessment can be produced:
+
+| Crosses the API | Stays in Metabase / local only |
+|---|---|
+| Aggregate counts (model / question / dashboard / collection counts) | Warehouse rows — never queried |
+| Object names, collection paths, types, `view_count` (v50+) | Database credentials (the endpoints used never return them) |
+| Card JSON: MBQL trees, **native SQL text**, custom-expression trees, viz settings | The customer's actual query *results* / result sets |
+| Dashboard JSON: grid layout, parameter definitions, click behaviors | Per-user activity history (not fetched) |
+| Database **schema** metadata: table/field names + ids (required to resolve MBQL field refs) | — |
+
+MBQL filters and **native SQL text** (which can embed business logic and
+sometimes literal threshold values, e.g. `WHERE tier = 'enterprise'`) are part
+of the definitions and do cross the API. They do not include row-level
+warehouse data.
+
+## Where outputs go
+
+The skill writes to a local directory (`/tmp/metabase-assessment-<env>/` by
+default): `inventory.json`, the fetched definitions under `specs/`, schema
+metadata under `metadata/`, `coverage.json`, and `readout.html` (plus
+`sandboxes.json` on Pro/EE instances with sandboxing policies). Nothing is
+uploaded anywhere. Sharing the readout with a Sigma rep is a deliberate action
+by the user, not automatic.
+
+## Auth handling
+
+The skill reads an API key (`MB_KEY`, sent as `x-api-key`) or a session token
+(`MB_SESSION`, sent as `X-Metabase-Session`) from environment variables the
+user sets. They are used only as request headers, are not stored, and are not
+written to any output file.
+
+## How to run it more privately
+
+- Run in **offline mode** against card/dashboard JSON files already exported
+  to disk — no live Metabase connection is made at all.
+- Personal collections are **skipped by default** (only `--include-personal`
+  pulls them in).
+- Use a session token scoped to a low-privilege account if the assessment
+  should only see a subset of collections — Metabase's own permission model
+  bounds what the walk can read.

--- a/metabase-migration-skills/metabase-assessment/README.md
+++ b/metabase-migration-skills/metabase-assessment/README.md
@@ -1,0 +1,55 @@
+# metabase-assessment
+
+Read-only migration-readiness assessment for a Metabase instance → Sigma.
+Mirrors the `tableau-assessment` pattern: inventory the collection tree, score
+each model / question / dashboard against the **exact** coverage of the
+`metabase-to-sigma` converter, roll up an estate auto-migration %, name every
+gap, and render a branded HTML readout.
+
+```
+SKILL.md                      phased workflow (Connect → Discover → Score → Effort → Render)
+PRIVACY.md                    customer-facing data-handling disclosure
+scripts/
+  discover-metabase.sh        bulk fast path: GET /api/card (one response) + parallel dashboard GETs + db metadata → inventory.json (read-only; --walk = legacy per-collection walk)
+  mb-bulk-split.py            local splitter for the bulk card payload (stdlib-only, never networks)
+  pmbql-normalize.mjs         pMBQL ("lib/" MBQL) → legacy normalizer (synced copy of the converter's)
+  score-coverage.mjs          classify auto/hint/manual/unhandled vs. converter gaps; per-artifact + roll-up (zero-dep)
+  render-report.mjs           branded standalone readout.html (zero-dep)
+refs/
+  mb-rest.md                  endpoints + the two auth shapes used + the fast path
+  scoring-rubric.md           every gap signal → bucket → remediation + production calibration (7k-card estate)
+  usage-telemetry.md          honest take on Metabase usage stats (view_count v50+ is thin; rich audit is Pro/EE)
+fixtures/
+  101.card.json               all-auto MBQL question
+  102.card.json               cum-sum question (unhandled)
+  103.card.json               native-SQL model with a field-filter tag (hint)
+  104.card.json               pMBQL (modern "lib/" format) native question with every tag kind
+  201.dashboard.json          funnel dashcard (unhandled) + click behavior (manual) + view_count
+  202.dashboard.json          pMBQL dashboard: tag-targeting parameters + object detail card
+```
+
+Discovery + scoring are **production-validated**: a 7,023-card / 1,548-dashboard
+Metabase Cloud estate (v1.61.4, 100% pMBQL) discovered in ~1 minute and scored
+97% auto-migratable. See `refs/scoring-rubric.md` § Production calibration.
+
+## Quick start (offline, against the bundled fixtures)
+
+```bash
+node scripts/score-coverage.mjs --in fixtures --out /tmp/metabase-assessment-sample
+node scripts/render-report.mjs  --out /tmp/metabase-assessment-sample
+open /tmp/metabase-assessment-sample/readout.html
+```
+
+## Live
+
+```bash
+export MB_BASE="https://<host>"        # no trailing /api
+export MB_KEY="mb_..."                 # or: export MB_SESSION="<token>"
+bash scripts/discover-metabase.sh --probe
+bash scripts/discover-metabase.sh --out /tmp/metabase-assessment-<env>
+node scripts/score-coverage.mjs --in /tmp/metabase-assessment-<env>/specs --out /tmp/metabase-assessment-<env>
+node scripts/render-report.mjs  --out /tmp/metabase-assessment-<env>
+```
+
+Read-only and all-free. Tableau is the reference point. Not a replacement for
+a deeper hands-on engagement.

--- a/metabase-migration-skills/metabase-assessment/SKILL.md
+++ b/metabase-migration-skills/metabase-assessment/SKILL.md
@@ -1,0 +1,289 @@
+---
+name: metabase-assessment
+description: Take inventory of a Metabase instance and produce a migration-readiness readout — collection-tree counts, per-artifact conversion complexity (scored against the Metabase→Sigma converter's exact coverage), an estate-wide auto-migration percentage, a named gap analysis, and an effort/wave plan. Use when a user wants to scope a Metabase→Sigma migration, audit Metabase sprawl, or pick which models / questions / dashboards to convert first. Read-only, all-free, ~Tableau-assessment-style pre-scoping that complements (does not replace) a deeper paid engagement.
+user-invocable: true
+---
+
+# Metabase Assessment
+
+Surveys a Metabase instance (open source or Pro/EE, v46+) via its first-class
+REST API (`/api`) and produces a branded, share-friendly HTML readout plus a
+JSON inventory. The differentiator versus a generic BI audit is
+**converter-coverage scoring**: every model, question (card), and dashboard is
+classified auto-convert vs. flagged using the *same* rules the
+`metabase-to-sigma` converter (`converter/metabase.ts`, `translateMbqlExpr`)
+actually applies — so the readout's auto-migration % reflects what the tool
+will really do, not a hand-wave.
+
+> **Read-only.** This skill only issues `GET`s against the Metabase API. It
+> never POSTs, modifies, runs, or schedules anything in Metabase — and it never
+> touches Sigma. It can also run fully offline against card/dashboard JSON
+> files already on disk.
+
+> **All free.** Everything here — inventory, scoring, the HTML readout — is part
+> of the open migration tooling. There is no paid tier to upsell. For a deeper
+> hands-on engagement (permissions audit, sandboxing/RLS port, live parity
+> testing), point the customer at a Sigma SE.
+
+> **Tableau is the reference point.** This skill mirrors the structure and tone
+> of the `tableau-assessment` skill (environment counts → coverage → effort →
+> readout). If you've run that, this will feel familiar; the Metabase-specific
+> work is all in the coverage scorer.
+
+---
+
+## Privacy posture (READ FIRST, surface to the customer)
+
+**This skill reads content metadata and definitions, not warehouse data.**
+
+| Crosses the LLM API | Stays in Metabase / local |
+|---|---|
+| Aggregate counts (model / question / dashboard / collection counts) | Warehouse rows (this skill never runs a query) |
+| Object names, collection path, type, `view_count` (v50+) | Database credentials (Metabase never exposes them via these endpoints anyway) |
+| Card JSON (MBQL trees, **native SQL text**, expressions, viz settings) | The customer's actual query *results* |
+| Dashboard JSON (grid layout, parameters, click behaviors) | User PII beyond creator ids on objects |
+| Database **schema** metadata (table/field names + ids — required to resolve MBQL field refs) | — |
+
+Like every Claude Code skill, what it reads is sent through the LLM API to
+Claude. Tell the user this before running. Outputs are written to a local
+`/tmp/metabase-assessment-<env>/` directory and uploaded nowhere — sharing is a
+deliberate action, not automatic. See `PRIVACY.md` for the full disclosure.
+
+---
+
+## When to use this skill
+
+- A Metabase customer wants a fast scoping view before committing to a migration.
+- A Sigma SE preparing for a discovery call wants a pre-built conversion shortlist.
+- A customer is deciding which Metabase questions/dashboards to retire vs. migrate.
+- A `metabase-to-sigma` conversion needs a Phase 0 inventory of the source estate.
+
+**Not for**: running live Metabase questions, extracting warehouse data, or
+making any change to the Metabase instance.
+
+---
+
+## Modes
+
+| Mode | Setup | Use when |
+|---|---|---|
+| **Live (REST)** | `MB_BASE` + (`MB_KEY` or `MB_SESSION`) env (see below) | Real estate scan against a running Metabase (OSS or Pro/EE) |
+| **Offline (files)** | A directory of `*.card.json` + `*.dashboard.json` already on disk | No live access; scoring a sample set or an export the customer mailed you |
+
+Both modes feed the same scorer + renderer. The bundled `fixtures/` let you
+validate the whole pipeline offline.
+
+---
+
+## Phase 0 — Connect / probe access
+
+Live mode needs one of two auth shapes (both are plain request headers):
+
+```bash
+export MB_BASE="https://<host>"            # no trailing /api — the script adds it
+
+# Option A (preferred, v49+): an API key from Admin → Settings → Authentication → API keys
+export MB_KEY="mb_..."                     # sent as `x-api-key`
+
+# Option B: a session token from POST /api/session {"username","password"}
+export MB_SESSION="<token>"                # sent as `X-Metabase-Session`
+
+# Cheap probe — prints the instance version, no auth strictly required:
+bash scripts/discover-metabase.sh --probe
+```
+
+If an authenticated request 401s, the session expired (sessions default to 14
+days, sooner with SSO) — re-login and re-export `MB_SESSION`, or switch to an
+API key. If an API-key request 403s, the key's **group** lacks read access to
+the collections — ask the admin for a key in a group with view rights
+(Administrators for a full scan). The discovery script surfaces a clear
+token-expiry note rather than dumping a stack trace.
+
+Offline mode needs no auth — skip straight to Phase 2 pointing the scorer at
+the file directory.
+
+---
+
+## Phase 1 — Discover the estate (live mode)
+
+```bash
+bash scripts/discover-metabase.sh --out /tmp/metabase-assessment-<env>
+# include per-user personal collections too (skipped by default):
+bash scripts/discover-metabase.sh --out /tmp/metabase-assessment-<env> --include-personal
+# useful caps / knobs: --concurrency 16  --max-dashboards N  --skip-cards  --walk
+```
+
+`discover-metabase.sh` uses the **bulk fast path** (production-validated: a
+7,023-card / 1,548-dashboard Metabase Cloud estate in ~1 minute — the old
+per-item walk took >1 hour on the same estate):
+
+1. `GET /api/collection` → collection names + personal flags
+2. **`GET /api/card`** — EVERY card with its full definition in ONE response
+   (~110MB for 7k cards), streamed to disk and split locally by
+   `scripts/mb-bulk-split.py` → `<out>/specs/<id>.card.json`
+3. `GET /api/dashboard` (shallow list) + **parallel** `GET /api/dashboard/{id}`
+   (default 16 concurrent, resumable) → `<out>/specs/<id>.dashboard.json`
+4. each **referenced database**, once → `GET /api/database/{id}/metadata`
+   → `<out>/metadata/<db>.metadata.json` (the integer-field-id → column map the
+   converter requires). A **403 on a scoped key is recorded, not fatal** —
+   field resolution falls back to card `result_metadata`, then
+   `GET /api/field/{id}` (works even for restricted DBs).
+
+It emits `<out>/inventory.json` =
+`{ environment: {...counts}, artifacts: [ {id,type,name,collection,view_count,specFile} ] }`.
+
+Notes baked into the script:
+- **Fallback walk** — `--walk` (or automatically when bulk `GET /api/card`
+  isn't available) uses the old paginated per-collection item walk; default
+  page size 100.
+- **Personal collections** — skipped by default (`personal_owner_id != null`);
+  `--include-personal` overrides. Personal sandboxes are usually retire-not-
+  migrate content and they dominate raw counts.
+- **Token expiry** — on a 401 it writes a `token_expired: true` flag into
+  `inventory.json` and stops gracefully so you can re-auth and re-run (already
+  fetched specs on disk are skipped — resumable).
+- **`view_count`** — recorded when the instance exposes it on card/dashboard
+  responses (**v50+**). Pre-v50 OSS exposes essentially no usage data via REST
+  (see `refs/usage-telemetry.md`); treat usage as a known gap and request the
+  Pro/EE Usage analytics export from the admin.
+- **Sandboxing (EE)** — probes `GET /api/mt/gtap` once; on Pro/EE with
+  sandboxes defined it saves `sandboxes.json` (surfaced as a needs-review
+  item); on OSS the 404 is silently ignored.
+
+---
+
+## Phase 2 — Score converter coverage (THE differentiator)
+
+```bash
+node scripts/score-coverage.mjs --in /tmp/metabase-assessment-<env>/specs --out /tmp/metabase-assessment-<env>
+# offline against the bundled fixtures:
+node scripts/score-coverage.mjs --in fixtures --out /tmp/metabase-assessment-<env>
+```
+
+For every `*.card.json` and `*.dashboard.json`, the scorer classifies features
+into four buckets — **auto / hint / manual / unhandled** — by detecting the
+*exact* gap signals the converter flags. It does NOT re-implement the
+converter; MBQL is plain JSON, so it recurses the `dataset_query` trees and
+matches op names against `translateMbqlExpr`'s translated-vs-flagged tables
+(`refs/expression-dsl.md` in the sibling converter skill). Each detected gap is
+recorded with a count **and** the specific reason + remediation.
+
+### Card signals (mirror `metabase.ts` / `expression-dsl.md`)
+
+| Bucket | Signal | Why |
+|---|---|---|
+| `auto` | MBQL table source, breakouts, translated aggregations (`count/sum/avg/min/max/median/distinct/stddev/var/percentile/count-where/sum-where/share`), translated expression & filter ops (arithmetic, `case`, `coalesce`, string fns, date fns, casts, `in`/`not-in`, comparison/`between`/`time-interval`…); native-SQL cards (→ DM `sql` element) with plain `text`/`number`/`date`/`boolean` template tags (same `{{}}` syntax in Sigma); single-rule conditional formatting; displays `table/bar/row/line/area/combo/scatter/pie/scalar/smartscalar/pivot/map` | translated cleanly by the converter (pMBQL is normalized at intake) |
+| `hint` | nested-card source (`source-table: "card__N"`); `dimension`-type **field-filter** template tags; `{{#card}}` tags; optional `[[…]]` SQL blocks; explicit MBQL `joins` | convert fine, but review (source ordering, control wiring, join fan-out) |
+| `manual` | `binning` opts on a breakout (numeric histogram); `["segment", id]` / legacy `["metric", id]` refs (definitions live in other objects — inline needed); `click_behavior`; `snippet` template tags; gradient/range conditional formatting; `object` detail views; multi-stage queries | converter passes through + warns; brief re-creation in Sigma |
+| `unhandled` | `cum-sum` / `cum-count` / `offset` aggregations (window scope lives on the consuming element); displays `funnel/gauge/progress/waterfall/sankey`; sandboxing policies (EE); any unmapped MBQL op | converter emits a flagged placeholder + loud warning |
+
+### Dashboard signals
+
+| Bucket | Signal | Why |
+|---|---|---|
+| `auto` | dashcards whose card `display` is supported (24-col grid maps 1:1 to Sigma); text/heading virtual cards (markdown passes through); `parameters` → Sigma controls; `tabs` → workbook pages | converter emits clean elements |
+| `manual` | `click_behavior` on a dashcard (cross-filter / drill link) | re-implement as a Sigma action |
+| `unhandled` | dashcards whose card `display` is `funnel/gauge/progress/waterfall/sankey` | data preserved as a flagged table; re-pick the closest Sigma element |
+
+### Output
+
+`<out>/coverage.json` — per artifact:
+`{ id, type, name, n_features, n_auto, n_hint, n_manual, n_unhandled, complexity, gaps:[{signal,count,bucket,reason,remediation}], view_count, uses_cards, value, cost, score, tag }`
+plus an estate roll-up: `{ pct_auto_migratable, gap_histogram, by_complexity, by_tag, totals, usage_available }`.
+
+Scoring (same framework as every `*-assessment` skill):
+`cost = 10·n_unhandled + 3·n_manual + 1·n_hint`;
+`value = 10 × view_count` when the instance exposes `view_count` on
+cards/dashboards (v50+), else `10 × n_features` (proxy — see usage-telemetry ref);
+`score = value / (1 + cost)`.
+Complexity: `n_unhandled>0 → high`; else `n_manual>0 → medium`; else `low`.
+Tags: `n_unhandled≥1 → needs-review`; `(manual+unhandled)==0 → migrate-first`;
+`score≥10 → easy-win`; else `moderate`.
+
+---
+
+## Phase 3 — Effort / wave plan
+
+The scorer's roll-up feeds a simple wave plan (computed in `render-report.mjs`):
+
+- **Wave 1 — migrate-first / easy-win.** Low-complexity models + questions +
+  dashboards, no unhandled features. These are the pilot.
+- **Wave 2 — moderate.** Medium complexity (manual setup, no unhandled) —
+  convert with light review.
+- **Wave 3 — needs-review.** Any artifact with an unhandled feature: a
+  cumulative/offset calc, a funnel/gauge/progress/waterfall viz, a sandboxing
+  policy. Each needs a human decision before conversion.
+
+**Models migrate before the dashboards (and questions) that use them** — a
+question sourced from `card__N` and a dashboard's dashcards both point at the
+migrated model's DM element. The dependency is detectable from each card's
+`dataset_query.source-table` (`card__N` refs) and each dashboard's dashcard
+`card_id`s; the scorer records it as `uses_cards` and the renderer sequences
+models ahead of dependents within each wave.
+
+---
+
+## Phase 4 — Render the HTML readout
+
+```bash
+node scripts/render-report.mjs --out /tmp/metabase-assessment-<env>
+# → writes /tmp/metabase-assessment-<env>/readout.html
+```
+
+Reads `inventory.json` (if present) + `coverage.json` and emits a standalone,
+brand-styled `readout.html` (~6 sections, Sigma palette, print-friendly):
+
+1. **Executive summary** — estate size, auto-migration %, headline finding.
+2. **Estate inventory** — counts by type, artifact table (with views when v50+).
+3. **Coverage & auto-migration** — auto/hint/manual/unhandled breakdown, % auto.
+4. **Gap analysis** — named artifacts + the specific gap + why + remediation.
+5. **Effort / wave plan** — the 3 waves, models sequenced before dependents.
+6. **Next steps** — pilot recommendation, what to request from the admin.
+
+All-free framing throughout; no paid upsell.
+
+---
+
+## Phase 5 — Hand off (optional)
+
+After the readout, you can hand the shortlist to the `metabase-to-sigma`
+converter skill for the migrate-first artifacts. The coverage JSON's
+per-artifact `specFile` points the converter straight at the card/dashboard
+JSON it already fetched — and `metadata/<db>.metadata.json` is exactly the
+`--metadata` file the converter requires for field-id resolution. No
+re-discovery.
+
+> Do not auto-convert. Surface the shortlist and let the user choose.
+
+---
+
+## Scripts overview
+
+| Script | Purpose |
+|---|---|
+| `scripts/discover-metabase.sh` | Bulk fast path: `GET /api/card` (all definitions in one response, split locally) + `GET /api/dashboard` list + parallel per-dashboard GETs + per-database schema metadata, emit `inventory.json`. Production-validated: 7k-card estate in ~1 minute. Auth via `MB_KEY` (x-api-key) or `MB_SESSION`. Read-only, resumable, token-expiry aware, skips personal collections by default; `--walk` = legacy per-collection walk. |
+| `scripts/mb-bulk-split.py` | Local companion (stdlib-only): splits the bulk card payload into per-card specs, builds artifact records + `databases.txt`, filters dashboard fetch lists (resumable). Never talks to the network. |
+| `scripts/pmbql-normalize.mjs` | pMBQL ("lib/" MBQL) → legacy MBQL normalizer (byte-identical copy of the converter's — the converter test suite guards the sync). |
+| `scripts/score-coverage.mjs` | Classify every card/dashboard auto/hint/manual/unhandled against the converter's exact gap signals by walking the (normalized) MBQL JSON trees; per-artifact complexity + estate roll-up. Production-validated on 8,571 artifacts. |
+| `scripts/render-report.mjs` | Emit the branded standalone `readout.html`. Zero-dependency. |
+
+## Refs
+
+| Ref | Contents |
+|---|---|
+| `refs/mb-rest.md` | The Metabase REST endpoints this skill uses + the two auth shapes. |
+| `refs/scoring-rubric.md` | Every gap signal, what it means, which bucket, and the remediation text shown in the readout. |
+| `refs/usage-telemetry.md` | Honest investigation of Metabase usage stats: `view_count` (v50+) and `/api/activity/recents` are thin; rich audit is Pro/EE "Usage analytics"; pre-v50 OSS has essentially nothing. |
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `discover-metabase.sh --probe` fails | `MB_BASE` wrong / instance unreachable | Probe hits `GET /api/session/properties` — verify the base URL (no trailing `/api`) |
+| Authenticated requests 401 | `MB_SESSION` expired (14-day default, sooner with SSO) | Re-login (`POST /api/session`) and re-export, or switch to an API key (`MB_KEY`) |
+| API-key requests 403 | The key's **group** lacks collection read permissions | Ask the admin for a key in a group with view access (Administrators for a full scan) |
+| `inventory.json` has `token_expired: true` | Auth died mid-walk | Re-auth, re-run — on-disk specs are skipped (resumable) |
+| `score-coverage.mjs` finds 0 artifacts | `--in` points at the wrong dir | Point at the `specs/` dir (live) or `fixtures/` (offline) |
+| Dashboard scores 0 dashcards | Pre-v48 instance returns `ordered_cards` (with `sizeX/sizeY`), not `dashcards` | The scorer handles both shapes — if counts still look wrong, check the raw JSON for a third variant |
+| `view_count` all blank / value falls back to feature counts | Instance is pre-v50 (OSS exposes no view counts before that) | Expected — see `refs/usage-telemetry.md`; request the Pro/EE Usage analytics export from the admin |
+| Personal-collection content missing from the inventory | Skipped by default | Re-run with `--include-personal` |

--- a/metabase-migration-skills/metabase-assessment/fixtures/101.card.json
+++ b/metabase-migration-skills/metabase-assessment/fixtures/101.card.json
@@ -1,0 +1,32 @@
+{
+  "id": 101,
+  "name": "Revenue by Month",
+  "description": "Clean MBQL question — everything translates automatically.",
+  "collection_id": 5,
+  "database_id": 2,
+  "table_id": 45,
+  "type": "question",
+  "display": "line",
+  "dataset_query": {
+    "type": "query",
+    "database": 2,
+    "query": {
+      "source-table": 45,
+      "aggregation": [
+        ["sum", ["field", 72, null]],
+        ["count"]
+      ],
+      "breakout": [["field", 80, { "temporal-unit": "month" }]],
+      "filter": ["=", ["field", 81, null], "Widget", "Gadget"]
+    }
+  },
+  "result_metadata": [
+    { "name": "CREATED_AT", "display_name": "Created At", "base_type": "type/DateTime", "field_ref": ["field", 80, { "temporal-unit": "month" }] },
+    { "name": "sum", "display_name": "Sum of Total", "base_type": "type/Float" },
+    { "name": "count", "display_name": "Count", "base_type": "type/Integer" }
+  ],
+  "visualization_settings": {
+    "graph.dimensions": ["CREATED_AT"],
+    "graph.metrics": ["sum", "count"]
+  }
+}

--- a/metabase-migration-skills/metabase-assessment/fixtures/102.card.json
+++ b/metabase-migration-skills/metabase-assessment/fixtures/102.card.json
@@ -1,0 +1,30 @@
+{
+  "id": 102,
+  "name": "Cumulative Revenue",
+  "description": "Uses cum-sum — the converter flags it (window scope lives on the consuming element).",
+  "collection_id": 5,
+  "database_id": 2,
+  "table_id": 45,
+  "type": "question",
+  "display": "line",
+  "dataset_query": {
+    "type": "query",
+    "database": 2,
+    "query": {
+      "source-table": 45,
+      "expressions": {
+        "Profit": ["-", ["field", 72, null], ["field", 73, null]]
+      },
+      "aggregation": [["cum-sum", ["field", 72, null]]],
+      "breakout": [["field", 80, { "temporal-unit": "month" }]]
+    }
+  },
+  "result_metadata": [
+    { "name": "CREATED_AT", "display_name": "Created At", "base_type": "type/DateTime", "field_ref": ["field", 80, { "temporal-unit": "month" }] },
+    { "name": "cum-sum", "display_name": "Cumulative sum of Total", "base_type": "type/Float" }
+  ],
+  "visualization_settings": {
+    "graph.dimensions": ["CREATED_AT"],
+    "graph.metrics": ["cum-sum"]
+  }
+}

--- a/metabase-migration-skills/metabase-assessment/fixtures/103.card.json
+++ b/metabase-migration-skills/metabase-assessment/fixtures/103.card.json
@@ -1,0 +1,27 @@
+{
+  "id": 103,
+  "name": "Orders Cleaned (model)",
+  "description": "Native-SQL model with one plain text tag (auto) and one dimension field-filter tag (hint).",
+  "collection_id": 5,
+  "database_id": 2,
+  "table_id": null,
+  "type": "model",
+  "display": "table",
+  "dataset_query": {
+    "type": "native",
+    "database": 2,
+    "native": {
+      "query": "SELECT * FROM ORDERS WHERE STATUS = {{status}} AND {{date_range}}",
+      "template-tags": {
+        "status": { "name": "status", "display-name": "Status", "type": "text", "default": "completed" },
+        "date_range": { "name": "date_range", "display-name": "Date Range", "type": "dimension", "widget-type": "date/range", "dimension": ["field", 80, null] }
+      }
+    }
+  },
+  "result_metadata": [
+    { "name": "ID", "display_name": "ID", "base_type": "type/BigInteger" },
+    { "name": "TOTAL", "display_name": "Total", "base_type": "type/Float" },
+    { "name": "CREATED_AT", "display_name": "Created At", "base_type": "type/DateTime" }
+  ],
+  "visualization_settings": {}
+}

--- a/metabase-migration-skills/metabase-assessment/fixtures/104.card.json
+++ b/metabase-migration-skills/metabase-assessment/fixtures/104.card.json
@@ -1,0 +1,43 @@
+{
+  "id": 401,
+  "name": "Filtered Revenue (pMBQL Native + Tags)",
+  "description": "Modern-format native card with every template-tag kind: text + number variables, a dimension field filter (pMBQL field clause), a card ref, and an optional [[…]] block. Synthetic.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/native",
+        "native": "SELECT c.REGION, SUM(o.SALES_AMOUNT) AS REVENUE\nFROM CSA.TJ.ORDER_FACT o\nJOIN CSA.TJ.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY\nWHERE c.REGION = {{region}} AND {{order_date}} AND o.QUANTITY >= {{min_qty}} [[AND c.LOYALTY_TIER = {{tier}}]]\n  AND o.ORDER_NUMBER IN (SELECT ORDER_NUMBER FROM {{#400-daily-revenue}})\nGROUP BY 1",
+        "template-tags": {
+          "region": {
+            "id": "tt1", "name": "region", "display-name": "Region", "type": "text", "default": "West"
+          },
+          "min_qty": {
+            "id": "tt2", "name": "min_qty", "display-name": "Min Quantity", "type": "number", "default": 1
+          },
+          "order_date": {
+            "id": "tt3", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+            "widget-type": "date/range", "required": false,
+            "dimension": ["field", { "lib/uuid": "00000000-0000-4000-8000-000000000071", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71]
+          },
+          "tier": {
+            "id": "tt4", "name": "tier", "display-name": "Loyalty Tier", "type": "text"
+          },
+          "#400-daily-revenue": {
+            "id": "tt5", "name": "#400-daily-revenue", "display-name": "#400 Daily Revenue", "type": "card", "card-id": 400
+          }
+        }
+      }
+    ]
+  },
+  "result_metadata": [
+    { "name": "REGION", "display_name": "Region", "base_type": "type/Text" },
+    { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+  ],
+  "visualization_settings": {}
+}

--- a/metabase-migration-skills/metabase-assessment/fixtures/201.dashboard.json
+++ b/metabase-migration-skills/metabase-assessment/fixtures/201.dashboard.json
@@ -1,0 +1,42 @@
+{
+  "id": 201,
+  "name": "Executive Overview",
+  "description": "One supported line dashcard, one funnel (unhandled), a text card, a parameter, and a click behavior (manual).",
+  "collection_id": 5,
+  "view_count": 240,
+  "parameters": [
+    { "id": "abc123", "name": "Date", "slug": "date", "type": "date/range", "default": "past30days" }
+  ],
+  "tabs": [{ "id": 1, "name": "Overview" }],
+  "dashcards": [
+    {
+      "id": 1,
+      "card_id": 101,
+      "row": 0, "col": 0, "size_x": 12, "size_y": 6,
+      "dashboard_tab_id": 1,
+      "card": { "id": 101, "name": "Revenue by Month", "display": "line" },
+      "parameter_mappings": [
+        { "parameter_id": "abc123", "card_id": 101, "target": ["dimension", ["field", 80, null]] }
+      ],
+      "visualization_settings": {}
+    },
+    {
+      "id": 2,
+      "card_id": 104,
+      "row": 0, "col": 12, "size_x": 12, "size_y": 6,
+      "dashboard_tab_id": 1,
+      "card": { "id": 104, "name": "Order Funnel", "display": "funnel" },
+      "parameter_mappings": [],
+      "visualization_settings": {
+        "click_behavior": { "type": "link", "linkType": "url", "linkTemplate": "https://example.com/orders/{{ID}}" }
+      }
+    },
+    {
+      "id": 3,
+      "card_id": null,
+      "row": 6, "col": 0, "size_x": 24, "size_y": 2,
+      "dashboard_tab_id": 1,
+      "visualization_settings": { "virtual_card": { "display": "text" }, "text": "## Orders KPIs" }
+    }
+  ]
+}

--- a/metabase-migration-skills/metabase-assessment/fixtures/202.dashboard.json
+++ b/metabase-migration-skills/metabase-assessment/fixtures/202.dashboard.json
@@ -1,0 +1,131 @@
+{
+  "id": 500,
+  "name": "Regional Ops (pMBQL)",
+  "description": "Modern-format dashboard: parameters targeting native template tags (variable + field-filter), a pMBQL dimension target, conditional formatting, series_settings renames, and an object-detail card. Synthetic.",
+  "collection_id": 5,
+  "parameters": [
+    { "id": "p1", "name": "Region", "slug": "region_param", "type": "string/=", "default": "West" },
+    { "id": "p2", "name": "Order Window", "slug": "order_window", "type": "date/range" },
+    { "id": "p3", "name": "Order Date", "slug": "order_date_param", "type": "date/all-options" }
+  ],
+  "tabs": [],
+  "dashcards": [
+    {
+      "id": 9001,
+      "card_id": 401,
+      "row": 0, "col": 0, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p1", "card_id": 401, "target": ["variable", ["template-tag", "region"]] },
+        { "parameter_id": "p3", "card_id": 401, "target": ["dimension", ["template-tag", "order_date"], { "stage-number": 0 }] }
+      ],
+      "visualization_settings": {
+        "table.column_formatting": [
+          { "columns": ["REVENUE"], "type": "single", "operator": ">", "value": 10000, "color": "#22c55e", "highlight_row": false },
+          { "columns": ["REVENUE"], "type": "range", "colors": ["#ffffff", "#509ee3"], "min_type": null, "max_type": null }
+        ]
+      },
+      "card": {
+        "id": 401,
+        "name": "Filtered Revenue (pMBQL Native + Tags)",
+        "display": "table",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [
+            {
+              "lib/type": "mbql.stage/native",
+              "native": "SELECT c.REGION, SUM(o.SALES_AMOUNT) AS REVENUE FROM CSA.TJ.ORDER_FACT o JOIN CSA.TJ.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY WHERE c.REGION = {{region}} AND {{order_date}} GROUP BY 1",
+              "template-tags": {
+                "region": { "id": "tt1", "name": "region", "display-name": "Region", "type": "text", "default": "West" },
+                "order_date": {
+                  "id": "tt3", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+                  "widget-type": "date/range",
+                  "dimension": ["field", { "lib/uuid": "00000000-0000-4000-8000-000000000071", "base-type": "type/DateTime" }, 71]
+                }
+              }
+            }
+          ]
+        },
+        "result_metadata": [
+          { "name": "REGION", "display_name": "Region", "base_type": "type/Text" },
+          { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9002,
+      "card_id": 402,
+      "row": 0, "col": 12, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p2", "card_id": 402, "target": ["dimension", ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000d001", "base-type": "type/DateTime", "temporal-unit": "week" }, 71], { "stage-number": 0 }] }
+      ],
+      "visualization_settings": {
+        "series_settings": { "total_revenue": { "title": "Revenue ($)", "color": "#88BF4D" } }
+      },
+      "card": {
+        "id": 402,
+        "name": "Weekly Orders by Region (pMBQL)",
+        "display": "bar",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [
+            {
+              "lib/type": "mbql.stage/mbql",
+              "source-table": 45,
+              "aggregation": [
+                ["count", { "lib/uuid": "00000000-0000-4000-8000-00000000a001" }],
+                ["sum", { "lib/uuid": "00000000-0000-4000-8000-00000000a002", "name": "total_revenue", "display-name": "Total Revenue" },
+                  ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000a003", "base-type": "type/Float" }, 72]]
+              ],
+              "breakout": [
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000b001", "base-type": "type/DateTime", "temporal-unit": "week" }, 71]
+              ]
+            }
+          ]
+        },
+        "result_metadata": [
+          { "name": "ORDER_DATE", "display_name": "Order Date: Week", "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "week" }] },
+          { "name": "count", "display_name": "Count", "base_type": "type/Integer", "field_ref": ["aggregation", 0] },
+          { "name": "total_revenue", "display_name": "Total Revenue", "base_type": "type/Float", "field_ref": ["aggregation", 1] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9003,
+      "card_id": 406,
+      "row": 6, "col": 0, "size_x": 8, "size_y": 4,
+      "parameter_mappings": [],
+      "visualization_settings": {},
+      "card": {
+        "id": 406,
+        "name": "Order Record",
+        "display": "object",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 45 }]
+        },
+        "result_metadata": [
+          { "name": "ORDER_NUMBER", "display_name": "Order Number", "base_type": "type/Integer", "field_ref": ["field", 70, null] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9004,
+      "card_id": null,
+      "row": 6, "col": 8, "size_x": 8, "size_y": 4,
+      "parameter_mappings": [],
+      "visualization_settings": {
+        "virtual_card": { "display": "text" },
+        "text": "## Ops Notes\nSynthetic markdown block."
+      }
+    }
+  ]
+}

--- a/metabase-migration-skills/metabase-assessment/refs/mb-rest.md
+++ b/metabase-migration-skills/metabase-assessment/refs/mb-rest.md
@@ -1,0 +1,45 @@
+# Metabase REST endpoints used by metabase-assessment
+
+All read-only `GET`s against the first-class public API (`<host>/api/...`) —
+works on open source and Pro/EE alike, v46+. Auth is one plain header, either:
+
+| Method | Header | Notes |
+|---|---|---|
+| **API key** (preferred, v49+) | `x-api-key: $MB_KEY` | Admin → Settings → Authentication → API keys. Durable. A 403 means the key's **group** lacks collection read perms — ask for a key in a group with view access (Administrators for a full scan). |
+| **Session token** | `X-Metabase-Session: $MB_SESSION` | From `POST /api/session {"username","password"}`. Expires (14-day default, sooner with SSO) — on 401 re-login and re-run (the walk is resumable). |
+
+## Fast path (default — production-validated, 7k-card estate in ~1 minute)
+
+The per-item collection walk took **>1 hour** on a 7,023-card / 1,548-dashboard
+Metabase Cloud estate. The rewritten `discover-metabase.sh` uses bulk endpoints:
+
+| Need | Endpoint | Notes |
+|---|---|---|
+| Probe / version | `GET /api/session/properties` | `version.tag` — works without auth; tells you whether `view_count` will exist (v50+) |
+| Collection tree | `GET /api/collection?archived=false` | flat list; `personal_owner_id != null` (or `is_personal`) = personal space — skipped by default → `<out>/collections.json` |
+| **ALL cards (bulk)** | `GET /api/card` | EVERY card **with its full definition** in one response (~110MB for 7k cards) — streamed to disk, split locally by `mb-bulk-split.py split-cards` into `<out>/specs/{id}.card.json` + `databases.txt`. Falls back to the legacy walk if unavailable |
+| Dashboard list | `GET /api/dashboard` | shallow list `{id, name, collection_id, archived}` → `<out>/dashboards.list.json` |
+| **Dashboard defs (parallel)** | `GET /api/dashboard/{id}` | ~16 concurrent, resumable (on-disk specs skipped), `--max-dashboards N` to cap; `dashcards[]` (⚠ pre-v48: `ordered_cards[]`) + `parameters[]` + `tabs[]` + `view_count` (v50+) → `<out>/specs/{id}.dashboard.json` |
+| **Schema metadata** | `GET /api/database/{id}/metadata` | once per referenced database → `<out>/metadata/{id}.metadata.json`. **403 on scoped keys is recorded, not fatal** — fallback chain below |
+| Field-id fallback | `GET /api/field/{id}` | when metadata 403s: card `result_metadata` first, then this endpoint (**worked even for restricted DBs on the reference estate**), then names from the SQL when native |
+| Sandboxing probe (EE) | `GET /api/mt/gtap` | Pro/EE only — 404 on OSS (silently ignored); non-empty array → `sandboxes.json`, surfaced as needs-review |
+| Recent views (thin) | `GET /api/activity/recents` | not used for ranking — see `usage-telemetry.md` |
+
+Legacy walk (`--walk`, or automatic fallback): `GET
+/api/collection/{id}/items?models=card&models=dashboard&models=dataset&limit=100&offset=N`
+per collection, then per-item GETs — keep for pre-bulk instances only.
+
+Format note: modern instances (Cloud v1.61+) return `dataset_query` in
+**pMBQL** (`{"lib/type":"mbql/query","stages":[…]}`); the scorer normalizes via
+`pmbql-normalize.mjs` at intake. Sniff the `lib/type` key per card — a list may
+mix formats across versions.
+
+## What is NOT available here
+
+- **Per-artifact usage history** (views over time, per-user reach) — `view_count`
+  (v50+) is a lifetime counter only; rich audit is the Pro/EE "Usage analytics"
+  collection. Pre-v50 OSS has essentially nothing. See `usage-telemetry.md`.
+- **Serialization export** (`/api/ee/serialization/export`, YAML bundles) is
+  Pro/EE-only — this skill never depends on it; the REST walk above works on OSS.
+- **Warehouse data** — this skill never calls `/api/card/{id}/query` or
+  `/api/dataset`; definitions only, never results.

--- a/metabase-migration-skills/metabase-assessment/refs/scoring-rubric.md
+++ b/metabase-migration-skills/metabase-assessment/refs/scoring-rubric.md
@@ -1,0 +1,104 @@
+# Metabase→Sigma coverage scoring rubric
+
+`score-coverage.mjs` classifies every feature into one of four buckets by
+detecting the **exact** signals the `metabase-to-sigma` converter
+(`converter/metabase.ts`, `translateMbqlExpr`) acts on. It does not re-run the
+converter; it mirrors what the converter translates cleanly vs. flags. MBQL is
+already-parsed JSON, so the scorer recurses the `dataset_query` trees and
+matches op names — no regex DSL parsing. Each detected gap is recorded with a
+count, the reason, and the remediation shown in the readout.
+
+## Buckets
+
+| Bucket | Meaning | Converter behavior |
+|---|---|---|
+| **auto** | Converts cleanly, zero touch | emitted directly (table source, breakout, aggregation, expression, chart, control, sql element) |
+| **hint** | Converts, but review one thing (no logic rebuild) | converts; a sequencing/wiring/fan-out check (nested card, field filter, join) |
+| **manual** | Brief re-creation in Sigma | converter passes through + warns; you rebuild it by hand |
+| **unhandled** | No clean Sigma analog — needs a human design decision | converter emits a flagged placeholder + a loud warning (never silent, never guessed) |
+
+## Cost / value / tag (same framework as every `*-assessment` skill)
+
+- `cost  = 10·n_unhandled + 3·n_manual + 1·n_hint`
+- `value = 10 · view_count` when the instance exposes `view_count` on cards/dashboards (**v50+**); else `10 · n_features` *(proxy — see `usage-telemetry.md`)*
+- `score = value / (1 + cost)`
+- complexity: `n_unhandled>0 → high`; else `n_manual>0 → medium`; else `low`
+- tag: `n_unhandled≥1 → needs-review`; else `(manual+unhandled)==0 → migrate-first`; else `score≥10 → easy-win`; else `moderate`
+- `pct_auto_migratable = (n_auto + n_hint) / n_features` — hint is a review, not rework, so it counts as auto-migratable.
+
+## Card signals (from `metabase.ts` / the converter's `expression-dsl.md`)
+
+| Signal | Bucket | Reason | Remediation |
+|---|---|---|---|
+| table source (`source-table: <int>`) | auto | → the model/DM element for the warehouse table | — |
+| breakout (no binning) | auto | → Sigma grouping / chart axis (`temporal-unit` → `DateTrunc`) | — |
+| translated aggregation — `count/sum/avg/min/max/median/distinct/stddev/var/percentile/count-where/sum-where/share` (+ `aggregation-options` name wrapper) | auto | → `Sum/Avg/CountIf/SumIf/Percentile/…` via `translateMbqlExpr` | — |
+| translated expression/filter op — arithmetic, `case`, `coalesce`, `concat`, string fns (`substring/trim/upper/lower/length/replace/regex-match-first/split-part`), math (`round/floor/ceil/abs/sqrt/exp/power/log`), date fns (`datetime-add/-subtract/-diff`, `get-*`, `now`, `relative-datetime`), comparisons, `between`, `is-null/not-null/is-empty/not-empty`, `starts-with/ends-with/contains/does-not-contain`, `time-interval`, `inside` | auto | maps via `translateMbqlExpr` (multi-value `=` → `Or` chain — Sigma has no `IsIn`) | — |
+| native SQL card | auto | the SQL text → a Sigma Custom SQL (`sql`) element verbatim | — |
+| plain template tag (`type: text/number/date`) | auto | → a Sigma `=`-parameter control | — |
+| supported display — `table/bar/row/line/area/combo/scatter/pie/scalar/smartscalar/trend/pivot/map` | auto | → native Sigma table/chart/pivot/KPI/map element | — (note: the `smartscalar`/`trend` auto "vs previous period" comparison line is a manual follow-up — the KPI value itself converts) |
+| nested-card source (`source-table: "card__N"`) | hint | built on another saved card (usually a model) | converts to an element sourced from card N's element — sequence the source card first; recorded in `uses_cards` for the wave plan |
+| field-filter template tag (`type: dimension`) | hint | the tag expands to a whole WHERE clause at runtime | becomes a Sigma control on the target column + an element filter — verify widget type + default |
+| nested-card template tag (`{{#N}}`, `type: card`) | hint | inlines another saved question as a sub-query | sequence the referenced card first |
+| explicit MBQL `joins` | hint | converts to a Sigma DM `join` source | review fan-out (row multiplication) before trusting aggregates — same risk as in Metabase |
+| `binning` opts on a breakout | manual | numeric histogram buckets | recreate with `BinFixed()`/`BinCount()` in the consuming workbook element |
+| `["segment", id]` ref | manual | definition lives in another object | inline the segment's MBQL filter (`GET /api/segment/{id}`) |
+| `["metric", id]` ref (legacy) | manual | definition lives in another object | inline the metric's aggregation (`GET /api/legacy-metric/{id}`) |
+| `click_behavior` (top-level or per-column) | manual | cross-filter / drill link | re-implement as a Sigma action |
+| snippet template tag (`type: snippet`) | manual | splices a shared SQL snippet | inline the snippet text into the Custom SQL |
+| optional `[[…]]` SQL block | hint | Metabase includes it only when the tag has a value; Sigma has no optional-clause syntax | field-filter/default-carrying blocks stay active; others are dropped (Metabase's empty-value behavior) with a loud warning — review each |
+| conditional formatting — `single` rule | auto | threshold rule → Sigma `conditionalFormats` entry | — |
+| conditional formatting — gradient/`range` scale | manual | backgroundScale spec shape not live-verified | recreate in the Sigma UI |
+| `object` display (record detail) | manual | single-record detail view | flagged table; recreate detail with element filters / drill |
+| multi-stage query (pMBQL `stages`>1 / `source-query`) | manual | a sub-query, not a flat card | rebuild as chained Sigma elements; converter flags + skips |
+| `cum-sum` / `cum-count` / `offset` | unhandled | running-total / lag window — the window scope lives on the consuming element | rebuild with `CumulativeSum` / `Lag` in the date-grouped workbook element (proven pattern); converter emits a flagged placeholder |
+| display `funnel/gauge/progress/waterfall/sankey` | unhandled | no native Sigma element | data preserved as a flagged table; re-pick the closest element (ordered bar for funnel, KPI for gauge/progress) |
+| unmapped MBQL op | unhandled | no confirmed Sigma mapping | translate by hand; converter emits `/* unmapped: <op> */` + a loud warning |
+| sandboxing policy (EE, from `sandboxes.json`) | unhandled | GTAP row-level security per group | port to Sigma user attributes + DM filters via the shared RLS engine (`apply_sigma_rls.py`) — opt-in, reviewed per policy |
+
+## Dashboard signals
+
+| Signal | Bucket | Reason | Remediation |
+|---|---|---|---|
+| dashcard with a supported card display | auto | 24-col grid → Sigma's 24-col layout 1:1 | — |
+| text/heading card (`card_id: null` + `virtual_card`) | auto | markdown → Sigma text element | — |
+| `parameters[]` | auto | → Sigma controls (+ `parameter_mappings` → per-card filter targets) | — |
+| `tabs[]` | auto | → workbook pages | — |
+| `click_behavior` on a dashcard | manual | cross-filter / drill link | re-implement as a Sigma action |
+| dashcard with display `funnel/gauge/progress/waterfall` | unhandled | no native Sigma element | flagged table; re-pick the closest element |
+
+Both `dashcards[]` (v48+, `size_x/size_y`) and legacy `ordered_cards[]`
+(`sizeX/sizeY`) shapes are accepted.
+
+## Production calibration (a 7k-card production estate, 2026-06)
+
+First production run of this scorer — Metabase Cloud v1.61.4, 7,023 cards /
+12 models / 1,548 dashboards (8,571 artifacts), 100% pMBQL. Results to sanity-
+check your own runs against:
+
+- **97% auto-migratable** (50,806 features: 45,303 auto · 4,152 hint ·
+  894 manual · 457 unhandled)
+- tags: **migrate-first 8,039 · easy-win 272 · needs-review 183 · moderate 77**
+- display histogram (cards): table 2999 · bar 1604 · line 1176 · combo 449 ·
+  scalar 259 · pie 135 · row 130 · funnel 83 · area 67 · pivot 39 · object 37 ·
+  waterfall 15 · sankey 13 · gauge 11 · scatter 3 · progress 3 — everything
+  except funnel/waterfall/sankey/gauge/progress (flagged tables) and object
+  (flagged detail) converts natively
+- top gaps: funnel display (353 incl. dashcards) · gradient conditional
+  formatting (594) · object detail (273) · gauge (40) · waterfall (29) ·
+  sankey (21) · multi-stage (16) · `month-name`/`day-name` (7)
+- 45% of cards carry template tags; 53% of dashboards carry parameters; 17%
+  use tabs; `view_count` available (usage-based value path exercised)
+
+## Calibrating against the bundled fixtures
+
+Running against `fixtures/` (4 cards + 2 dashboards) must produce all four buckets:
+
+- **Revenue by Month** (101) — all-auto MBQL (sum/count, month breakout, multi-value `=` filter, line) → `migrate-first`, low.
+- **Cumulative Revenue** (102) — `cum-sum` → `needs-review`, high (the `-` Profit expression still scores auto).
+- **Orders Cleaned (model)** (103) — native SQL model; `{{status}}` text tag auto, `{{date_range}}` dimension field filter → 1 **hint**; `migrate-first`, low.
+- **Executive Overview** (201) — funnel dashcard → **unhandled**; a `click_behavior` → **manual**; parameter/tab/line/text → auto; `view_count: 240` exercises the usage-based value path.
+- **Filtered Revenue (pMBQL Native + Tags)** (104) — modern `lib/type` format: plain tags auto, field-filter + card tags + optional block → **hints**; `migrate-first`.
+- **Regional Ops (pMBQL)** (202) — pMBQL dashboard: parameters auto, object dashcard → **manual**.
+
+If those don't show up, the scorer regressed.

--- a/metabase-migration-skills/metabase-assessment/refs/usage-telemetry.md
+++ b/metabase-migration-skills/metabase-assessment/refs/usage-telemetry.md
@@ -1,0 +1,55 @@
+# Usage telemetry on Metabase — an honest investigation
+
+The universal weak spot of every BI migration assessment is **usage**: which
+content is actually viewed, so you can rank a migration shortlist by audience
+value and confidently retire dead content. Here is what Metabase does — and
+does not — expose, and what to do about it.
+
+## What the OSS REST surface gives you (it's thin)
+
+1. **`view_count` (v50+).** Card and dashboard API responses carry a lifetime
+   `view_count` integer. This is the best free signal and the scorer uses it
+   directly: `value = 10 · view_count` when present. But it is a **lifetime
+   counter** — no time series, no per-user breakdown, no "viewed this quarter".
+   A dashboard viewed 5,000 times in 2022 and never since looks identical to a
+   daily driver.
+2. **`GET /api/activity/recents`.** The "recently viewed" list for the calling
+   user — a handful of items, no counts, no history. Useful as a sniff test
+   ("is anything here even touched?"), useless for ranking. The discovery
+   script does not rank on it.
+3. **Pre-v50 OSS: essentially nothing.** No `view_count`, no audit endpoints.
+   The scorer falls back to `value = 10 · n_features` (a size proxy), and the
+   readout says so plainly — the shortlist is ranked by conversion effort, not
+   popularity.
+
+## Where the rich usage data actually lives (Pro/EE)
+
+Metabase Pro/EE ships **"Usage analytics"** — an instance-level analytics
+collection (formerly "Audit tools") backed by the app DB's `view_log` /
+`audit_log`: views **over time**, **per-user** activity, dashboard/question
+usage rankings, unused-content reports. That is exactly the series a migration
+ranking wants. It is:
+
+- **Pro/EE only** — not available on OSS at any version.
+- Accessed in-product (the Usage analytics collection) — an admin can export
+  the relevant questions to CSV in a few clicks.
+- Backed by application-DB tables (`view_log`, `audit_log`) that a
+  self-hosting admin *can* query directly, but that's unsupported surface —
+  prefer the in-product export.
+
+## Recommendation (what the readout tells the user)
+
+> **v50+ instance:** the shortlist is already ranked by `view_count`. Still
+> ask the admin for the Pro/EE Usage analytics export (views over time,
+> per-user reach) before retiring anything — a lifetime counter can't
+> distinguish "popular once" from "popular now".
+>
+> **Pre-v50 / OSS without view counts:** request a usage export from the
+> Metabase admin — either the Pro/EE Usage analytics CSVs, or (self-hosted) a
+> read-only query against the app DB's `view_log`. Until then the shortlist is
+> ranked by conversion effort, not popularity, and the readout says so.
+
+If/when the admin provides a usage CSV (`item_id, item_type, views,
+distinct_users, last_viewed`), the scorer's `value` term can be upgraded to
+`views · sqrt(distinct_users)` — the same value formula the Tableau and Qlik
+assessments use — without changing anything else in the pipeline.

--- a/metabase-migration-skills/metabase-assessment/scripts/discover-metabase.sh
+++ b/metabase-migration-skills/metabase-assessment/scripts/discover-metabase.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# Metabase estate discovery — read-only inventory walk for the
+# metabase-assessment skill.
+#
+# Auth (one of):
+#   export MB_BASE="https://<host>"        # no trailing /api — added here
+#   export MB_KEY="mb_..."                 # API key (v49+)  → x-api-key header
+#   export MB_SESSION="<token>"            # session token   → X-Metabase-Session header
+#
+# Usage:
+#   discover-metabase.sh --probe
+#       Cheap check — GET /api/session/properties, prints the instance version.
+#   discover-metabase.sh --out <dir> [--include-personal] [--concurrency N]
+#                        [--max-dashboards N] [--skip-cards] [--walk] [--page N]
+#       FAST PATH (default — production-validated on a 7k-card / 1.5k-dashboard
+#       estate, ~1 minute vs >1 hour for the old per-item walk):
+#         1. GET /api/card        — ALL card definitions in ONE response
+#                                   (~110MB for 7k cards; streamed to disk, then
+#                                   split locally by mb-bulk-split.py)
+#         2. GET /api/dashboard   — the dashboard list, then PARALLEL
+#                                   per-dashboard GETs (default 16 concurrent,
+#                                   resumable: on-disk specs are skipped)
+#         3. GET /api/database/{id}/metadata once per referenced database
+#            (403 on scoped keys is recorded, not fatal — the converter falls
+#             back to card result_metadata, then GET /api/field/{id})
+#       --walk forces the legacy per-collection item walk (also the automatic
+#       fallback when the bulk card endpoint is unavailable).
+#
+# READ-ONLY: only ever issues GETs. Never POSTs / modifies / runs anything.
+# Resumable (already-downloaded specs are skipped), 401-aware (writes
+# token_expired:true into inventory.json and exits gracefully).
+# Personal collections are skipped by default (--include-personal to override).
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+
+OUT=""
+PROBE=0
+PAGE=100
+INCLUDE_PERSONAL=0
+CONC=16
+MAX_DASH=""
+SKIP_CARDS=0
+WALK=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --probe) PROBE=1; shift ;;
+    --out)   OUT="$2"; shift 2 ;;
+    --page)  PAGE="$2"; shift 2 ;;
+    --concurrency) CONC="$2"; shift 2 ;;
+    --max-dashboards) MAX_DASH="$2"; shift 2 ;;
+    --skip-cards) SKIP_CARDS=1; shift ;;
+    --walk) WALK=1; shift ;;
+    --include-personal) INCLUDE_PERSONAL=1; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+: "${MB_BASE:?set MB_BASE (e.g. https://metabase.example.com — no trailing /api)}"
+MB_BASE="${MB_BASE%/}"
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 2; }
+
+# Pick the auth header: MB_KEY (x-api-key) wins, else MB_SESSION.
+AUTH_NAME=""; AUTH_VALUE=""
+if [ -n "${MB_KEY:-}" ]; then
+  AUTH_NAME="x-api-key"; AUTH_VALUE="$MB_KEY"
+elif [ -n "${MB_SESSION:-}" ]; then
+  AUTH_NAME="X-Metabase-Session"; AUTH_VALUE="$MB_SESSION"
+elif [ "$PROBE" = "0" ]; then
+  echo "set MB_KEY (API key) or MB_SESSION (session token)" >&2; exit 2
+fi
+
+# req <path-with-leading-slash> — body lands in $RESP, status in $HTTP_CODE.
+# NOT command-substituted (a subshell would lose HTTP_CODE); curl -o keeps the
+# body and the status code separate, so no fragile tail-line parsing either.
+RESP=$(mktemp); trap 'rm -f "$RESP"' EXIT
+HTTP_CODE=""
+TOKEN_EXPIRED=0
+req() {
+  : > "$RESP"
+  if [ -n "$AUTH_NAME" ]; then
+    HTTP_CODE=$(curl -s -o "$RESP" -w '%{http_code}' "$MB_BASE$1" \
+      -H 'Accept: application/json' -H "$AUTH_NAME: $AUTH_VALUE" || echo "000")
+  else
+    HTTP_CODE=$(curl -s -o "$RESP" -w '%{http_code}' "$MB_BASE$1" \
+      -H 'Accept: application/json' || echo "000")
+  fi
+  if [ "$HTTP_CODE" = "401" ]; then TOKEN_EXPIRED=1; fi
+}
+ok() { [ -n "$HTTP_CODE" ] && [ "$HTTP_CODE" -ge 200 ] 2>/dev/null && [ "$HTTP_CODE" -lt 400 ] 2>/dev/null; }
+
+# ---- probe ----
+if [ "$PROBE" = "1" ]; then
+  req "/api/session/properties"
+  if ! ok; then
+    echo "PROBE FAILED (HTTP ${HTTP_CODE:-?}) — check MB_BASE (no trailing /api) and that the instance is reachable." >&2
+    exit 1
+  fi
+  version=$(jq -r '.version.tag // "unknown"' "$RESP" 2>/dev/null || echo "unknown")
+  echo "PROBE OK (HTTP $HTTP_CODE). Metabase version: $version"
+  case "$version" in
+    v0.4[0-9].*|v1.4[0-9].*|v0.3*|v1.3*) echo "NOTE: pre-v50 — view_count is not exposed; usage ranking falls back to feature counts." ;;
+  esac
+  exit 0
+fi
+
+[ -n "$OUT" ] || { echo "--out <dir> required (unless --probe)" >&2; exit 2; }
+mkdir -p "$OUT/specs" "$OUT/metadata"
+ART="$OUT/.artifacts.jsonl"; : > "$ART"
+PFLAG=""
+[ "$INCLUDE_PERSONAL" = "1" ] && PFLAG="--include-personal"
+
+# instance version (best effort, for the inventory header)
+req "/api/session/properties"
+VERSION=$(jq -r '.version.tag // "unknown"' "$RESP" 2>/dev/null || echo "unknown")
+
+# ---- collection list (flat — needed by both paths for names + personal flags) ----
+req "/api/collection?archived=false"
+if ! ok; then
+  jq -n --arg base "$MB_BASE" --arg code "${HTTP_CODE:-?}" \
+    '{environment:{base:$base,error:("collection list failed (HTTP " + $code + ")")},artifacts:[],token_expired:true}' \
+    > "$OUT/inventory.json"
+  echo "AUTH FAILED (HTTP ${HTTP_CODE:-?}) listing collections — wrote token_expired flag; re-auth (MB_SESSION expired? MB_KEY group lacks perms?) and re-run." >&2
+  exit 0
+fi
+cp "$RESP" "$OUT/collections.json"
+N_COLLECTIONS=$(jq 'length' "$OUT/collections.json" 2>/dev/null || echo 0)
+
+# id + name per collection (legacy walk); skip personal collections unless asked.
+COLL_TSV=$(jq -r --argjson p "$INCLUDE_PERSONAL" '
+  [ .[] | select($p == 1 or ((.personal_owner_id // null) == null and ((.is_personal // false) | not))) ]
+  | .[] | "\(.id)\t\(.name)"' "$OUT/collections.json" 2>/dev/null || true)
+if ! printf '%s\n' "$COLL_TSV" | cut -f1 | grep -qx 'root'; then
+  COLL_TSV=$(printf 'root\tOur analytics\n%s' "$COLL_TSV")
+fi
+
+fetched_dbs=""  # space-separated db ids already fetched
+
+fetch_metadata() { # $1 = database id
+  local db="$1" f
+  [ -n "$db" ] && [ "$db" != "null" ] || return 0
+  case " $fetched_dbs " in *" $db "*) return 0 ;; esac
+  fetched_dbs="$fetched_dbs $db"
+  f="$OUT/metadata/$db.metadata.json"
+  [ -s "$f" ] && return 0
+  req "/api/database/$db/metadata"
+  if ok && [ -s "$RESP" ]; then
+    cp "$RESP" "$f"
+  elif [ "$HTTP_CODE" = "403" ]; then
+    # Scoped keys often can't read whole-database metadata. NOT fatal: the
+    # converter resolves field ids via card result_metadata, then
+    # GET /api/field/{id} (which works even for restricted DBs), then SQL names.
+    echo "database $db: metadata HTTP 403 — use the field-id fallback chain (result_metadata → GET /api/field/{id})" >> "$OUT/metadata/unavailable.txt"
+  fi
+}
+
+record_failed() { # $1=id $2=type $3=name $4=collection — definition fetch failed
+  jq -n --arg id "$1" --arg type "$2" --arg name "$3" --arg coll "$4" \
+    '{id:($id|tonumber? // $id),type:$type,name:$name,collection:$coll,specFile:null}' >> "$ART"
+}
+
+fetch_card() { # $1=id $2=name $3=collection — appends an artifact record (legacy walk)
+  local id="$1" name="$2" coll="$3" f="$OUT/specs/$1.card.json" db
+  if [ ! -s "$f" ]; then
+    req "/api/card/$id"
+    [ "$TOKEN_EXPIRED" = "1" ] && return 0
+    if ! ok || [ ! -s "$RESP" ]; then record_failed "$id" "card" "$name" "$coll"; return 0; fi
+    cp "$RESP" "$f"
+  fi
+  db=$(jq -r '.database_id // .dataset_query.database // empty' "$f" 2>/dev/null || true)
+  fetch_metadata "$db"
+  jq -c --arg coll "$coll" --arg sf "specs/$id.card.json" '
+    {id:.id, type:(if (.type=="model") or (.dataset==true) then "model" elif .type=="metric" then "metric" else "card" end),
+     name:.name, collection:$coll, view_count:(.view_count // null), specFile:$sf}' "$f" >> "$ART" 2>/dev/null || \
+    record_failed "$id" "card" "$name" "$coll"
+}
+
+fetch_dashboard() { # $1=id $2=name $3=collection (legacy walk)
+  local id="$1" name="$2" coll="$3" f="$OUT/specs/$1.dashboard.json"
+  if [ ! -s "$f" ]; then
+    req "/api/dashboard/$id"
+    [ "$TOKEN_EXPIRED" = "1" ] && return 0
+    if ! ok || [ ! -s "$RESP" ]; then record_failed "$id" "dashboard" "$name" "$coll"; return 0; fi
+    cp "$RESP" "$f"
+  fi
+  jq -c --arg coll "$coll" --arg sf "specs/$id.dashboard.json" \
+    '{id:.id, type:"dashboard", name:.name, collection:$coll, view_count:(.view_count // null), specFile:$sf}' \
+    "$f" >> "$ART" 2>/dev/null || record_failed "$id" "dashboard" "$name" "$coll"
+}
+
+# ============================================================================
+# FAST PATH (default): bulk card endpoint + parallel dashboard GETs
+# ============================================================================
+if [ "$WALK" = "0" ]; then
+  # ---- cards: one bulk GET, split locally ----
+  if [ "$SKIP_CARDS" = "0" ]; then
+    if ls "$OUT/specs/"*.card.json >/dev/null 2>&1 && [ -s "$OUT/databases.txt" ]; then
+      echo "cards already split on disk — rebuilding artifact records (re-delete specs/ to force a re-fetch)"
+      python3 "$SCRIPT_DIR/mb-bulk-split.py" collect-cards --collections "$OUT/collections.json" --out "$OUT" $PFLAG
+    else
+      echo "bulk-fetching ALL card definitions (GET /api/card — ~15MB per 1k cards, streamed to disk) …"
+      BULK="$OUT/cards.bulk.json"
+      CODE=$(curl -s -o "$BULK" -w '%{http_code}' "$MB_BASE/api/card" \
+        -H 'Accept: application/json' -H "$AUTH_NAME: $AUTH_VALUE" || echo "000")
+      if [ "$CODE" = "200" ] && [ -s "$BULK" ]; then
+        python3 "$SCRIPT_DIR/mb-bulk-split.py" split-cards --bulk "$BULK" --collections "$OUT/collections.json" --out "$OUT" $PFLAG
+        rm -f "$BULK"
+      elif [ "$CODE" = "401" ]; then
+        TOKEN_EXPIRED=1
+      else
+        echo "bulk GET /api/card failed (HTTP $CODE) — falling back to the legacy per-collection walk." >&2
+        WALK=1
+      fi
+    fi
+  fi
+
+  # ---- dashboards: list once, fetch in parallel (resumable) ----
+  if [ "$WALK" = "0" ] && [ "$TOKEN_EXPIRED" = "0" ]; then
+    req "/api/dashboard"
+    if ok; then
+      cp "$RESP" "$OUT/dashboards.list.json"
+      DIDS="$OUT/.dash_ids"
+      python3 "$SCRIPT_DIR/mb-bulk-split.py" list-dashboards --list "$OUT/dashboards.list.json" \
+        --collections "$OUT/collections.json" --out "$OUT" $PFLAG ${MAX_DASH:+--max "$MAX_DASH"} > "$DIDS"
+      N_TO_FETCH=$(grep -c . "$DIDS" || true)
+      if [ "${N_TO_FETCH:-0}" -gt 0 ]; then
+        echo "fetching $N_TO_FETCH dashboards ($CONC parallel, resumable) …"
+        export MB_BASE AUTH_NAME AUTH_VALUE OUT
+        xargs -P "$CONC" -n 1 sh -c '
+          id="$0"; f="$OUT/specs/$id.dashboard.json"
+          [ -s "$f" ] && exit 0
+          tmp="$f.tmp.$$"
+          code=$(curl -s -o "$tmp" -w "%{http_code}" "$MB_BASE/api/dashboard/$id" \
+            -H "Accept: application/json" -H "$AUTH_NAME: $AUTH_VALUE" || echo 000)
+          if [ "$code" = "200" ] && [ -s "$tmp" ]; then mv "$tmp" "$f"
+          else rm -f "$tmp"; echo "dashboard $id: HTTP $code" >&2; fi
+        ' < "$DIDS" || true
+      fi
+      python3 "$SCRIPT_DIR/mb-bulk-split.py" collect-dashboards --collections "$OUT/collections.json" --out "$OUT"
+      rm -f "$DIDS"
+    elif [ "$HTTP_CODE" = "401" ]; then
+      TOKEN_EXPIRED=1
+    else
+      echo "GET /api/dashboard failed (HTTP $HTTP_CODE) — dashboards via the legacy walk." >&2
+      WALK=1
+    fi
+  fi
+
+  # ---- database metadata (once per referenced database; 403 = fallback chain) ----
+  if [ "$TOKEN_EXPIRED" = "0" ] && [ -s "$OUT/databases.txt" ]; then
+    while IFS= read -r db; do
+      [ -n "$db" ] && fetch_metadata "$db"
+    done < "$OUT/databases.txt"
+  fi
+fi
+
+# ============================================================================
+# LEGACY WALK (--walk, or automatic fallback): per-collection item pages
+# ============================================================================
+if [ "$WALK" = "1" ]; then
+  while IFS=$'\t' read -r cid cname; do
+    [ -n "$cid" ] || continue
+    [ "$TOKEN_EXPIRED" = "1" ] && break
+    offset=0
+    while :; do
+      [ "$TOKEN_EXPIRED" = "1" ] && break
+      req "/api/collection/$cid/items?models=card&models=dashboard&models=dataset&limit=$PAGE&offset=$offset"
+      [ "$TOKEN_EXPIRED" = "1" ] && break
+      ok || break
+      n=$(jq '.data | length' "$RESP" 2>/dev/null || echo 0)
+      [ "$n" -gt 0 ] 2>/dev/null || break
+      # snapshot the page before inner reqs reuse $RESP
+      items=$(jq -r '.data[] | "\(.model)\t\(.id)\t\(.name)"' "$RESP")
+      while IFS=$'\t' read -r model iid iname; do
+        [ -n "$iid" ] || continue
+        [ "$TOKEN_EXPIRED" = "1" ] && break
+        case "$model" in
+          card|dataset) fetch_card "$iid" "$iname" "$cname" ;;
+          dashboard)    fetch_dashboard "$iid" "$iname" "$cname" ;;
+        esac
+      done <<< "$items"
+      [ "$n" -lt "$PAGE" ] && break
+      offset=$((offset + PAGE))
+    done
+  done <<< "$COLL_TSV"
+fi
+
+# ---- sandboxing probe (Pro/EE only; 404 on OSS is fine) ----
+if [ "$TOKEN_EXPIRED" = "0" ]; then
+  req "/api/mt/gtap" || true
+  if ok && jq -e 'type=="array" and length>0' "$RESP" >/dev/null 2>&1; then
+    cp "$RESP" "$OUT/sandboxes.json"
+    echo "NOTE: $(jq 'length' "$OUT/sandboxes.json") sandboxing policies found (EE) -> $OUT/sandboxes.json"
+  fi
+fi
+
+# ---- assemble inventory.json ----
+jq -s --arg base "$MB_BASE" --arg version "$VERSION" --argjson ncoll "${N_COLLECTIONS:-0}" \
+   --argjson expired "$TOKEN_EXPIRED" '
+  . as $arts |
+  {environment:{
+     generated_at: (now | strftime("%Y-%m-%d")),
+     base: $base, version: $version,
+     n_collections: $ncoll,
+     by_type: (reduce $arts[] as $a ({}; .[$a.type] = ((.[$a.type] // 0) + 1))),
+     n_artifacts: ($arts | length),
+     n_cards: ([$arts[] | select(.type=="card" or .type=="metric")] | length),
+     n_models: ([$arts[] | select(.type=="model")] | length),
+     n_dashboards: ([$arts[] | select(.type=="dashboard")] | length)
+   },
+   artifacts: $arts}
+  + (if $expired == 1 then {token_expired:true} else {} end)
+' "$ART" > "$OUT/inventory.json"
+rm -f "$ART"
+
+n_total=$(jq '.environment.n_artifacts' "$OUT/inventory.json")
+n_models=$(jq '.environment.n_models' "$OUT/inventory.json")
+n_cards=$(jq '.environment.n_cards' "$OUT/inventory.json")
+n_dash=$(jq '.environment.n_dashboards' "$OUT/inventory.json")
+msg="discovered $n_total artifacts ($n_models models, $n_cards questions, $n_dash dashboards) -> $OUT/inventory.json"
+if [ "$TOKEN_EXPIRED" = "1" ]; then
+  msg="$msg  [WARNING: auth expired mid-walk (401) — re-auth and re-run to complete; on-disk specs are kept]"
+fi
+echo "$msg"

--- a/metabase-migration-skills/metabase-assessment/scripts/mb-bulk-split.py
+++ b/metabase-migration-skills/metabase-assessment/scripts/mb-bulk-split.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""mb-bulk-split.py — companion to discover-metabase.sh's bulk fast path.
+
+Production finding (7k-card / 1.5k-dashboard Metabase Cloud estate): the old
+per-item sequential walk took >1 hour; `GET /api/card` returns EVERY card with
+its full definition in one response (~110MB for 7k cards). Stream that to disk,
+then split it locally — the whole discovery drops to ~1 minute.
+
+Subcommands (all local-file only; the shell script does the HTTP):
+  split-cards        --bulk cards.bulk.json --collections collections.json --out DIR
+                     [--include-personal]
+        → DIR/specs/{id}.card.json (skip-if-exists), appends DIR/.artifacts.jsonl,
+          writes DIR/databases.txt (distinct database ids, for metadata fetches)
+  list-dashboards    --list dashboards.list.json --collections collections.json --out DIR
+                     [--include-personal] [--max N]
+        → prints dashboard ids to fetch (one per line), already-downloaded ids skipped
+  collect-cards      --collections collections.json --out DIR [--include-personal]
+        → rebuilds artifact records + databases.txt from DIR/specs/*.card.json
+          (resume path — avoids re-downloading the bulk payload)
+  collect-dashboards --collections collections.json --out DIR
+        → appends artifact records for every DIR/specs/*.dashboard.json on disk
+
+Stdlib only. Read-only with respect to Metabase (never talks to the network).
+"""
+import argparse
+import json
+import os
+import sys
+from glob import glob
+
+
+def load_collections(path):
+    """collection id → name; plus the set of personal-collection ids."""
+    names = {None: 'Our analytics', 'root': 'Our analytics'}
+    personal = set()
+    try:
+        with open(path) as f:
+            colls = json.load(f)
+    except (OSError, ValueError):
+        return names, personal
+    for c in colls if isinstance(colls, list) else []:
+        cid = c.get('id')
+        names[cid] = c.get('name') or str(cid)
+        if c.get('personal_owner_id') is not None or c.get('is_personal'):
+            personal.add(cid)
+    return names, personal
+
+
+def artifact_type(card):
+    if card.get('type') == 'model' or card.get('dataset') is True:
+        return 'model'
+    if card.get('type') == 'metric':
+        return 'metric'
+    return 'card'
+
+
+def split_cards(args):
+    names, personal = load_collections(args.collections)
+    with open(args.bulk) as f:
+        cards = json.load(f)
+    if not isinstance(cards, list):
+        sys.exit('split-cards: bulk file is not a JSON array — is this really GET /api/card?')
+    specs = os.path.join(args.out, 'specs')
+    os.makedirs(specs, exist_ok=True)
+    dbs, n_written, n_skipped, n_personal = set(), 0, 0, 0
+    art = open(os.path.join(args.out, '.artifacts.jsonl'), 'a')
+    for c in cards:
+        cid = c.get('id')
+        if cid is None or c.get('archived'):
+            continue
+        coll_id = c.get('collection_id')
+        if coll_id in personal and not args.include_personal:
+            n_personal += 1
+            continue
+        path = os.path.join(specs, f'{cid}.card.json')
+        if os.path.exists(path) and os.path.getsize(path) > 0:
+            n_skipped += 1
+        else:
+            tmp = path + '.tmp'
+            with open(tmp, 'w') as f:
+                json.dump(c, f)
+            os.replace(tmp, path)
+            n_written += 1
+        db = c.get('database_id') or (c.get('dataset_query') or {}).get('database')
+        if db:
+            dbs.add(db)
+        art.write(json.dumps({
+            'id': cid, 'type': artifact_type(c), 'name': c.get('name'),
+            'collection': names.get(coll_id, str(coll_id)),
+            'view_count': c.get('view_count'),
+            'specFile': f'specs/{cid}.card.json',
+        }) + '\n')
+    art.close()
+    with open(os.path.join(args.out, 'databases.txt'), 'w') as f:
+        for db in sorted(dbs):
+            f.write(f'{db}\n')
+    print(f'split-cards: {n_written} written, {n_skipped} already on disk, '
+          f'{n_personal} personal-collection cards skipped, {len(dbs)} databases referenced',
+          file=sys.stderr)
+
+
+def list_dashboards(args):
+    _, personal = load_collections(args.collections)
+    with open(args.list) as f:
+        dashes = json.load(f)
+    if isinstance(dashes, dict):  # some versions wrap in {data:[…]}
+        dashes = dashes.get('data', [])
+    specs = os.path.join(args.out, 'specs')
+    out = []
+    for d in dashes if isinstance(dashes, list) else []:
+        did = d.get('id')
+        if did is None or d.get('archived'):
+            continue
+        if d.get('collection_id') in personal and not args.include_personal:
+            continue
+        p = os.path.join(specs, f'{did}.dashboard.json')
+        if os.path.exists(p) and os.path.getsize(p) > 0:
+            continue  # resumable: already downloaded
+        out.append(did)
+    if args.max is not None:
+        out = out[:args.max]
+    for did in out:
+        print(did)
+
+
+def collect_cards(args):
+    names, personal = load_collections(args.collections)
+    specs = os.path.join(args.out, 'specs')
+    art = open(os.path.join(args.out, '.artifacts.jsonl'), 'a')
+    dbs, n = set(), 0
+    for p in sorted(glob(os.path.join(specs, '*.card.json'))):
+        try:
+            with open(p) as f:
+                c = json.load(f)
+        except (OSError, ValueError):
+            continue
+        if c.get('collection_id') in personal and not args.include_personal:
+            continue
+        art.write(json.dumps({
+            'id': c.get('id'), 'type': artifact_type(c), 'name': c.get('name'),
+            'collection': names.get(c.get('collection_id'), str(c.get('collection_id'))),
+            'view_count': c.get('view_count'),
+            'specFile': f"specs/{os.path.basename(p)}",
+        }) + '\n')
+        db = c.get('database_id') or (c.get('dataset_query') or {}).get('database')
+        if db:
+            dbs.add(db)
+        n += 1
+    art.close()
+    with open(os.path.join(args.out, 'databases.txt'), 'w') as f:
+        for db in sorted(dbs):
+            f.write(f'{db}\n')
+    print(f'collect-cards: {n} cards recorded from disk', file=sys.stderr)
+
+
+def collect_dashboards(args):
+    names, _ = load_collections(args.collections)
+    specs = os.path.join(args.out, 'specs')
+    art = open(os.path.join(args.out, '.artifacts.jsonl'), 'a')
+    n = 0
+    for p in sorted(glob(os.path.join(specs, '*.dashboard.json'))):
+        try:
+            with open(p) as f:
+                d = json.load(f)
+        except (OSError, ValueError):
+            continue
+        art.write(json.dumps({
+            'id': d.get('id'), 'type': 'dashboard', 'name': d.get('name'),
+            'collection': names.get(d.get('collection_id'), str(d.get('collection_id'))),
+            'view_count': d.get('view_count'),
+            'specFile': f"specs/{os.path.basename(p)}",
+        }) + '\n')
+        n += 1
+    art.close()
+    print(f'collect-dashboards: {n} dashboards recorded', file=sys.stderr)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest='cmd', required=True)
+    s1 = sub.add_parser('split-cards')
+    s1.add_argument('--bulk', required=True)
+    s1.add_argument('--collections', required=True)
+    s1.add_argument('--out', required=True)
+    s1.add_argument('--include-personal', action='store_true')
+    s2 = sub.add_parser('list-dashboards')
+    s2.add_argument('--list', required=True)
+    s2.add_argument('--collections', required=True)
+    s2.add_argument('--out', required=True)
+    s2.add_argument('--include-personal', action='store_true')
+    s2.add_argument('--max', type=int, default=None)
+    s3 = sub.add_parser('collect-dashboards')
+    s3.add_argument('--collections', required=True)
+    s3.add_argument('--out', required=True)
+    s4 = sub.add_parser('collect-cards')
+    s4.add_argument('--collections', required=True)
+    s4.add_argument('--out', required=True)
+    s4.add_argument('--include-personal', action='store_true')
+    args = ap.parse_args()
+    {'split-cards': split_cards, 'list-dashboards': list_dashboards,
+     'collect-dashboards': collect_dashboards, 'collect-cards': collect_cards}[args.cmd](args)
+
+
+if __name__ == '__main__':
+    main()

--- a/metabase-migration-skills/metabase-assessment/scripts/pmbql-normalize.mjs
+++ b/metabase-migration-skills/metabase-assessment/scripts/pmbql-normalize.mjs
@@ -1,0 +1,228 @@
+/**
+ * pMBQL ("lib/" MBQL, Metabase Lib) → legacy MBQL normalizer.
+ *
+ * Modern Metabase instances (observed: Metabase Cloud v1.61.x; 100% of a
+ * 7k-card production estate) return `dataset_query` in pMBQL form:
+ *
+ *   { "lib/type": "mbql/query", "database": N, "stages": [ ... ] }
+ *
+ * instead of the legacy `{ "type": "native"|"query", ... }` the converter and
+ * scorer were built against. A single card-list response may contain EITHER
+ * format depending on instance version — sniff the `lib/type` key, never the
+ * version string.
+ *
+ * Shape differences handled here (all verified against production payloads):
+ *   query    {lib/type:"mbql/query", stages:[…]}     → {type, database, native|query}
+ *   stage    mbql.stage/native {native:"sql", template-tags} → {native:{query, template-tags}}
+ *   stage    mbql.stage/mbql   {aggregation, breakout, filters, joins, …}
+ *   clause   [op, {opts}, …args]                     → [op, …args] (opts map is ALWAYS
+ *            the 2nd element in pMBQL; legacy puts it last, or 3rd for "field")
+ *   field    ["field", {opts}, idOrName]             → ["field", idOrName, opts|null]
+ *   filters  array (implicit AND)                    → single `filter` (["and", …])
+ *   in/not-in                                        → multi-value "="/"!=" (the
+ *            converter renders those as Or/And chains — Sigma has no IsIn)
+ *   named aggregation (name/display-name in opts)    → ["aggregation-options", inner, {…}]
+ *   expressions list (lib/expression-name in opts)   → {name: clause} map
+ *   source-card N                                    → source-table "card__N"
+ *   joins {stages:[{source-table}], conditions:[…]}  → {source-table, condition, …}
+ *   multi-stage (rare but real: 14 of 7,023 cards)   → legacy source-query nesting
+ *   template-tags dimension clauses                  → legacy field refs
+ *
+ * `normalizeCard` prefers the server-provided `legacy_query` JSON string when
+ * present and parseable (the instance's own down-conversion — authoritative),
+ * falling back to this normalizer. Zero dependencies; usable from Node ≥18.
+ *
+ * NOTE: this file exists in two locations (converter + assessment scripts) so
+ * each skill stays self-contained. The converter test suite asserts the two
+ * copies are byte-identical — edit one, copy to the other.
+ */
+
+const isOptsMap = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
+
+/** A pMBQL clause is [op:string, optsMap, ...args] — opts ALWAYS second. */
+const isPmbqlClause = (n) => Array.isArray(n) && typeof n[0] === 'string' && isOptsMap(n[1]);
+
+function cleanOpts(opts) {
+  const out = {};
+  for (const [k, v] of Object.entries(opts || {})) {
+    if (k.startsWith('lib/') || k === 'effective-type' || k === 'ident') continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+const STRING_MATCH_OPS = new Set(['starts-with', 'ends-with', 'contains', 'does-not-contain']);
+
+/** Recursively normalize a pMBQL clause tree into legacy MBQL. */
+export function normalizeClause(node) {
+  if (!Array.isArray(node)) return node;
+  if (!isPmbqlClause(node)) return node.map(normalizeClause); // e.g. case clause-pair lists
+  const op = node[0];
+  const opts = cleanOpts(node[1]);
+  const args = node.slice(2);
+  const hasOpts = Object.keys(opts).length > 0;
+
+  switch (op) {
+    case 'field':
+      // ["field", {opts}, idOrName] → ["field", idOrName, opts|null]
+      return ['field', args[0], hasOpts ? opts : null];
+    case 'expression':
+      return hasOpts ? ['expression', args[0], opts] : ['expression', args[0]];
+    case 'aggregation':
+      return ['aggregation', args[0]];
+    case 'template-tag':
+      return ['template-tag', args[0]];
+    case 'value':
+      return normalizeClause(args[0]); // literal wrapper — unwrap
+    case 'absolute-datetime':
+      return normalizeClause(args[0]); // legacy filters carry the bare ISO string
+    case 'case':
+    case 'if': {
+      // ["case", {opts}, [[pred, expr], …], default?] → ["case", [[…]], {default}?]
+      const pairs = (args[0] || []).map((p) =>
+        Array.isArray(p) ? [normalizeClause(p[0]), normalizeClause(p[1])] : p);
+      const out = ['case', pairs];
+      if (args.length > 1 && args[1] !== undefined) out.push({ default: normalizeClause(args[1]) });
+      return out;
+    }
+    case 'in':
+      return ['=', ...args.map(normalizeClause)];
+    case 'not-in':
+      return ['!=', ...args.map(normalizeClause)];
+    case 'time-interval':
+    case 'relative-time-interval': {
+      // ["time-interval", {opts}, field, n, unit] → ["time-interval", field, n, unit, opts?]
+      const rest = args.map(normalizeClause);
+      return hasOpts ? ['time-interval', ...rest, opts] : ['time-interval', ...rest];
+    }
+    case 'segment':
+    case 'metric':
+      return [op, args[0]];
+    default: {
+      const rest = args.map(normalizeClause);
+      // string-match ops carry case-sensitive in opts — legacy puts it last
+      if (STRING_MATCH_OPS.has(op) && hasOpts) return [op, ...rest, opts];
+      return [op, ...rest];
+    }
+  }
+}
+
+/** Aggregation clause — pMBQL names live in opts → legacy aggregation-options wrapper. */
+function normalizeAggregation(a) {
+  if (!isPmbqlClause(a)) return normalizeClause(a);
+  const o = a[1];
+  const norm = normalizeClause(a);
+  const nm = o['display-name'] || o.name;
+  if (!nm) return norm;
+  const wrap = {};
+  if (o.name) wrap.name = o.name;
+  if (o['display-name']) wrap['display-name'] = o['display-name'];
+  return ['aggregation-options', norm, wrap];
+}
+
+function normalizeJoin(j) {
+  const out = {};
+  const st0 = (j.stages && j.stages[0]) || {};
+  if (st0['source-card'] != null) out['source-table'] = `card__${st0['source-card']}`;
+  else if (st0['source-table'] != null) out['source-table'] = st0['source-table'];
+  else if (j['source-table'] != null) out['source-table'] = j['source-table'];
+  if (j.alias != null) out.alias = j.alias;
+  if (j.strategy != null) out.strategy = j.strategy;
+  if (Array.isArray(j.conditions)) {
+    const cs = j.conditions.map(normalizeClause);
+    out.condition = cs.length === 1 ? cs[0] : ['and', ...cs];
+  } else if (j.condition) {
+    out.condition = normalizeClause(j.condition);
+  }
+  if (j.fields != null) out.fields = Array.isArray(j.fields) ? j.fields.map(normalizeClause) : j.fields;
+  return out;
+}
+
+function normalizeTemplateTags(tags) {
+  if (!tags) return tags;
+  const out = {};
+  for (const [k, t] of Object.entries(tags)) {
+    out[k] = t && t.dimension ? { ...t, dimension: normalizeClause(t.dimension) } : t;
+  }
+  return out;
+}
+
+/** One pMBQL stage → legacy query object (native stages return {__native}). */
+function normalizeStage(stage, prev) {
+  if (stage['lib/type'] === 'mbql.stage/native') {
+    const native = { query: stage.native ?? stage.query ?? '' };
+    if (stage['template-tags']) native['template-tags'] = normalizeTemplateTags(stage['template-tags']);
+    if (stage.collection) native.collection = stage.collection; // MongoDB
+    return { __native: native };
+  }
+  const q = {};
+  if (prev) {
+    q['source-query'] = prev.__native
+      ? { native: prev.__native.query, 'template-tags': prev.__native['template-tags'] || {} }
+      : prev;
+  } else if (stage['source-card'] != null) {
+    q['source-table'] = `card__${stage['source-card']}`;
+  } else if (stage['source-table'] != null) {
+    q['source-table'] = stage['source-table'];
+  }
+  if (Array.isArray(stage.joins)) q.joins = stage.joins.map(normalizeJoin);
+  if (Array.isArray(stage.expressions)) {
+    q.expressions = {};
+    for (const e of stage.expressions) {
+      const nm = (isPmbqlClause(e) && e[1]['lib/expression-name']) || `expr_${Object.keys(q.expressions).length}`;
+      q.expressions[nm] = normalizeClause(e);
+    }
+  }
+  if (Array.isArray(stage.aggregation)) q.aggregation = stage.aggregation.map(normalizeAggregation);
+  if (Array.isArray(stage.breakout)) q.breakout = stage.breakout.map(normalizeClause);
+  if (Array.isArray(stage.filters) && stage.filters.length) {
+    const fs = stage.filters.map(normalizeClause);
+    q.filter = fs.length === 1 ? fs[0] : ['and', ...fs];
+  } else if (stage.filter) {
+    q.filter = normalizeClause(stage.filter);
+  }
+  if (Array.isArray(stage['order-by'])) {
+    q['order-by'] = stage['order-by'].map((o) =>
+      Array.isArray(o) && isOptsMap(o[1]) ? [o[0], normalizeClause(o[2])] : normalizeClause(o));
+  }
+  if (stage.limit != null) q.limit = stage.limit;
+  if (Array.isArray(stage.fields)) q.fields = stage.fields.map(normalizeClause);
+  return q;
+}
+
+export function isPmbqlQuery(dq) {
+  return !!dq && typeof dq === 'object' && dq['lib/type'] === 'mbql/query';
+}
+
+/**
+ * pMBQL dataset_query → legacy dataset_query. Legacy input passes through
+ * untouched (format-sniffing: a list endpoint may return either).
+ */
+export function normalizeDatasetQuery(dq) {
+  if (!isPmbqlQuery(dq)) return dq;
+  const stages = Array.isArray(dq.stages) ? dq.stages : [];
+  let acc = null;
+  for (const s of stages) acc = normalizeStage(s, acc);
+  if (acc && acc.__native) return { type: 'native', database: dq.database, native: acc.__native };
+  return { type: 'query', database: dq.database, query: acc || {} };
+}
+
+/**
+ * Normalize a full card object (non-mutating). Prefers the server-provided
+ * `legacy_query` (a JSON string — the instance's own down-conversion, present
+ * on ~70% of cards observed) and falls back to normalizeDatasetQuery.
+ */
+export function normalizeCard(card) {
+  if (!card || typeof card !== 'object') return card;
+  if (!isPmbqlQuery(card.dataset_query)) return card;
+  if (typeof card.legacy_query === 'string' && card.legacy_query.trim().startsWith('{')) {
+    try {
+      const lq = JSON.parse(card.legacy_query);
+      if (lq && (lq.type === 'native' || lq.type === 'query')) return { ...card, dataset_query: lq };
+    } catch { /* fall through to the normalizer */ }
+  }
+  if (isOptsMap(card.legacy_query) && (card.legacy_query.type === 'native' || card.legacy_query.type === 'query')) {
+    return { ...card, dataset_query: card.legacy_query };
+  }
+  return { ...card, dataset_query: normalizeDatasetQuery(card.dataset_query) };
+}

--- a/metabase-migration-skills/metabase-assessment/scripts/render-report.mjs
+++ b/metabase-migration-skills/metabase-assessment/scripts/render-report.mjs
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * render-report.mjs — branded standalone HTML readout for the metabase-assessment skill.
+ *
+ *   node render-report.mjs --out <dir>            # reads <dir>/coverage.json (+ inventory.json if present)
+ *   node render-report.mjs --coverage <f> --out <f.html>
+ *
+ * Sigma-branded, print-friendly, ~6 sections, all-free framing. Zero deps.
+ * CSS/palette lifted from the tableau-assessment render-readout-html.rb.
+ */
+import { readFileSync, existsSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const args = process.argv.slice(2);
+let outDir = null, coveragePath = null, outFile = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--out') outDir = args[++i];
+  else if (args[i] === '--coverage') coveragePath = args[++i];
+}
+if (outDir && !coveragePath) coveragePath = join(outDir, 'coverage.json');
+if (outDir && outDir.endsWith('.html')) { outFile = outDir; outDir = null; }
+if (!coveragePath || !existsSync(coveragePath)) {
+  console.error('coverage.json not found — pass --out <dir> (containing coverage.json) or --coverage <file>');
+  process.exit(1);
+}
+if (!outFile) outFile = outDir ? join(outDir, 'readout.html') : 'readout.html';
+
+const cov = JSON.parse(readFileSync(coveragePath, 'utf8'));
+const invPath = outDir ? join(outDir, 'inventory.json') : null;
+const inv = invPath && existsSync(invPath) ? JSON.parse(readFileSync(invPath, 'utf8')) : null;
+
+const R = cov.rollup;
+const arts = cov.artifacts;
+const usage = !!R.usage_available;
+
+const h = (s) => String(s ?? '').replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+const num = (n) => Number(n || 0).toLocaleString('en-US');
+const fmtDate = (() => { try { return new Date(R.generated_at + 'T00:00:00').toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }); } catch { return R.generated_at; } })();
+
+const TAG_META = {
+  'migrate-first': ['tag-go', 'Migrate first'],
+  'easy-win': ['tag-blue', 'Easy win'],
+  'moderate': ['tag-gray', 'Standard'],
+  'needs-review': ['tag-warn', 'Needs review'],
+};
+const tagPill = (t) => { const [c, l] = TAG_META[t] || ['tag-gray', t]; return `<span class="tag ${c}">${h(l)}</span>`; };
+const bar = (v, max, color = 'bar-blue') => {
+  const pct = max ? Math.round((v / max) * 100) : 0;
+  return `<div class="bar-cell"><div class="bar-track"><div class="bar-fill ${color}" style="width:${pct}%"></div></div><div class="bar-num">${num(v)}</div></div>`;
+};
+
+// ---- waves (models sequenced before the questions/dashboards that use them) ----
+const TYPE_ORDER = { model: 0, card: 1, metric: 1, dashboard: 2 };
+const waveSort = (a, b) => (TYPE_ORDER[a.type] ?? 1) - (TYPE_ORDER[b.type] ?? 1) || b.score - a.score;
+const wave1 = arts.filter((a) => a.tag === 'migrate-first' || a.tag === 'easy-win').sort(waveSort);
+const wave2 = arts.filter((a) => a.tag === 'moderate').sort(waveSort);
+const wave3 = arts.filter((a) => a.tag === 'needs-review').sort(waveSort);
+
+// ---- hero finding ----
+const nReview = wave3.length;
+const heroFinding =
+  R.pct_auto_migratable >= 85
+    ? `Migration is largely automatic: ${R.pct_auto_migratable}% of detected features convert with the Metabase→Sigma tooling. ${nReview} of ${R.n_artifacts} artifact${nReview === 1 ? '' : 's'} contain a feature that warrants individual review.`
+    : `${R.pct_auto_migratable}% of detected features convert automatically. ${nReview} artifact${nReview === 1 ? '' : 's'} need individual review before conversion.`;
+
+// ---- KPI tiles ----
+const env = inv?.environment;
+const kpis = [
+  ['Artifacts', R.n_artifacts, env?.version ? `Metabase ${env.version}` : 'scored'],
+  ['Models', R.n_models, 'semantic layer'],
+  ['Questions', R.n_cards, 'MBQL + native SQL'],
+  ['Dashboards', R.n_dashboards, 'grids, tabs, filters'],
+  ['Auto-migratable', R.pct_auto_migratable + '%', 'of detected features'],
+  ['Needs review', nReview, 'human decision first'],
+].map(([l, v, s]) => `<div class="kpi"><div class="kpi-v">${h(v)}</div><div class="kpi-l">${h(l)}</div><div class="kpi-sub">${h(s)}</div></div>`).join('');
+
+// ---- inventory table ----
+const maxFeat = Math.max(1, ...arts.map((a) => a.n_features));
+const typeClass = (t) => t === 'model' ? 'ds-published' : t === 'dashboard' ? 'ds-dash' : 'ds-embedded';
+const invRows = arts.map((a) => `<tr>
+  <td>${h(a.name)}</td>
+  <td><span class="ds-bucket ${typeClass(a.type)}">${h(a.type)}</span></td>
+  <td>${bar(a.n_features, maxFeat)}</td>
+  ${usage ? `<td class="al-right num">${a.view_count != null ? num(a.view_count) : '<span class="muted">—</span>'}</td>` : ''}
+  <td><span class="risk-chip ${a.complexity === 'high' ? 'risk-red' : a.complexity === 'medium' ? 'risk-amber' : 'risk-clean'}"><span class="risk-dot"></span>${h(a.complexity)}</span></td>
+  <td>${tagPill(a.tag)}</td>
+</tr>`).join('');
+
+// ---- coverage breakdown ----
+const cb = R.totals;
+const coverageBars = [
+  ['Auto-convert', cb.n_auto, 'bar-blue', 'translated cleanly by the converter'],
+  ['Review, no rebuild', cb.n_hint, 'bar-blue', 'nested cards, field-filter tags, joins — sequencing/fan-out check'],
+  ['Manual setup', cb.n_manual, 'bar-blue', 'brief re-creation in Sigma (binning, segments/metrics, click behavior, snippets)'],
+  ['Needs review', cb.n_unhandled, 'bar-blue', 'no clean analog — human decision'],
+];
+const maxCov = Math.max(1, ...coverageBars.map((b) => b[1]));
+const coverageRows = coverageBars.map(([l, v, c, why]) => `<tr><td>${h(l)}</td><td>${bar(v, maxCov, c)}</td><td class="muted">${h(why)}</td></tr>`).join('');
+
+// ---- gap analysis ----
+const gapRows = R.gap_histogram.map((g) => {
+  const arr = [...new Set(g.artifacts)];
+  const named = arr.slice(0, 6).map((n) => `<code>${h(n)}</code>`).join(' ') + (arr.length > 6 ? ` +${arr.length - 6} more` : '');
+  return `<tr>
+    <td><span class="risk-chip ${g.bucket === 'unhandled' ? 'risk-red' : 'risk-amber'}"><span class="risk-dot"></span>${h(g.signal)}</span></td>
+    <td class="al-right num">${g.count}</td>
+    <td>${named}</td>
+    <td class="muted">${h(g.remediation)}</td>
+  </tr>`;
+}).join('');
+
+// ---- wave plan ----
+const waveBlock = (n, title, desc, members, cls) => {
+  if (!members.length) return '';
+  const list = members.slice(0, 20).map((a) => `<div class="cluster-member"><strong>${h(a.name)}</strong> <span class="muted">· ${h(a.type)} · ${h(a.complexity)}</span></div>`).join('');
+  return `<div class="stat ${cls}" style="grid-column: span 1;">
+    <div class="stat-l">Wave ${n} — ${h(title)}</div>
+    <div class="stat-v" style="font-size:24px;">${members.length}<span style="font-size:13px;color:var(--mute);font-weight:600;"> artifacts</span></div>
+    <div class="stat-sub" style="margin-bottom:10px;">${h(desc)}</div>
+    ${list}${members.length > 20 ? `<div class="muted" style="font-size:11px;margin-top:6px;">+${members.length - 20} more</div>` : ''}
+  </div>`;
+};
+
+const CSS = `
+  @import url('https://fonts.googleapis.com/css2?family=DM+Sans:opsz,wght@9..40,400;9..40,500;9..40,600;9..40,700&family=DM+Mono:wght@400;500&display=swap');
+  :root {
+    --bg:#fafafa; --card:#ffffff; --ink:#292929; --ink-2:#3d3d3d;
+    --line:#e5e5e5; --line-soft:#f5f5f5;
+    --accent:#292929; --accent-soft:#f0f0f0;
+    --go:#1f9d57; --go-soft:#e6fbef;
+    --warn:#c2562a; --warn-soft:#fff1ea;
+    --blue:#2b8ca6; --blue-soft:#eaf8fc;
+    --mute:#6e7877; --mute-soft:#f0f0f0;
+  }
+  * { box-sizing: border-box; }
+  html, body { margin:0; padding:0; background:var(--bg); color:var(--ink); }
+  body { font-family:"DM Sans",ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif; font-size:14px; line-height:1.55; -webkit-font-smoothing:antialiased; }
+  main { max-width:1120px; margin:0 auto; padding:48px 48px 80px; }
+  .brand-bar { display:flex; align-items:center; gap:10px; margin-bottom:28px; }
+  .brand-mark { font-weight:700; font-size:21px; letter-spacing:-0.02em; color:var(--ink); }
+  .brand-dot { width:9px; height:9px; border-radius:2px; background:var(--blue); -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .brand-tag { font-size:12px; color:var(--mute); font-weight:500; text-transform:uppercase; letter-spacing:0.08em; }
+  .doc-header { margin-bottom:40px; }
+  .doc-eyebrow { font-size:11px; font-weight:600; color:var(--accent); text-transform:uppercase; letter-spacing:0.08em; margin-bottom:8px; }
+  .doc-title { font-size:36px; font-weight:700; letter-spacing:-0.02em; margin:0 0 8px; line-height:1.1; }
+  .doc-meta { font-size:13px; color:var(--ink-2); }
+  .hero { background:var(--accent-soft); border:1px solid var(--line); border-left:4px solid var(--blue); border-radius:8px; padding:18px 22px; margin-bottom:40px; display:flex; align-items:center; gap:16px; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .hero-label { font-size:11px; font-weight:700; color:var(--accent); text-transform:uppercase; letter-spacing:0.08em; white-space:nowrap; padding-right:16px; border-right:1px solid var(--line); }
+  .hero-text { font-size:15px; color:var(--ink); font-weight:500; line-height:1.4; }
+  section { margin-bottom:56px; }
+  .section-head { display:flex; align-items:baseline; justify-content:space-between; margin-bottom:16px; padding-bottom:12px; border-bottom:1px solid var(--line); }
+  .section-num { font-size:12px; font-weight:600; color:var(--mute); letter-spacing:0.06em; }
+  .section-title { font-size:22px; font-weight:600; letter-spacing:-0.01em; margin:0; flex:1; padding-left:14px; }
+  .section-aside { font-size:12px; color:var(--mute); }
+  .section-lede { font-size:14px; color:var(--ink-2); margin:-4px 0 16px; }
+  .kpi-grid { display:grid; grid-template-columns:repeat(6,1fr); gap:12px; }
+  .kpi { background:var(--card); border:1px solid var(--line); border-radius:10px; padding:18px 16px; }
+  .kpi-v { font-size:28px; font-weight:700; letter-spacing:-0.01em; line-height:1; }
+  .kpi-l { font-size:11px; color:var(--mute); text-transform:uppercase; letter-spacing:0.06em; font-weight:600; margin-top:10px; }
+  .kpi-sub { font-size:11px; color:var(--mute); margin-top:4px; line-height:1.4; }
+  .stat-row { display:grid; grid-template-columns:repeat(3,1fr); gap:12px; margin-bottom:24px; align-items:start; }
+  .stat { background:#fafafa; border:1px solid var(--line); border-left:3px solid var(--accent); border-radius:8px; padding:16px 18px; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .stat.stat-go { border-left-color:var(--go); background:var(--go-soft); }
+  .stat.stat-warn { border-left-color:var(--warn); background:var(--warn-soft); }
+  .stat.stat-blue { border-left-color:var(--blue); background:var(--blue-soft); }
+  .stat-l { font-size:10px; color:var(--mute); text-transform:uppercase; letter-spacing:0.06em; font-weight:700; margin-bottom:6px; }
+  .stat-v { font-size:30px; font-weight:700; line-height:1; letter-spacing:-0.02em; }
+  .stat-v.go { color:var(--go); } .stat-v.warn { color:var(--warn); }
+  .stat-sub { font-size:12px; color:var(--mute); margin-top:6px; }
+  table.data { width:100%; border-collapse:collapse; background:var(--card); border:1px solid var(--line); border-radius:10px; overflow:hidden; font-size:13px; }
+  table.data th { font-weight:600; font-size:11px; color:var(--mute); text-transform:uppercase; letter-spacing:0.06em; padding:12px 16px; background:#fafafa; border-bottom:1px solid var(--line); text-align:left; }
+  table.data td { padding:12px 16px; border-bottom:1px solid var(--line-soft); vertical-align:middle; }
+  table.data tbody tr:last-child td { border-bottom:0; }
+  table.data tbody tr:hover td { background:#fafafa; }
+  .al-right { text-align:right; }
+  table.data td.al-right, table.data th.al-right, table.data td:has(.bar-cell) { width:1%; white-space:nowrap; }
+  .num { font-variant-numeric:tabular-nums; } .muted { color:var(--mute); }
+  .tag { display:inline-block; padding:3px 10px; border-radius:99px; font-size:11px; font-weight:600; white-space:nowrap; }
+  .tag-go { background:var(--go-soft); color:var(--go); }
+  .tag-blue { background:var(--blue-soft); color:var(--blue); }
+  .tag-gray { background:#f5f5f5; color:var(--ink-2); }
+  .tag-warn { background:var(--warn-soft); color:var(--warn); }
+  .bar-cell { display:flex; align-items:center; gap:10px; }
+  .bar-track { flex:none; width:84px; height:6px; background:#f5f5f5; border-radius:4px; overflow:hidden; }
+  .bar-fill { height:100%; border-radius:4px; }
+  .bar-blue { background:linear-gradient(90deg,#4cec8c,#2fb874); }
+  .bar-num { font-variant-numeric:tabular-nums; font-weight:600; min-width:36px; text-align:right; }
+  .ds-bucket { display:inline-block; padding:3px 10px; border-radius:6px; font-size:11px; font-weight:600; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .ds-published { background:var(--blue-soft); color:var(--blue); }
+  .ds-embedded { background:#f5f5f5; color:var(--ink-2); }
+  .ds-dash { background:var(--go-soft); color:var(--go); }
+  .risk-chip { display:inline-flex; align-items:center; gap:6px; font-size:12px; font-variant-numeric:tabular-nums; }
+  .risk-dot { width:8px; height:8px; border-radius:50%; -webkit-print-color-adjust:exact; print-color-adjust:exact; }
+  .risk-clean .risk-dot { background:var(--go); } .risk-clean { color:var(--go); font-weight:600; }
+  .risk-amber .risk-dot { background:#f59e0b; } .risk-amber { color:#a16207; font-weight:600; }
+  .risk-red .risk-dot { background:var(--warn); } .risk-red { color:var(--warn); font-weight:700; }
+  .cluster-member { padding:2px 0; font-size:12px; line-height:1.4; }
+  .cluster-member + .cluster-member { border-top:1px dashed var(--line-soft); }
+  .note { font-size:12px; color:var(--mute); font-style:italic; margin:12px 0 0; }
+  .callout { background:var(--warn-soft); border-left:3px solid var(--warn); padding:12px 16px; border-radius:6px; margin-top:16px; font-size:13px; color:#7c2d12; }
+  code { font-family:"DM Mono",ui-monospace,"SF Mono",Menlo,monospace; font-size:12.5px; background:var(--line-soft); padding:1px 6px; border-radius:4px; }
+  ol.next-steps { margin:0; padding-left:0; counter-reset:step; list-style:none; }
+  ol.next-steps li { counter-increment:step; padding:14px 0 14px 44px; position:relative; border-bottom:1px solid var(--line-soft); font-size:14px; }
+  ol.next-steps li:last-child { border-bottom:0; }
+  ol.next-steps li::before { content:counter(step); position:absolute; left:0; top:14px; width:28px; height:28px; border-radius:50%; background:var(--accent-soft); color:var(--accent); display:flex; align-items:center; justify-content:center; font-size:13px; font-weight:700; }
+  footer { color:var(--mute); font-size:11px; text-align:center; margin-top:56px; padding-top:20px; border-top:1px solid var(--line); }
+  @media print {
+    @page { margin:0.6in 0.5in; size:letter portrait; }
+    body { background:white; font-size:11.5px; } main { max-width:none; padding:0; }
+    .doc-title { font-size:26px; } section { margin-bottom:24px; }
+    .kpi-v { font-size:22px; } table.data { font-size:11px; } table.data thead { display:table-header-group; }
+    .hero,.kpi,.stat,table.data,table.data th,.ds-bucket,.tag,.bar-track,.bar-fill,.risk-dot,.callout,ol.next-steps li::before { -webkit-print-color-adjust:exact !important; print-color-adjust:exact !important; }
+    table.data tr { page-break-inside:avoid; } .section-head { page-break-after:avoid; }
+  }
+`;
+
+const usageStep = usage
+  ? `<li><strong>Confirm the usage ranking with the admin.</strong> This instance exposes <code>view_count</code> (v50+), so the shortlist is already ranked by real views. For richer signal — views over time, per-user reach — ask the admin for the Pro/EE <em>Usage analytics</em> collection export and merge it in before retiring anything.</li>`
+  : `<li><strong>Request usage telemetry from your Metabase admin.</strong> This instance does not expose <code>view_count</code> on cards/dashboards (pre-v50), so the shortlist is ranked by conversion effort, not popularity. Ask for the Pro/EE <em>Usage analytics</em> export (or upgrade and re-run) to confirm which artifacts are actually used — and which to retire.</li>`;
+
+const html = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<title>Metabase Migration Assessment</title>
+<style>${CSS}</style></head>
+<body><main>
+
+<div class="brand-bar"><span class="brand-dot"></span><span class="brand-mark">sigma</span><span class="brand-tag">Migration Assessment</span></div>
+<div class="doc-header">
+  <div class="doc-eyebrow">Metabase → Sigma — Estate Readout</div>
+  <h1 class="doc-title">Metabase Migration Assessment</h1>
+  <div class="doc-meta">${env ? h(env.base) + ' · ' : ''}Generated ${h(fmtDate)} · ${R.n_artifacts} artifacts scored</div>
+</div>
+
+<div class="hero"><div class="hero-label">Headline finding</div><div class="hero-text">${h(heroFinding)}</div></div>
+
+<section>
+  <div class="section-head"><span class="section-num">01</span><h2 class="section-title">Executive summary</h2></div>
+  <p class="section-lede">A read-only scan of the Metabase instance, scored against the exact coverage of the Metabase→Sigma converter. Every model, question, and dashboard below was classified by walking its MBQL/native definition and detecting the specific features the converter translates cleanly versus the ones it flags for a human. This is a fast, no-cost pre-scoping pass — like the equivalent Tableau assessment — to size the migration and pick a pilot.</p>
+  <div class="kpi-grid">${kpis}</div>
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">02</span><h2 class="section-title">Estate inventory</h2><span class="section-aside">${R.n_models} models · ${R.n_cards} questions · ${R.n_dashboards} dashboards</span></div>
+  <p class="section-lede">Every scored artifact with its detected feature count${usage ? ', views' : ''}, conversion complexity, and recommendation. Complexity is <strong>low</strong> (converts cleanly), <strong>medium</strong> (brief manual setup), or <strong>high</strong> (contains a feature with no clean Sigma analog).</p>
+  <table class="data"><thead><tr><th>Artifact</th><th>Type</th><th>Features</th>${usage ? '<th class="al-right">Views</th>' : ''}<th>Complexity</th><th>Recommendation</th></tr></thead><tbody>${invRows}</tbody></table>
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">03</span><h2 class="section-title">Coverage &amp; auto-migration</h2><span class="section-aside">${R.pct_auto_migratable}% auto-migratable</span></div>
+  <p class="section-lede">Of the ${num(R.totals.n_features)} features detected across the estate, this is how the converter handles them. "Auto-migratable" combines clean auto-conversion with review-only items (nested-card sequencing, field-filter control wiring, join fan-out checks) — work that doesn't require rebuilding logic.</p>
+  <div class="stat-row">
+    <div class="stat stat-go"><div class="stat-l">Auto-migratable</div><div class="stat-v go">${R.pct_auto_migratable}%</div><div class="stat-sub">${num(cb.n_auto + cb.n_hint)} of ${num(R.totals.n_features)} features</div></div>
+    <div class="stat ${cb.n_manual ? 'stat-blue' : ''}"><div class="stat-l">Manual setup features</div><div class="stat-v">${num(cb.n_manual)}</div><div class="stat-sub">binning, segments/metrics, click behavior, snippets</div></div>
+    <div class="stat ${cb.n_unhandled ? 'stat-warn' : ''}"><div class="stat-l">Needs-review features</div><div class="stat-v ${cb.n_unhandled ? 'warn' : ''}">${num(cb.n_unhandled)}</div><div class="stat-sub">cumulative/offset calcs, funnel/gauge/progress/waterfall</div></div>
+  </div>
+  <table class="data"><thead><tr><th>Bucket</th><th>Features</th><th>What it means</th></tr></thead><tbody>${coverageRows}</tbody></table>
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">04</span><h2 class="section-title">Gap analysis</h2><span class="section-aside">${R.gap_histogram.length} distinct gap type${R.gap_histogram.length === 1 ? '' : 's'}</span></div>
+  <p class="section-lede">Every feature that needs a human — named to the artifact, with the specific reason and the remediation. Amber = brief manual setup in Sigma; red = no clean analog, needs a decision before conversion. Identifying these up front means no surprises mid-migration.</p>
+  ${R.gap_histogram.length ? `<table class="data"><thead><tr><th>Gap</th><th class="al-right">Count</th><th>Artifacts</th><th>Remediation</th></tr></thead><tbody>${gapRows}</tbody></table>` : '<p class="note">No manual or needs-review gaps detected — the entire estate converts cleanly.</p>'}
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">05</span><h2 class="section-title">Effort &amp; wave plan</h2><span class="section-aside">3 waves · models before dependent dashboards</span></div>
+  <p class="section-lede">A risk-minimizing migration sequence. Wave 1 is the low-risk pilot; Wave 3 holds anything with a needs-review feature, each requiring a human decision first. Within every wave, convert models ahead of the questions and dashboards that source them (dashcards and <code>card__N</code> refs point at the migrated model's element).</p>
+  <div class="stat-row">
+    ${waveBlock(1, 'pilot', 'migrate-first / easy-win — no needs-review features; models first, then their dashboards', wave1, 'stat-go')}
+    ${waveBlock(2, 'standard', 'medium complexity — convert with light review', wave2, 'stat-blue')}
+    ${waveBlock(3, 'review-first', 'contains a cumulative/offset calc, unsupported viz, or sandboxing policy', wave3, 'stat-warn')}
+  </div>
+  ${cb.n_unhandled || R.n_sandboxes ? `<div class="callout"><strong>${nReview} artifact${nReview === 1 ? '' : 's'}</strong> include a feature with no clean Sigma analog (cumulative/offset window calcs, funnel/gauge/progress/waterfall viz${R.n_sandboxes ? `, plus ${R.n_sandboxes} EE sandboxing polic${R.n_sandboxes === 1 ? 'y' : 'ies'} at the instance level` : ''}). Plan a short design decision for each before converting — the converter emits a flagged placeholder rather than guessing.</div>` : ''}
+</section>
+
+<section>
+  <div class="section-head"><span class="section-num">06</span><h2 class="section-title">Recommended next steps</h2></div>
+  <ol class="next-steps">
+    <li><strong>Pilot Wave 1 (${wave1.length} artifact${wave1.length === 1 ? '' : 's'}).</strong> These convert with no needs-review features — the lowest-risk way to demonstrate an end-to-end Metabase→Sigma migration. Convert the models first, then the dashboards (and questions) that source them.</li>
+    ${cb.n_unhandled || R.n_sandboxes ? `<li><strong>Hold a design review for the needs-review items.</strong> Decide the Sigma equivalent for each cumulative/offset calc, funnel/gauge/progress/waterfall viz${R.n_sandboxes ? ', and sandboxing policy (these port to Sigma user attributes via the RLS engine — reviewed per policy)' : ''} up front (see the gap analysis above).</li>` : ''}
+    ${usageStep}
+    <li><strong>Request a durable API key from the admin</strong> (Admin → Settings → Authentication → API keys, in a group with view access) so the conversion phase doesn't depend on a 14-day session token${R.n_sandboxes ? ' — and, since this is a Pro/EE instance, the Usage analytics audit export' : ''}.</li>
+    <li><strong>Hand the pilot to the <code>metabase-to-sigma</code> converter.</strong> The per-artifact card/dashboard JSON and the per-database <code>metadata/*.metadata.json</code> (the field-id map the converter requires) are already cached from this scan — the converter can skip re-discovery and go straight to building the Sigma data model + workbook.</li>
+  </ol>
+</section>
+
+<footer>Read-only assessment · generated ${h(fmtDate)} · supporting <code>coverage.json</code>${inv ? ' + <code>inventory.json</code>' : ''} alongside in the same folder · all-free migration tooling</footer>
+
+</main></body></html>`;
+
+writeFileSync(outFile, html);
+console.log(`wrote ${outFile} (${html.length} bytes)`);

--- a/metabase-migration-skills/metabase-assessment/scripts/score-coverage.mjs
+++ b/metabase-migration-skills/metabase-assessment/scripts/score-coverage.mjs
@@ -1,0 +1,451 @@
+#!/usr/bin/env node
+/**
+ * score-coverage.mjs — converter-coverage scorer for the metabase-assessment skill.
+ *
+ * For every Metabase card JSON (*.card.json) and dashboard JSON
+ * (*.dashboard.json), classify features into auto / hint / manual / unhandled
+ * by detecting the EXACT gap signals the metabase-to-sigma converter
+ * (converter/metabase.ts, translateMbqlExpr) translates cleanly vs. flags.
+ * This does NOT re-run the converter — it detects the same patterns so the
+ * estate's auto-migration % matches what the tool will actually do.
+ *
+ * Zero external dependencies (Node built-ins only). MBQL arrives already
+ * parsed (nested JSON arrays like ["sum", ["field", 72, null]]), so the
+ * scorer simply recurses the dataset_query trees and matches op names against
+ * the converter's translated-vs-flagged tables — no regex DSL parsing at all.
+ *
+ *   node score-coverage.mjs --in <dir-of-specs> --out <dir>
+ *
+ * Reads --in for *.card.json + *.dashboard.json (recurses one level into
+ * specs/). If a sandboxes.json (EE GTAP export) sits next to the specs, its
+ * policies are surfaced as needs-review items. Writes <out>/coverage.json.
+ * Read-only.
+ */
+import { readFileSync, readdirSync, statSync, existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join, basename, dirname } from 'node:path';
+// pMBQL ("lib/" MBQL) → legacy — modern instances (Cloud v1.61+) return
+// dataset_query as {"lib/type":"mbql/query","stages":[…]} (100% of a 7k-card
+// production estate). Normalized at intake; a list may mix both formats.
+import { normalizeCard } from './pmbql-normalize.mjs';
+
+// ---- args ----
+const args = process.argv.slice(2);
+let inDir = null, outDir = null;
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === '--in') inDir = args[++i];
+  else if (args[i] === '--out') outDir = args[++i];
+}
+if (!inDir || !outDir) {
+  console.error('usage: score-coverage.mjs --in <specs-dir> --out <dir>');
+  process.exit(2);
+}
+if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+
+// ---- collect spec files (the dir itself, and a specs/ subdir if present) ----
+function collect(dir) {
+  const out = [];
+  const tryDir = (d) => {
+    if (!existsSync(d)) return;
+    for (const f of readdirSync(d)) {
+      const p = join(d, f);
+      let st;
+      try { st = statSync(p); } catch { continue; }
+      if (st.isFile() && (f.endsWith('.card.json') || f.endsWith('.dashboard.json'))) out.push(p);
+    }
+  };
+  tryDir(dir);
+  tryDir(join(dir, 'specs'));
+  return [...new Set(out)];
+}
+
+// ============================================================================
+// GAP SIGNAL DEFINITIONS — each maps to a converter behavior.
+// See refs/scoring-rubric.md (this skill) + refs/expression-dsl.md (converter).
+// ============================================================================
+
+// Aggregations translateMbqlExpr maps cleanly (Sum/Avg/CountIf/SumIf/share…).
+const AUTO_AGGS = new Set(['count', 'sum', 'avg', 'min', 'max', 'median', 'distinct',
+  'stddev', 'var', 'percentile', 'count-where', 'sum-where', 'share']);
+
+// Cumulative / window aggregations the converter flags loudly — the window
+// scope lives on the consuming Sigma element, so they're never faked.
+const UNHANDLED_AGGS = new Set(['cum-sum', 'cum-count', 'offset']);
+
+// Expression / filter ops in expression-dsl.md's translated table.
+const AUTO_OPS = new Set([
+  '+', '-', '*', '/', 'case', 'coalesce', 'concat', 'substring',
+  'trim', 'ltrim', 'rtrim', 'upper', 'lower', 'length', 'replace',
+  'regex-match-first', 'split-part',
+  'round', 'floor', 'ceil', 'abs', 'sqrt', 'exp', 'power', 'log',
+  'datetime-add', 'datetime-subtract', 'datetime-diff',
+  'get-year', 'get-quarter', 'get-month', 'get-week', 'get-day',
+  'get-day-of-week', 'get-hour', 'get-minute', 'get-second',
+  'now', 'relative-datetime',
+  'text', 'integer', 'float', 'date',          // casts → Text/Int/Number/DateTrunc
+  '=', '!=', 'in', 'not-in', '<', '<=', '>', '>=', 'between',
+  'is-null', 'not-null', 'is-empty', 'not-empty',
+  'starts-with', 'ends-with', 'contains', 'does-not-contain',
+  'time-interval', 'inside',
+]);
+
+// Structural tokens — handled elsewhere or free; never counted as features.
+const IGNORE_OPS = new Set(['field', 'expression', 'aggregation', 'value',
+  'aggregation-options', 'and', 'or', 'not', 'asc', 'desc', 'datetime', 'interval']);
+
+// Card displays the converter builds natively (chart/table/pivot/KPI/map).
+// Production histogram (7k-card estate): table 2999 · bar 1604 · line 1176 ·
+// combo 449 · scalar 259 · pie 135 · row 130 · area 67 · pivot 39 · scatter 3
+// all convert natively — see refs/scoring-rubric.md.
+const AUTO_DISPLAYS = new Set(['table', 'bar', 'row', 'line', 'area', 'combo',
+  'scatter', 'pie', 'scalar', 'smartscalar', 'trend', 'pivot', 'map']);
+// Displays with no Sigma analog — converter emits a flagged table, never fakes.
+// (production: funnel 83 · waterfall 15 · sankey 13 · gauge 11 · progress 3)
+const UNHANDLED_DISPLAYS = new Set(['funnel', 'gauge', 'progress', 'waterfall', 'sankey']);
+
+function makeAdd(state) {
+  return (signal, bucket, reason, remediation) => {
+    let g = state.gaps.find((x) => x.signal === signal);
+    if (!g) { g = { signal, bucket, count: 0, reason, remediation }; state.gaps.push(g); }
+    g.count++;
+    if (bucket === 'auto') state.nAuto++; else if (bucket === 'hint') state.nHint++;
+    else if (bucket === 'manual') state.nManual++; else state.nUnhandled++;
+  };
+}
+
+// ---- MBQL tree walker — classifies every op the way translateMbqlExpr would.
+function walkExpr(node, where, add) {
+  if (!Array.isArray(node)) return;
+  const op = typeof node[0] === 'string' ? node[0].toLowerCase() : null;
+  if (op === 'value') return; // literal wrapper — unwraps transparently
+  if (op === 'field') {
+    const opts = node[2];
+    if (opts && typeof opts === 'object' && opts.binning) {
+      add('binning breakout (numeric histogram)', 'manual', `"${where}" bins a numeric field (${JSON.stringify(opts.binning)})`,
+        'The converter passes binning through with a warning. Recreate the buckets with BinFixed()/BinCount() in the consuming Sigma workbook element.');
+    }
+    return;
+  }
+  if (op === 'segment') {
+    add('segment ref (["segment", id])', 'manual', `"${where}" references a saved segment — its definition lives in another object`,
+      'Inline the segment\'s own MBQL filter (GET /api/segment/{id}) into the Sigma element filter; the converter flags the ref instead of guessing.');
+    return;
+  }
+  if (op === 'metric') {
+    add('legacy metric ref (["metric", id])', 'manual', `"${where}" references a saved legacy metric`,
+      'Inline the metric\'s own MBQL aggregation (GET /api/legacy-metric/{id}) as a Sigma metric; the converter flags the ref instead of guessing.');
+    return;
+  }
+  if (op) {
+    if (UNHANDLED_AGGS.has(op)) {
+      add(`${op} (cumulative/offset window calc)`, 'unhandled', `"${where}" uses MBQL ${op}`,
+        'Running totals / lag need a window scope Sigma defines on the consuming element. Rebuild with CumulativeSum / Lag in the date-grouped workbook element (proven pattern); the converter emits a flagged placeholder.');
+    } else if (AUTO_AGGS.has(op)) {
+      add('translated aggregation', 'auto', `"${where}" uses ${op} — maps via translateMbqlExpr`, '—');
+    } else if (AUTO_OPS.has(op)) {
+      add('translated expression/filter op', 'auto', `"${where}" uses ${op} — maps via translateMbqlExpr`, '—');
+    } else if (op === 'aggregation-options') {
+      // wrapper supplies the metric's name — score the inner aggregation only
+      walkExpr(node[1], where, add);
+      return;
+    } else if (!IGNORE_OPS.has(op)) {
+      add(`unmapped MBQL op ${op}`, 'unhandled', `"${where}" uses ${op} — no confirmed Sigma mapping`,
+        'Review and translate by hand; the converter emits a /* unmapped */ placeholder + a loud warning — never silent, never guessed.');
+    }
+  }
+  for (const child of node.slice(op ? 1 : 0)) walkExpr(child, where, add);
+}
+
+// ---- MBQL query (structural pass + expression trees) ----
+function scoreMbqlQuery(q, where, add, deps) {
+  if (!q || typeof q !== 'object') return;
+  if (q['source-query']) {
+    // pMBQL stages>1 / legacy nested source-query — converter flags + skips
+    // (rare but real: 14 of 7,023 on the reference production estate)
+    add('multi-stage query (nested source-query)', 'manual', `"${where}" aggregates over an inner query stage`,
+      'Rebuild as a chain of Sigma elements (inner stage → element, outer stage → child element) or a custom-SQL element; the converter flags it, never mistranslates.');
+  }
+  const st = q['source-table'];
+  if (typeof st === 'string' && st.startsWith('card__')) {
+    const dep = Number(st.slice(6));
+    if (!Number.isNaN(dep)) deps.push(dep);
+    add('nested-card source (card__N)', 'hint', `"${where}" is built on saved card ${st.slice(6)}`,
+      'Converts to an element sourced from that card\'s element — sequence the source card (usually a model) first; the converter wires it when both are in the input set.');
+  } else if (st != null) {
+    add('table source', 'auto', 'maps to the model/DM element for the warehouse table', '—');
+  }
+  if (q['source-query']) scoreMbqlQuery(q['source-query'], `${where} (inner query)`, add, deps);
+
+  for (const j of q.joins || []) {
+    add('explicit MBQL join', 'hint', `"${where}" joins ${typeof j['source-table'] === 'string' ? j['source-table'] : 'table ' + j['source-table']} (${j.strategy || 'left-join'})`,
+      'Converts to a Sigma DM join source — review for fan-out (row multiplication) before trusting aggregates, exactly as you would in Metabase.');
+    if (typeof j['source-table'] === 'string' && j['source-table'].startsWith('card__')) {
+      const dep = Number(j['source-table'].slice(6));
+      if (!Number.isNaN(dep)) deps.push(dep);
+    }
+    walkExpr(j.condition, `${where} join condition`, add);
+  }
+  for (const [name, expr] of Object.entries(q.expressions || {})) {
+    walkExpr(expr, `${where} expression "${name}"`, add);
+  }
+  for (const agg of q.aggregation || []) walkExpr(agg, `${where} aggregation`, add);
+  for (const b of q.breakout || []) {
+    const opts = Array.isArray(b) && b[0] === 'field' ? b[2] : null;
+    if (opts && typeof opts === 'object' && opts.binning) {
+      walkExpr(b, `${where} breakout`, add); // emits the binning manual signal
+    } else {
+      add('breakout (group-by)', 'auto', 'maps to a Sigma grouping / chart axis', '—');
+    }
+  }
+  walkExpr(q.filter, `${where} filter`, add);
+  // order-by / limit / fields are free — the converter carries them silently.
+}
+
+function classifyDisplay(display, where, add) {
+  const d = String(display || 'table').toLowerCase();
+  if (AUTO_DISPLAYS.has(d)) {
+    add(`${d} display → Sigma element`, 'auto', `${d} maps to a native Sigma chart/table/pivot/KPI/map element`, '—');
+  } else if (d === 'object') {
+    add('object display (record detail view)', 'manual', `"${where}" is a single-record detail view`,
+      'The converter emits the data as a flagged table; recreate the detail experience with element filters / drill in Sigma.');
+  } else if (UNHANDLED_DISPLAYS.has(d)) {
+    add(`${d} display (no Sigma analog)`, 'unhandled', `"${where}" renders as a ${d} — no native Sigma element`,
+      'Data is preserved as a flagged table; re-pick the closest Sigma element (e.g. ordered bar for funnel, KPI for gauge/progress) in the workbook.');
+  } else {
+    add(`${d} display (no converter mapping)`, 'unhandled', `"${where}" uses display "${d}"`,
+      'Review and pick the closest Sigma element by hand; the converter emits a flagged table.');
+  }
+}
+
+function countClickBehaviors(vs) {
+  // click_behavior can sit at the top level or under column_settings.* — count keys anywhere.
+  let n = 0;
+  const walk = (o) => {
+    if (!o || typeof o !== 'object') return;
+    if (Array.isArray(o)) { for (const c of o) walk(c); return; }
+    for (const [k, v] of Object.entries(o)) {
+      if (k === 'click_behavior' && v) n++;
+      walk(v);
+    }
+  };
+  walk(vs);
+  return n;
+}
+
+// ---- card scorer (mirrors metabase.ts) ----
+function scoreCard(text, name) {
+  let card;
+  try { card = JSON.parse(text); } catch { return null; }
+  try { card = normalizeCard(card); } catch { /* score the raw card — never crash the walk */ }
+  const type = (card.type === 'model' || card.dataset === true) ? 'model'
+    : card.type === 'metric' ? 'metric' : 'card';
+  const state = { gaps: [], nAuto: 0, nHint: 0, nManual: 0, nUnhandled: 0 };
+  const add = makeAdd(state);
+  const deps = [];
+  const dispName = card.name || name;
+
+  const dq = card.dataset_query || {};
+  if (dq.type === 'native') {
+    add('native SQL card → DM sql element', 'auto', 'the SQL text becomes a Sigma Custom SQL element verbatim', '—');
+    const tags = (dq.native && dq.native['template-tags']) || {};
+    for (const [tname, tag] of Object.entries(tags)) {
+      const ttype = String(tag?.type || '').toLowerCase();
+      if (ttype === 'dimension') {
+        add('field-filter template tag (type: dimension)', 'hint', `tag {{${tname}}} expands to a whole WHERE clause at runtime`,
+          'Converts to a Sigma control on the target column + an element filter (not a plain =-parameter) — verify the widget type and default after conversion.');
+      } else if (ttype === 'card') {
+        add('nested-card template tag ({{#N}})', 'hint', `tag {{${tname}}} inlines another saved question as a sub-query`,
+          'Sequence the referenced card first; the converter wires it when both are in the input set.');
+      } else if (ttype === 'snippet') {
+        add('snippet template tag', 'manual', `tag {{${tname}}} splices a shared SQL snippet`,
+          'Inline the snippet text (GET /api/native-query-snippet) into the Sigma Custom SQL by hand; Sigma has no snippet library.');
+      } else {
+        add('plain template tag → control (text/number/date/boolean)', 'auto', `tag {{${tname}}} (${ttype || 'text'}) maps to a Sigma control — Sigma custom SQL uses the SAME {{control-id}} parameter syntax, so the statement converts near-verbatim`, '—');
+      }
+    }
+    if (/\[\[/.test(dq.native?.query || '')) {
+      add('optional [[…]] SQL block', 'hint', `"${dispName}" uses Metabase optional-clause syntax`,
+        'Sigma has no optional-clause syntax: blocks whose tags are field filters or have defaults stay active; others are dropped (matching Metabase\'s empty-value behavior) with a loud warning. Review each.');
+    }
+  } else {
+    scoreMbqlQuery(dq.query, dispName, add, deps);
+  }
+
+  classifyDisplay(card.display, dispName, add);
+
+  // table.column_formatting — single rules convert to Sigma conditionalFormats;
+  // gradient/range scales are flagged (spec shape not yet live-verified).
+  for (const r of card.visualization_settings?.['table.column_formatting'] || []) {
+    if (r?.type === 'single') {
+      add('conditional formatting (single rule) → conditionalFormats', 'auto',
+        `"${dispName}" has a threshold formatting rule — converts to a Sigma conditionalFormats entry`, '—');
+    } else {
+      add('conditional formatting (gradient/range scale)', 'manual',
+        `"${dispName}" has a "${r?.type}" formatting scale`,
+        'Recreate as a Sigma backgroundScale conditional format in the UI; the converter flags it.');
+    }
+  }
+
+  const clicks = countClickBehaviors(card.visualization_settings);
+  for (let i = 0; i < clicks; i++) {
+    add('click_behavior (cross-filter / link)', 'manual', `"${dispName}" defines a click behavior`,
+      'Re-implement as a Sigma action (cross-element filter / open-link); the converter flags it, never fakes it.');
+  }
+
+  return finalize({
+    type, name: dispName, gaps: state.gaps,
+    nAuto: state.nAuto, nHint: state.nHint, nManual: state.nManual, nUnhandled: state.nUnhandled,
+    viewCount: typeof card.view_count === 'number' ? card.view_count : null,
+    usesCards: [...new Set(deps)],
+  });
+}
+
+// ---- dashboard scorer ----
+function scoreDashboard(text, name) {
+  let d;
+  try { d = JSON.parse(text); } catch { return null; }
+  const state = { gaps: [], nAuto: 0, nHint: 0, nManual: 0, nUnhandled: 0 };
+  const add = makeAdd(state);
+  const deps = [];
+  const dispName = d.name || name;
+
+  // v48+ uses dashcards[].size_x; pre-v48 uses ordered_cards[].sizeX — accept both.
+  const dashcards = d.dashcards || d.ordered_cards || [];
+
+  for (const p of d.parameters || []) {
+    add('dashboard parameter → control', 'auto', `parameter "${p.name || p.slug}" maps to a Sigma control (+ per-card targets from parameter_mappings)`, '—');
+  }
+  for (const t of d.tabs || []) {
+    add('dashboard tab → workbook page', 'auto', `tab "${t.name}" maps to a Sigma workbook page`, '—');
+  }
+
+  for (const dc of dashcards) {
+    const vs = dc.visualization_settings || {};
+    if ((dc.card_id == null || dc.card_id === undefined) && vs.virtual_card) {
+      add('text/heading card → text element', 'auto', 'markdown passes through to a Sigma text element', '—');
+    } else {
+      if (dc.card_id != null) deps.push(dc.card_id);
+      const cardDisplay = dc.card?.display || vs?.virtual_card?.display;
+      classifyDisplay(cardDisplay, `${dispName} / card ${dc.card_id ?? '?'}`, add);
+    }
+    const clicks = countClickBehaviors(vs);
+    for (let i = 0; i < clicks; i++) {
+      add('click_behavior (cross-filter / link)', 'manual', `a dashcard on "${dispName}" defines a click behavior`,
+        'Re-implement as a Sigma action (cross-element filter / open-link); the converter flags it, never fakes it.');
+    }
+  }
+
+  return finalize({
+    type: 'dashboard', name: dispName, gaps: state.gaps,
+    nAuto: state.nAuto, nHint: state.nHint, nManual: state.nManual, nUnhandled: state.nUnhandled,
+    viewCount: typeof d.view_count === 'number' ? d.view_count : null,
+    usesCards: [...new Set(deps)],
+  });
+}
+
+function finalize(r) {
+  const nFeatures = r.nAuto + r.nHint + r.nManual + r.nUnhandled;
+  const cost = 10 * r.nUnhandled + 3 * r.nManual + 1 * r.nHint;
+  // value = 10·view_count when the instance exposes it (v50+), else 10·n_features.
+  const usageBased = r.viewCount != null;
+  const value = usageBased ? 10 * r.viewCount : 10 * nFeatures;
+  const score = Math.round((value / (1 + cost)) * 100) / 100;
+  const complexity = r.nUnhandled > 0 ? 'high' : r.nManual > 0 ? 'medium' : 'low';
+  let tag;
+  if (r.nUnhandled >= 1) tag = 'needs-review';
+  else if (r.nManual + r.nUnhandled === 0) tag = 'migrate-first';
+  else if (score >= 10) tag = 'easy-win';
+  else tag = 'moderate';
+  return {
+    id: r.name, type: r.type, name: r.name,
+    n_features: nFeatures, n_auto: r.nAuto, n_hint: r.nHint, n_manual: r.nManual, n_unhandled: r.nUnhandled,
+    complexity, gaps: r.gaps,
+    view_count: r.viewCount, uses_cards: r.usesCards || [],
+    value, cost, score, tag,
+  };
+}
+
+// ============================================================================
+// main
+// ============================================================================
+const files = collect(inDir);
+if (!files.length) {
+  console.error(`no *.card.json / *.dashboard.json found under ${inDir}`);
+  process.exit(1);
+}
+
+const artifacts = [];
+for (const f of files) {
+  const text = readFileSync(f, 'utf8');
+  const name = basename(f).replace(/\.(card\.json|dashboard\.json)$/, '');
+  const res = f.endsWith('.card.json') ? scoreCard(text, name) : scoreDashboard(text, name);
+  if (res) { res.specFile = f; artifacts.push(res); }
+}
+artifacts.sort((a, b) => b.score - a.score);
+
+// estate roll-up
+const totals = artifacts.reduce((t, a) => {
+  t.n_auto += a.n_auto; t.n_hint += a.n_hint; t.n_manual += a.n_manual; t.n_unhandled += a.n_unhandled;
+  t.n_features += a.n_features;
+  return t;
+}, { n_auto: 0, n_hint: 0, n_manual: 0, n_unhandled: 0, n_features: 0 });
+
+// % auto-migratable = features that convert with no manual/unhandled work.
+// (auto + hint count as auto-migratable; hint is a review, not rework.)
+const autoMigratable = totals.n_auto + totals.n_hint;
+const pctAuto = totals.n_features ? Math.round((autoMigratable / totals.n_features) * 100) : 0;
+
+// gap histogram = manual + unhandled signals aggregated by signal name
+const histo = {};
+for (const a of artifacts) {
+  for (const g of a.gaps) {
+    if (g.bucket === 'manual' || g.bucket === 'unhandled') {
+      const k = g.signal;
+      histo[k] = histo[k] || { signal: g.signal, bucket: g.bucket, count: 0, artifacts: [], reason: g.reason, remediation: g.remediation };
+      histo[k].count += g.count;
+      histo[k].artifacts.push(a.name);
+    }
+  }
+}
+
+// EE sandboxing (GTAP export saved by discovery) — estate-level needs-review item.
+let nSandboxes = 0;
+for (const cand of [join(inDir, 'sandboxes.json'), join(dirname(inDir), 'sandboxes.json'), outDir ? join(outDir, 'sandboxes.json') : null]) {
+  if (cand && existsSync(cand)) {
+    try {
+      const sb = JSON.parse(readFileSync(cand, 'utf8'));
+      if (Array.isArray(sb)) { nSandboxes = sb.length; break; }
+    } catch { /* ignore */ }
+  }
+}
+if (nSandboxes > 0) {
+  histo['sandboxing policy (EE row-level security)'] = {
+    signal: 'sandboxing policy (EE row-level security)', bucket: 'unhandled', count: nSandboxes,
+    artifacts: ['(instance-level — sandboxes.json)'],
+    reason: `${nSandboxes} GTAP sandboxing polic${nSandboxes === 1 ? 'y' : 'ies'} restrict data per group`,
+    remediation: 'Port to Sigma user attributes + data-model filters with the metabase-to-sigma RLS engine (apply_sigma_rls.py) after the DM is posted — opt-in, reviewed per policy, never silent.',
+  };
+}
+const gapHistogram = Object.values(histo).sort((a, b) => (b.bucket === 'unhandled' ? 1 : 0) - (a.bucket === 'unhandled' ? 1 : 0) || b.count - a.count);
+
+const byComplexity = { low: 0, medium: 0, high: 0 };
+const byTag = {};
+for (const a of artifacts) { byComplexity[a.complexity]++; byTag[a.tag] = (byTag[a.tag] || 0) + 1; }
+
+const rollup = {
+  generated_at: new Date().toISOString().slice(0, 10),
+  n_artifacts: artifacts.length,
+  n_models: artifacts.filter((a) => a.type === 'model').length,
+  n_cards: artifacts.filter((a) => a.type === 'card' || a.type === 'metric').length,
+  n_dashboards: artifacts.filter((a) => a.type === 'dashboard').length,
+  totals,
+  pct_auto_migratable: pctAuto,
+  gap_histogram: gapHistogram,
+  by_complexity: byComplexity,
+  by_tag: byTag,
+  usage_available: artifacts.some((a) => a.view_count != null),
+  n_sandboxes: nSandboxes,
+};
+
+const out = { rollup, artifacts };
+writeFileSync(join(outDir, 'coverage.json'), JSON.stringify(out, null, 2));
+console.log(`scored ${artifacts.length} artifacts (${rollup.n_models} models, ${rollup.n_cards} questions, ${rollup.n_dashboards} dashboards) — ${pctAuto}% auto-migratable -> ${join(outDir, 'coverage.json')}`);

--- a/metabase-migration-skills/metabase-to-sigma/SKILL.md
+++ b/metabase-migration-skills/metabase-to-sigma/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: metabase-to-sigma
+description: >-
+  Migrate Metabase content to Sigma. Use when the user has Metabase questions,
+  models, or dashboards and wants to recreate them in Sigma. Converts MBQL
+  cards/models (+ database metadata) → Sigma data model and dashboards → Sigma
+  workbooks, translating MBQL expressions/aggregations and flagging constructs
+  with no clean Sigma analog. Discovery via the Metabase REST API (API key or
+  session token) — works on open-source and Pro/EE alike.
+user-invocable: true
+---
+
+# Metabase → Sigma migration
+
+Convert Metabase **models + questions** into a Sigma **data model**, then convert the
+**dashboards** that sit on them into matching Sigma **workbooks**. Translate what maps
+cleanly; **flag what doesn't** (cum-sum/offset windows, saved segment refs, funnel/gauge
+viz, click behaviors) instead of emitting wrong logic.
+
+> **Status: production-validated end to end.** Extraction proven against a live
+> 7k-card / 1.5k-dashboard Metabase Cloud estate (v1.61.4 — 100% pMBQL); the
+> Sigma BUILD path live-validated with exact MCP-query parity, including models,
+> nested questions, combo charts, controls, and exact-grid layout
+> (`refs/design-notes.md` §9–§10d). BigQuery paths/casing are live-verified on
+> the Sigma side (§10c).
+
+> **This skill is customizable in plain language.** Read
+> `~/.metabase-to-sigma/preferences.md` if it exists at the start of every run,
+> restate the active preferences briefly, and honor them throughout (they may
+> override any default EXCEPT the verification gates). When the user corrects an
+> output or states a preference mid-run, OFFER to persist it — see
+> `refs/customization.md` for the three tiers (preferences / learned formula
+> rules / converter changes).
+
+> Read `refs/` before relying on shapes: `design-notes.md` (translation surface +
+> decisions + production findings), `rest-api.md` (endpoints + auth + version
+> gotchas), `mbql-shapes.md` (real card/dashboard JSON structures incl. pMBQL),
+> `expression-dsl.md` (MBQL → Sigma formula mapping table), `template-tags.md`
+> (native {{tags}} → Sigma controls), `control-parity.md` (SHARED cross-plugin
+> control-wiring contract: the control lint, the control-scope.json sidecar, the
+> flip test, and the verified target gotchas). For canonical Sigma data-model +
+> workbook spec shapes, defer to the companion `sigma-data-models` /
+> `sigma-workbooks` skills.
+
+---
+
+## Prerequisites
+
+- **Metabase REST access** — an **API key** (v49+: Admin → Settings → Authentication →
+  API keys; preferred, durable) or a username/password session. Capture either with
+  `scripts/get-metabase-session.sh`. Open-source Metabase is fully sufficient — no
+  Pro/EE features required (serialization export is EE-only; this skill doesn't use it).
+- **Sigma** API token (via the `sigma-api` skill) to POST the data model + workbook.
+- **The same warehouse on both sides.** Sigma reads the warehouse live; parity only
+  means something when the Sigma connection reaches the database Metabase queries.
+  (Metabase's bundled H2 Sample Database is NOT reachable from Sigma — pick content
+  on a real warehouse, or land the data first.)
+- **Know your warehouse dialect.** The converter auto-detects it from the Sigma connection
+  (`--connection <id>` triggers a `GET /v2/connections/<id>` lookup), or pass `--warehouse`
+  explicitly: `bigquery` | `snowflake` | `databricks` | `redshift` | `postgres` | `athena`.
+  Required for correct array-aggregation rewrites (BigQuery `ARRAY_AGG` → `array_to_string`,
+  Snowflake → `LISTAGG`, Databricks `collect_list` → `array_join`, etc.). Without it,
+  native SQL cards with array aggregations will render as blank cells in Sigma.
+- **Node** for the converter (`converter/`: `npm install` once).
+
+---
+
+## Phase 0 — Discover (Metabase REST)
+
+```bash
+export MB_BASE="https://<host>"        # + MB_KEY, or MB_USER/MB_PASS
+eval "$(scripts/get-metabase-session.sh)"
+scripts/metabase-discover.sh databases                  # find the warehouse connection
+scripts/metabase-discover.sh metadata 2 > metadata.json # FIELD IDS — required by the converter
+scripts/metabase-discover.sh collections                # folder tree
+scripts/metabase-discover.sh items 5                    # cards/models/dashboards in a collection
+scripts/metabase-discover.sh card 123      > orders-model.card.json
+scripts/metabase-discover.sh dashboard 9   > exec.dashboard.json
+```
+
+- **Always fetch `metadata <dbId>` first** — MBQL references columns by integer field
+  id; without the metadata map the converter falls back to per-card `result_metadata`
+  names (lossy, warned).
+- Models (`type: "model"`, or `dataset: true` pre-v50) are the semantic layer — fetch
+  them even when no dashboard uses them directly; questions stack on them via
+  `source-table: "card__N"`.
+- For estate-wide inventory + a migration shortlist, run the `metabase-assessment`
+  skill first — its `specs/` directory feeds this skill directly.
+
+## Phase 1 — Convert models/cards → Sigma data model
+
+```bash
+cd converter && npm install
+node --import tsx/esm cli.ts ../bundle.json --metadata ../metadata.json \
+  --connection <SIGMA_CONN> --database <DB> --schema <SCHEMA>
+```
+
+`bundle.json` is `{ "cards": [ <card JSONs> ] }` (or pass a single card file). Emits
+the Sigma data-model JSON on stdout; stats + warnings on stderr. Read the warnings
+aloud to the user — they are the parts that need manual authoring (cum-sum/offset
+windows, segment/metric refs to inline, binned breakouts, field-filter SQL tags).
+
+## Phase 1.5 — Reuse an existing DM? (avoid sprawl)
+
+Before POSTing a NEW data model in Phase 2, check whether an existing Sigma DM already
+covers the same warehouse tables (don't add a 4th near-identical DM for the same schema):
+
+```bash
+python3 scripts/metabase-dm-signature.py --dm-spec dm.json --out dm-signature.json
+eval "$(scripts/get-token.sh)"
+ruby scripts/find-or-pick-dm.rb --workbook-signature dm-signature.json \
+  --out dm-match.json --auto-pick           # exit 0 = candidate ≥ min-score
+```
+
+- **Score ≥ 0.6** → **ASK the user** reuse-vs-new: surface the candidate name, matched
+  cols (N/M), and the inherited-extras warning. If they reuse, run a **shape preflight**
+  (read the candidate spec back; every column the dashboard references must resolve with
+  no `type=error`), then **skip Phase 2** and run Phase 3 against the matched
+  `recommended_dm_id`.
+- **Score < 0.6** → POST new (Phase 2) and TELL the user no reusable DM was found.
+
+## Phase 1.9 — Choose where to build (ask first when no destination given)
+
+Don't pick the destination for the user. If they didn't supply a `--folder <id>`, ASK before the Phase 2 POST:
+
+1. `node scripts/pick-destination.mjs list` → `{ workspaces, folders (editable, with parentName), myDocuments }`
+2. Let the user pick ONE: a **workspace** (its `id` lands content in the workspace root), an existing **folder**, **My Documents** (when non-null — null for service tokens), or **create a new folder**: `node scripts/pick-destination.mjs create --name "<name>" [--parent <workspace-or-folder-id>]`
+3. Pass the chosen id as `--folder <id>` to every `post-and-readback.mjs` call (DM + workbook). `folderId` accepts a workspace id or a folder id.
+
+If a destination is already supplied, honor it silently — don't ask.
+
+## Phase 2 — POST the data model + read back ids (hard gate)
+
+```bash
+eval "$(scripts/get-token.sh)"                 # SIGMA_BASE_URL + SIGMA_API_TOKEN
+node scripts/post-and-readback.mjs --type datamodel --spec dm.json \
+  --folder <folderId> --out dm-map.json
+```
+
+POSTs to `/v2/dataModels/spec`, reads the spec back, and **fails on any `type=error`
+column** (a spec can POST 200 yet have formulas that don't resolve at query time — the
+readback scan catches it, derived view included). `dm-map.json` carries the real
+`dataModelId` + element ids (Sigma reassigns them on POST). Do not proceed past a
+non-zero exit.
+
+## Phase 3 — Convert the dashboard → Sigma workbook, wired to the DM
+
+```bash
+node --import tsx/esm cli.ts ../exec.dashboard.json --metadata ../metadata.json --dm <dataModelId> \
+  --layout-out hints.json --control-scope-out control-scope.json > wb.json
+node scripts/remap-wb-to-dm-ids.mjs --wb wb.json --dm-id <dataModelId> --dm-spec dm.json --out wb.remapped.json
+ruby scripts/lib/preflight_lint.rb wb.remapped.json   # MANDATORY — fix all violations before POST
+node scripts/post-and-readback.mjs --type workbook --spec wb.remapped.json --folder <folderId>
+node scripts/apply-layout.mjs --workbook <workbookId> --hints hints.json
+```
+
+**Preflight (mandatory):** `ruby scripts/lib/preflight_lint.rb wb.remapped.json` exits 1 with a precise message on the two migration-killer bugs — a `table` with aggregate columns + dimensions but **no `groupings`** (renders raw detail rows instead of an aggregated summary), and a malformed `control` (missing `id`/`controlId`/`controlType` or the flat list value fields `source`/`mode`/`selectionMode`/`values`). Fix every violation first; **never conclude a feature is "unsupported" from an `Invalid kind` error** — it means the inner fields are wrong. Verified shapes: `sigma-workbooks` `controls.md`/`tables.md`.
+
+Each dashcard becomes the matching Sigma element sourced from the migrated DM element
+(KPI/bar/line/area/pie/combo/scatter/table/pivot/map; text cards → text elements;
+funnel/gauge/progress/waterfall → flagged tables). The converter emits each element's
+`source.elementId` as the source card/table **name** (a placeholder) —
+`remap-wb-to-dm-ids.mjs` rewrites those to real ids from Phase 2's readback (native
+cards all read back "Custom SQL", so it falls back to column-set fingerprints and
+repairs every formula ref against the live DM columns).
+
+**Controls** (full contract: `refs/control-parity.md`). Metabase dashboard parameters
+declare their card targets explicitly (`parameter_mappings`) — the converter wires
+each mapping and emits the **`control-scope.json` sidecar** (`--control-scope-out`,
+keep it next to the workbook spec: post-and-readback and gate 7 pick it up there):
+
+- **scalar params** (string/number equality, incl. static-list → segmented grain
+  switchers with values + defaults) → hidden boolean `[Col] = [slug]` + element filter;
+- **range params** (`date/*` → date-range with flat `mode: "between"`,
+  `number/between` → number-range) → REAL control `filters` targets, re-rooted
+  through a hidden **base table** on a trailing `Data` page (control targets may
+  only point at table elements; list/scalar targets on datetime columns are
+  silently stripped — both verified cross-plugin gotchas);
+- **variable-tag params** (drive `{{tags}}` in card SQL) → `--dm-spec` emits
+  control→DM-parameter bindings; if the org rejects them, post-and-readback
+  **drops those controls** (decorative controls are exactly what gate 7 blocks —
+  the DM `{{tag}}` controls still carry the filter; sync a workbook control in
+  the UI when the org enables DM-parameter targeting, or pass
+  `--keep-rejected-bindings` to keep them and sync by hand);
+- **unmapped params + unwirable field-filters** → NO control, loud warning
+  (flag, never furniture).
+
+post-and-readback (workbook) finishes by running the SHARED layout + control lints
+on the readback spec — fix violations (repair recipes in `refs/control-parity.md`)
+or annotate genuine narrow intent in `control-scope.json` before moving on.
+Metabase's 24-col dashcard grid maps 1:1 onto Sigma's layout —
+`apply-layout.mjs --hints` reproduces the exact geometry, confirms it survives
+readback, and re-runs the layout lint (without `--hints` it falls back to a clean
+generic layout).
+
+## Phase 4 — Verify parity + the seven gates (hard gate — the real proof)
+
+```bash
+node scripts/assert-parity.mjs --plan --type workbook --id <workbookId>   # emits per-element SQL
+# run each via mcp-v2 query (or the Sigma query API), save totals to actual.json
+node scripts/assert-parity.mjs --check --actual actual.json --expected metabase.json --tol 0.01 \
+  --workdir <workdir>  --census '{"zones_total":N,"charts_built":M,"zones_unmatched":0,"unmatched_zone_names":[]}'
+ruby scripts/assert-phase6-ran.rb --workdir <workdir> --workbook-id <workbookId>   # gates 1–7
+```
+
+**Expected values must be LIVE**: re-run the Metabase cards (`POST /api/card/{id}/query`)
+at verification time — a baseline captured earlier drifts as warehouse rows land, and
+the diff reads as a phantom parity failure.
+
+`assert-parity --check` writes the `parity-final.json` sentinel into `--workdir`
+(post-and-readback already wrote `wb-ids.json` + `posted-workbooks.jsonl` there);
+derive the `--census` counts from the converter stats (dashcards converted vs
+elements built — name any legitimately unbuildable zones). Then
+**`assert-phase6-ran.rb` is the GREEN gate**: parity ran (1), no orphan workbooks
+(2), no error-typed columns (3), layout applied (4), tile census (5), layout lint
+(6), control lint honoring `control-scope.json` (7). Exit 0 or it isn't done.
+
+**Flip test** (runtime control evidence — REQUIRED after any hand-repaired wiring,
+recommended always; see `refs/control-parity.md` for why MCP cannot do this):
+
+```bash
+ruby scripts/probe-controls.rb --workbook-id <workbookId> --check-out-of-closure
+# date-range / number-range controls need an explicit flip value:
+#   --value <controlId>='min:2026-01-01,max:2026-03-31'
+```
+
+A mapped card's export must CHANGE under `parameters:{<controlId>: <value>}`; an
+unmapped same-page card must NOT (no leak).
+
+**Visual gate** (layout, control widgets, chart marks — things data queries can't see):
+export each page as PNG and LOOK at it:
+
+```bash
+# POST /v2/workbooks/{id}/export {"pageId":"<pageId>","format":{"type":"png","pixelWidth":1400}}
+# → {queryId} → poll GET /v2/query/{queryId}/download until 200 → PNG
+```
+
+Check: controls render as the right widget (segmented grain switcher, defaults filled),
+elements sit at the Metabase grid positions (not stacked), charts show marks (an empty
+chart with a title = a column/axis problem the readback scan can miss).
+
+A migration is **GREEN only when** (a) `assert-parity --check` passes, (b)
+`assert-phase6-ran.rb` exits 0 (all seven gates, control lint included), AND (c) the
+workbook came back with a clean layout (`apply-layout.mjs` reported
+`layoutOnReadback: true`) — never on a 200 POST alone. `metabase.json` = the numbers
+from the Metabase cards (run each card via `POST /api/card/{id}/query` — the one
+non-GET this skill may use, read-only in effect — or read them off the dashboard).
+Mind caching: Metabase serves cached results by default; Sigma reads live. A delta
+that matches rows landed since the cache filled is freshness, not a failure.
+
+**After parity passes, tell the user this in the conversation:**
+
+> "Migration complete. Before I wrap up, I'd like to send an anonymous usage ping so we can track which migration skills are being used. It records: tool name, your Sigma region, an anonymized org fingerprint (a hash of your client ID — not the credential itself), migration duration, and success. No workbook names, SQL, column names, or any customer data is included. See [TELEMETRY.md](https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md) for the exact payload. Just say 'skip' if you'd prefer not to send it."
+
+If the user does not object, run:
+
+```bash
+node scripts/report-telemetry.mjs --duration <elapsed_seconds>
+# on failure: node scripts/report-telemetry.mjs --duration <elapsed_seconds> --failed
+```
+
+---
+
+## What converts, what's flagged (never faked)
+
+**Converted (per the contract in `refs/expression-dsl.md` — fixture-tested; extraction
+production-validated, Sigma POST shapes pending first live build):**
+- **pMBQL ("lib/" MBQL)** — the modern wire format (100% of the reference production
+  estate) — normalized to legacy MBQL at intake (`converter/pmbql-normalize.mjs`;
+  the server's `legacy_query` is preferred when present). Multi-stage queries are
+  flagged, never mistranslated.
+- **MBQL questions/models** → DM elements: explicit `joins` → join sources
+  (left/right/inner/full), `expressions` → calc columns, `aggregation` → metrics
+  (incl. named `aggregation-options`, `count-where`/`sum-where` → `CountIf`/`SumIf`,
+  `share` → ratio + `%` format), temporal-unit breakouts → `DateTrunc` columns.
+- **FK metadata → DM relationships** (+ derived join view; the relationship's own key
+  column is skipped — a cross-element join-key passthrough compiles to type `error`).
+- **Native SQL questions** → first the converter tries to **auto-remodel to a NATIVE
+  Sigma data model**: a card that is a single `SELECT` over warehouse table(s) (no
+  CTE / subquery / CASE / window / set-op, only field-filter tags, real WHERE only on
+  those tags, no LIMIT) is re-expressed as a structured query and built as a
+  table/join model — NO custom SQL — so its columns are exposed and dashboard filters
+  reproduce as REAL Sigma controls + element filters (live-proven). SQL too complex to
+  remodel **falls back to a Custom SQL element** (no element name, bare `[Display Name]`
+  refs; dialect verbatim — BigQuery `project.dataset.table` near-verbatim). In the
+  fallback: plain `{{text/number/date/boolean}}` tags keep their `{{tag}}` + emit a
+  control (⚠️ a workbook control bound only to a DM-SQL `{{param}}` is INERT until
+  wired to the DM parameter in the UI — live-disproven); **field-filter tags** →
+  `1=1` + recreated as control/element filter when the column is in the result set;
+  `{{#card}}` inlined when tag-free; `[[…]]` kept/dropped per Metabase semantics
+  (always warned). Filters that can't be reproduced are reported in the result's
+  **`unreproducibleFilters`** (reason + manual-remodel hint) — never shipped as dead
+  controls. See `refs/template-tags.md`.
+- **Dashboards** → workbooks: one page per tab, 24-col grid 1:1, scalar/smartscalar →
+  KPI (`value: {columnId}`), pivot → pivot-table (`rowsBy`/`columnsBy` `{id}` objects +
+  bare-string `values`), `row` display → horizontal bar, maps → region-/point-map,
+  text/heading cards → text elements (markdown carries over), parameters → controls +
+  per-card target filters. Parameters that drive native template tags (the DOMINANT
+  production pattern) are recorded in the result's `parameterWiring` + ONE aggregated
+  warning per parameter.
+- **Formats**: `column_settings` (currency incl. symbol, decimals, prefix/suffix) →
+  Sigma d3 formats first, name/formula heuristics second; `series_settings` titles
+  rename series (colors flagged); `table.column_formatting` single threshold rules →
+  `conditionalFormats` (gradient/range scales flagged).
+
+**Flagged with a warning (and a readable placeholder), never faked:**
+`cum-sum`/`cum-count`/`offset` (rebuild with `CumulativeSum`/window calcs in the
+date-grouped consuming element), `["segment", id]` / legacy `["metric", id]` refs
+(inline their MBQL from `/api/segment/{id}` / `/api/legacy-metric/{id}`), binned
+breakouts (→ `BinFixed`/`BinCount`), multi-stage queries (→ chained Sigma elements),
+`click_behavior` (→ Sigma actions, manual), smartscalar previous-period comparisons,
+`object` detail views (→ flagged detail table), and viz with no native Sigma element:
+**funnel, gauge, progress, waterfall, sankey** → flagged table. Unknown MBQL ops emit
+`/* unmapped: <op> */` + a loud warning.
+
+## Security: Row-Level Security (sandboxing)
+
+Row security is **never silently dropped and never silently ported** — and it is handled
+by the **skill**, not baked into the converted model. Metabase **sandboxing is Pro/EE
+only** (`GET /api/mt/gtap` lists sandboxes; group-based). The converter only **detects
+and reports** (`security.json` + a loud `SECURITY:` line) when sandbox data is provided;
+on OSS there is nothing to detect — but **ask the customer anyway** (RLS is sometimes
+faked with per-group collections + duplicated filtered questions; inventory those by hand).
+
+**Flow (only when security was detected or found manually — zero overhead otherwise):**
+1. Convert + post the DM. Capture `dataModelId` + `security.json`
+   (manual entries use the same shape: `[{ "type": "row-filter", "name": …, "expression": …, "groups": […] }]`).
+2. **Gate (opt-in/out, default Port).** Plain-English summary of each rule + proposed
+   Sigma user-attribute mapping → **Port** / **Customize** / **Skip**. Reuse existing
+   Sigma user attributes/teams before creating new ones.
+3. Provision + apply with the shared engine:
+   ```bash
+   eval "$(scripts/get-token.sh)"
+   python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <id>            # plan only
+   python3 scripts/apply_sigma_rls.py --from-security security.json --dm-id <id> --provision --apply
+   ```
+4. Assign per-user attribute values from Metabase group membership
+   (`GET /api/permissions/group/{id}` lists members with emails — reconcile to Sigma members).
+
+**Skip is loud:** opting out leaves the migrated model showing ALL rows to everyone. Confirm first.
+
+## Gap scout — close a flagged expression
+
+For a flagged construct you want to actually resolve (an offset window, a segment ref,
+an unmapped op), spawn the **gap-scout subagent** (`scripts/gap-scout.md`): it proposes
+a Sigma formula, validates it against the customer's live Sigma via
+`scripts/scout-validate-and-persist.mjs`, and on success persists the rule to
+`~/.metabase-to-sigma/learned-rules.json` — which the converter CLI auto-applies
+*before* the built-in translator on the next run. If no formula validates, it returns
+an opt-in `scripts/escalate-gap.py` command to file a tracking issue (ask first).
+
+## Customizing the skill (your org, your rules)
+
+Everything above is the default behavior — not the required one. Tell Claude what
+you want different, in plain language, and ask it to remember:
+
+- **Run preferences** (naming, folders, which tabs/cards, control widget choices,
+  layout taste) → saved to `~/.metabase-to-sigma/preferences.md`, read at the start
+  of every run.
+- **Formula translations** specific to your SQL idioms → learned rules
+  (`~/.metabase-to-sigma/learned-rules.json`), validated live before persisting.
+- **Structural behavior** (chart mappings, DM shape) → converter changes with
+  fixture tests; share fixes back via `scripts/escalate-gap.py` or a PR.
+
+Both home-dir files survive `git pull`. Full guide + worked examples:
+`refs/customization.md`.

--- a/metabase-migration-skills/metabase-to-sigma/converter/cli.ts
+++ b/metabase-migration-skills/metabase-to-sigma/converter/cli.ts
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Metabase → Sigma converter CLI.
+ *   node --import tsx/esm cli.ts <input.json> [opts]
+ *
+ * Auto-detects input:
+ *   JSON with `dashcards`/`ordered_cards`             → dashboard → Sigma workbook spec
+ *   JSON with `cards`, an array of cards, or a single
+ *   card with `dataset_query`                         → cards → Sigma data model
+ *
+ * Options: --metadata <metadata.json> --connection <id> --database <DB> --schema <S>
+ *          --dm <dataModelId> --security-out <file>
+ *          --layout-out <file> --control-scope-out <file>   (dashboards only)
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { convertMetabaseToSigma, applyWarehouseTransforms, type WarehouseDialect } from './metabase.js';
+import { convertMetabaseDashboardToSigma } from './metabase-dashboard.js';
+
+// Map Sigma connection type strings → our WarehouseDialect enum.
+const SIGMA_TYPE_MAP: Record<string, WarehouseDialect> = {
+  bigquery: 'bigquery', snowflake: 'snowflake', databricks: 'databricks',
+  redshift: 'redshift', postgres: 'postgres', postgresql: 'postgres',
+  mysql: 'mysql', athena: 'athena',
+};
+
+async function detectWarehouse(connectionId: string): Promise<WarehouseDialect> {
+  const base = process.env.SIGMA_BASE_URL?.replace(/\/$/, '');
+  const token = process.env.SIGMA_API_TOKEN;
+  if (!base || !token || !connectionId || connectionId === '<CONNECTION_ID>') return 'unknown';
+  try {
+    const res = await fetch(`${base}/v2/connections/${connectionId}`, {
+      headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+    });
+    const json = await res.json() as any;
+    const type = String(json?.type || json?.connectionType || '').toLowerCase();
+    return SIGMA_TYPE_MAP[type] ?? 'unknown';
+  } catch { return 'unknown'; }
+}
+
+// Gap-scout learned rules (validated, customer-discovered translations) live in the
+// customer's home dir so a skill `git pull` never clobbers them. Applied before the
+// built-in translator (see scripts/gap-scout.md).
+function loadLearnedRules() {
+  try {
+    const p = join(homedir(), '.metabase-to-sigma', 'learned-rules.json');
+    const rules = JSON.parse(readFileSync(p, 'utf8'));
+    const arr = Array.isArray(rules) ? rules : (rules.rules || []);
+    if (arr.length) console.error(`[learned-rules] applying ${arr.length} customer rule(s) from ${p}`);
+    return arr;
+  } catch { return []; }
+}
+
+const args = process.argv.slice(2);
+const opt = (k: string, d = '') => { const i = args.indexOf('--' + k); return i >= 0 ? args[i + 1] : d; };
+// positional arg = the first token that is neither a flag nor a flag's value
+const input = args.find((a: string, i: number) => !a.startsWith('--') && !(i > 0 && args[i - 1].startsWith('--')));
+if (!input) { console.error('usage: cli.ts <cards.json|dashboard.json> [--metadata metadata.json --connection X --database DB --schema S --dm ID --security-out security.json]'); process.exit(1); }
+
+const raw = JSON.parse(readFileSync(input, 'utf8'));
+const metadataFile = opt('metadata');
+const metadata = metadataFile ? JSON.parse(readFileSync(metadataFile, 'utf8')) : undefined;
+const learnedRules = loadLearnedRules();
+
+const connectionId = opt('connection', '<CONNECTION_ID>');
+// --warehouse explicit > auto-detect from Sigma connection API > unknown (no transforms)
+const warehouseArg = opt('warehouse') as WarehouseDialect | '';
+const warehouse: WarehouseDialect = warehouseArg
+  ? (SIGMA_TYPE_MAP[warehouseArg.toLowerCase()] ?? warehouseArg as WarehouseDialect)
+  : await detectWarehouse(connectionId);
+if (warehouse !== 'unknown') console.error(`[warehouse] dialect: ${warehouse}`);
+else console.error(`[warehouse] dialect unknown — pass --warehouse <bigquery|snowflake|databricks|redshift|postgres|athena> to enable SQL transforms`);
+
+const isDashboard = !!(raw.dashcards || raw.ordered_cards);
+let res: any;
+if (isDashboard) {
+  res = convertMetabaseDashboardToSigma(raw, { dataModelId: opt('dm') || undefined, metadata, learnedRules });
+} else {
+  const cards = Array.isArray(raw) ? raw : raw.cards ? raw.cards : raw.dataset_query ? [raw] : [];
+  res = convertMetabaseToSigma(
+    { metadata: metadata ?? raw.metadata, cards, sandboxes: raw.sandboxes },
+    { connectionId, database: opt('database'), schema: opt('schema'), warehouse, learnedRules },
+  );
+}
+
+const payload = isDashboard ? res.workbook : res.model;
+process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+console.error(`\n[${isDashboard ? 'dashboard→workbook' : 'cards→data-model'}] stats: ${JSON.stringify(res.stats)}`);
+
+// 1:1 Metabase grid geometry (row/col/sizeX/sizeY per element) — feed to
+// scripts/apply-layout.mjs --hints to reproduce the dashboard layout exactly.
+if (isDashboard && res.layout && opt('layout-out')) {
+  writeFileSync(opt('layout-out'), JSON.stringify(res.layout, null, 2));
+  console.error(`layout hints → ${opt('layout-out')}`);
+}
+
+// control-scope.json sidecar (shared cross-plugin contract — see
+// scripts/lib/control_lint.rb header CONTRACT + refs/control-parity.md).
+// Write it NEXT TO the workbook spec in your workdir: post-and-readback and
+// assert-phase6-ran (gate 7) pick it up from there automatically.
+if (isDashboard && res.controlScope && opt('control-scope-out')) {
+  writeFileSync(opt('control-scope-out'), JSON.stringify(res.controlScope, null, 2));
+  console.error(`control scope sidecar → ${opt('control-scope-out')} (sourceFilterSignals=${res.controlScope.sourceFilterSignals}, controls=${res.controlScope.controls.length})`);
+}
+
+// Detected security (Metabase sandboxing) — detect-only; apply_sigma_rls.py ports it.
+if (res.security?.length) {
+  const out = opt('security-out', 'security.json');
+  writeFileSync(out, JSON.stringify(res.security, null, 2));
+  console.error(`SECURITY: ${res.security.length} rule(s) detected → ${out} — run scripts/apply_sigma_rls.py after posting the model (see SKILL.md "Security").`);
+}
+if (res.warnings.length) {
+  console.error(`warnings (${res.warnings.length}) — translated where possible, flagged where not:`);
+  res.warnings.forEach((w: string) => console.error('  ! ' + w));
+}

--- a/metabase-migration-skills/metabase-to-sigma/converter/metabase-dashboard.ts
+++ b/metabase-migration-skills/metabase-to-sigma/converter/metabase-dashboard.ts
@@ -1,0 +1,942 @@
+/**
+ * Metabase dashboard JSON → Sigma workbook spec.   [built from public docs — NOT yet live-validated]
+ *
+ * Input = GET /api/dashboard/{id}. Accepts BOTH the modern `dashcards` shape
+ * (size_x/size_y) and the legacy `ordered_cards` shape (sizeX/sizeY).
+ *
+ *   dashboard tab            → workbook page (no tabs → single page)
+ *   dashcard (by `display`)  → table / bar-chart (row = orientation:'horizontal' — the ONLY
+ *                              valid orientation value; vertical OMITS the key) / line-chart /
+ *                              area-chart / combo-chart / scatter-chart / pie-chart /
+ *                              kpi-chart (value = {columnId}) / pivot-table (rowsBy+columnsBy =
+ *                              [{id}] objects, values = bare column-id strings) /
+ *                              region-map | point-map (map.type) — funnel/gauge/progress/
+ *                              waterfall → table element + LOUD warning (never fake a viz)
+ *   text/heading dashcards   → text elements (markdown passes through)
+ *   dashboard parameters     → workbook controls (controlId = parameter slug); each
+ *                              parameter_mapping wires a REAL control `filters` target
+ *                              on a TABLE element (the dashcard itself when it is a
+ *                              table, else a hidden base table the chart re-roots
+ *                              through — chart/KPI targets 400, and boolean-match
+ *                              columns referencing list controls error live). The
+ *                              control-scope.json sidecar carries declared scope.
+ *
+ * Element sources are PLACEHOLDERS: source { kind:'table', elementId: '<DM element NAME>' }.
+ * The real Sigma element ids don't exist until the DM is POSTed —
+ * scripts/remap-wb-to-dm-ids.mjs rewrites the placeholders afterwards (matched by name).
+ *
+ * Layout: Metabase's 24-col grid maps 1:1 to Sigma's. Mirroring cognos-report's
+ * mechanism, the SPEC carries no baked positions (POST reassigns element ids, which
+ * breaks pre-baked layout XML); instead the result carries a `layout` hint structure
+ * ({ grid: 24, pages: [{ name, elements: [{elementId, name, row, col, sizeX, sizeY}] }] })
+ * for scripts/apply-layout.mjs (or an exact-grid variant of it) to apply post-POST.
+ */
+
+import { resetIds, sigmaShortId, sigmaDisplayName, formatFromMask } from './sigma-ids.js';
+import { buildFieldIndex, recognizeSimpleNativeSql, translateMbqlExpr, translateAggregation, type FieldIndex, type MbqlCtx, type LearnedRule } from './metabase.js';
+// pMBQL → legacy at intake: embedded dashcard cards AND parameter_mapping
+// targets arrive in pMBQL form on modern instances (Cloud v1.61+).
+import { normalizeCard, normalizeClause } from './pmbql-normalize.mjs';
+
+// ── workbook spec types (minimal) ────────────────────────────────────────────
+interface WbColumn { id: string; name: string; formula: string; format?: Record<string, any>; hidden?: boolean; }
+interface WbControl {
+  id: string; kind: 'control'; controlId: string; name: string; controlType: string;
+  source?: Record<string, any>; value?: any; values?: any[]; mode?: string;
+  filters?: Array<{ source: { kind: string; elementId: string }; columnId: string }>;
+}
+interface WbElement {
+  id: string; kind: string; name?: string; source?: Record<string, any>;
+  columns?: WbColumn[]; order?: string[]; filters?: any[]; conditionalFormats?: any[];
+  rowsBy?: Array<{ id: string }>; columnsBy?: Array<{ id: string }>; values?: string[];  // pivot
+  xAxis?: { columnId: string };                                                          // cartesian charts
+  yAxis?: { columnIds: Array<string | Record<string, any>> };
+  value?: { id?: string; columnId?: string };           // pie {id} · kpi {columnId} — NOT {id} (kpis.md is stale)
+  color?: any; stacking?: string; orientation?: string;
+  latitude?: { id: string }; longitude?: { id: string }; region?: { id: string; regionType: string };
+  text?: string;                                                                          // text elements
+}
+interface WbPage { id: string; name: string; elements: WbElement[]; }
+
+export interface DashboardLayoutHint {
+  grid: number;
+  pages: Array<{ name: string; elements: Array<{ elementId: string; name: string; row: number; col: number; sizeX: number; sizeY: number }> }>;
+}
+/** control-scope.json sidecar (shared cross-plugin contract — see
+ *  scripts/lib/control_lint.rb header CONTRACT + refs/control-parity.md).
+ *  sourceFilterSignals = dashboard parameters with >=1 parameter_mapping
+ *  (Metabase parameters declare their card targets EXPLICITLY — an unmapped
+ *  parameter filters nothing in Metabase either, so it is not a signal).
+ *  Per-control `scope` = the converted element names of its mapped cards
+ *  (the declared-target allowlist); `mustReach` = the subset the converter
+ *  actually wired (hard assertions for the lint's closure walk). */
+export interface ControlScopeSidecar {
+  version: 1; source: 'metabase'; sourceFilterSignals: number;
+  controls: Array<{ controlId: string; sourceName?: string; scope: string[] | 'page'; mustReach: string[] }>;
+}
+export interface MetabaseDashboardResult {
+  workbook: { name: string; schemaVersion: number; pages: WbPage[]; controls?: WbControl[] };
+  warnings: string[];
+  stats: Record<string, number>;
+  layout: DashboardLayoutHint;
+  /** control-scope.json sidecar — write next to the workbook spec (cli --control-scope-out). */
+  controlScope: ControlScopeSidecar;
+  /** dashboard-parameter → native-template-tag wirings (the dominant pattern on
+   *  production estates: the parameter drives a {{tag}} in a card's SQL). The
+   *  DM converter emits the matching {{tag}} control; these record which
+   *  dashboard parameter should drive it. */
+  parameterWiring?: Array<{ parameter: string; slug: string; card: string; tag: string; kind: 'variable' | 'field-filter' }>;
+}
+export interface MetabaseDashboardOptions {
+  workbookName?: string;
+  dataModelId?: string;
+  metadata?: any;                          // GET /api/database/{id}/metadata — field-id resolution
+  cardNameById?: Record<number, string>;   // card id → DM element name (for "card__N" sources)
+  learnedRules?: LearnedRule[];
+}
+
+// Metabase parameter type → Sigma control type. null type ⇒ flagged (warning, no control).
+function controlTypeFor(t: string): { type?: string; warn?: string } {
+  if (t === 'date/range') return { type: 'date-range' };
+  if (t === 'date' || t?.startsWith('date/')) return { type: 'date' };
+  if (t === 'temporal-unit') return { warn: 'temporal-unit ("time grouping") parameter has no Sigma control analog — flagged; pick a grouping in the chart instead.' };
+  if (t === 'string/=' || t === 'category' || t === 'id') return { type: 'list' };
+  if (t?.startsWith('string/')) return { type: 'list', warn: `parameter operator "${t}" approximated as a list (include) control — verify the filter semantics.` };
+  if (t === 'number/=') return { type: 'number' };
+  if (t === 'number/between') return { type: 'number-range' };
+  if (t?.startsWith('number/')) return { type: 'number', warn: `parameter operator "${t}" approximated as a number control — verify the filter semantics.` };
+  return { warn: `parameter type "${t}" not mapped — create the control manually.` };
+}
+
+const DISPLAY_KIND: Record<string, string> = {
+  table: 'table', bar: 'bar-chart', row: 'bar-chart', line: 'line-chart', area: 'area-chart',
+  combo: 'combo-chart', scatter: 'scatter-chart', pie: 'pie-chart',
+  scalar: 'kpi-chart', smartscalar: 'kpi-chart', trend: 'kpi-chart',
+  pivot: 'pivot-table',
+};
+// No Sigma analog → flagged table, never faked. Production histogram (7k-card
+// estate): funnel 83 · waterfall 15 · sankey 13 · gauge 11 · progress 3.
+const NO_ANALOG = new Set(['funnel', 'gauge', 'progress', 'waterfall', 'sankey']);
+const titleCase = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+export function convertMetabaseDashboardToSigma(dashboard: any, options: MetabaseDashboardOptions = {}): MetabaseDashboardResult {
+  resetIds();
+  const warnings: string[] = [];
+  const dash = typeof dashboard === 'string' ? JSON.parse(dashboard) : dashboard;
+  const fidx: FieldIndex | null = options.metadata ? buildFieldIndex(options.metadata) : null;
+  const name = options.workbookName || dash.name || 'Metabase Dashboard';
+
+  // ── dashcards: accept BOTH the modern and the legacy shape ───────────────────
+  const rawDcs: any[] = dash.dashcards || dash.ordered_cards || [];
+  const dcs = rawDcs.map((d: any) => ({
+    raw: d,
+    card: d.card ? normalizeCard(d.card) : d.card,
+    cardId: d.card_id,
+    vs: { ...(d.card?.visualization_settings || {}), ...(d.visualization_settings || {}) },
+    tabId: d.dashboard_tab_id ?? null,
+    row: d.row ?? 0, col: d.col ?? 0,
+    sizeX: d.size_x ?? d.sizeX ?? 4, sizeY: d.size_y ?? d.sizeY ?? 4,
+    parameterMappings: d.parameter_mappings || [],
+  }));
+
+  // Simple native-SQL cards are auto-remodeled to a NATIVE Sigma data model (see
+  // recognizeSimpleNativeSql) so their columns are exposed and dashboard filters
+  // reproduce natively. Mirror that here: swap the card to its structured form
+  // (+ the alias-aligned result_metadata so the viz keeps its axes) and rewrite
+  // each field-filter template-tag mapping to a raw dimension target — which the
+  // proven MBQL dimension-wiring path below turns into a control + element filter.
+  for (const dc of dcs) {
+    if (!dc.card || dc.card.dataset_query?.type !== 'native') continue;
+    const remodeled = recognizeSimpleNativeSql(dc.card, fidx);
+    if (!remodeled) continue;
+    const tags = dc.card.dataset_query?.native?.['template-tags'] || {};
+    dc.card = { ...dc.card, dataset_query: { type: 'query', database: dc.card.dataset_query.database, query: remodeled.query }, result_metadata: remodeled.resultMetadata };
+    dc.parameterMappings = dc.parameterMappings.map((pm: any) => {
+      const tgt = pm.target;
+      const tag = Array.isArray(tgt) && Array.isArray(tgt[1]) && tgt[1][0] === 'template-tag' ? String(tgt[1][1]) : null;
+      const dim = tag && tags[tag]?.type === 'dimension' ? tags[tag].dimension : null;
+      return dim ? { ...pm, target: ['dimension', dim] } : pm;
+    });
+  }
+
+  // ── parameters → controls (controlId = slug; wiring below is per-mapping) ────
+  // Metabase parameters declare their card targets EXPLICITLY (per-dashcard
+  // parameter_mappings) — count mappings up front so (a) unmapped parameters
+  // are skipped (they filter nothing in Metabase either; porting one would
+  // ship furniture the control lint rightly rejects), and (b) range-typed
+  // mapped parameters get REAL control filter targets (below) instead of the
+  // boolean-equality formula, which is wrong for range semantics.
+  const mappingCountByParam = new Map<string, number>();
+  for (const dc of dcs) for (const pm of dc.parameterMappings) {
+    mappingCountByParam.set(pm.parameter_id, (mappingCountByParam.get(pm.parameter_id) || 0) + 1);
+  }
+  const paramById = new Map<string, any>();
+  const controls: WbControl[] = [];
+  const controlBySlug = new Map<string, WbControl>();
+  for (const p of dash.parameters || []) {
+    paramById.set(p.id, p);
+    let { type, warn } = controlTypeFor(p.type);
+    if (warn) warnings.push(`parameter "${p.name}" (${p.type}): ${warn}`);
+    if (!type) continue;
+    if (!mappingCountByParam.get(p.id)) {
+      warnings.push(`parameter "${p.name}" (${p.type}) has NO parameter_mappings — it filters nothing in Metabase; no control emitted (flag, never furniture). Map it to a card in Metabase first if it should do something.`);
+      continue;
+    }
+    // Date parameters wired to dimension targets become date-RANGE controls:
+    // a scalar date control can only express equality, and the only verified
+    // Sigma wiring for a datetime target column is a date-range control with
+    // flat mode "between" (list/scalar targets on datetime columns are
+    // silently stripped at POST — see refs/control-parity.md).
+    if (type === 'date') type = 'date-range';
+    const ctrl: any = {
+      id: sigmaShortId(), kind: 'control', controlId: p.slug || p.id, name: p.name || p.slug,
+      controlType: type,
+    };
+    // Metabase static value list (e.g. day/week/month grain switchers) → Sigma's
+    // segmented control (the native idiom for small fixed choices); larger lists
+    // stay a list control with a manual source.
+    const staticVals: any[] | null =
+      p.values_source_type === 'static-list' ? (p.values_source_config?.values || null) : null;
+    if (staticVals?.length && type === 'list') {
+      ctrl.controlType = staticVals.length <= 6 ? 'segmented' : 'list';
+      ctrl.source = {
+        kind: 'manual',
+        valueType: typeof staticVals[0] === 'number' ? 'number' : 'text',
+        values: staticVals,
+      };
+    }
+    // Union discriminants are REQUIRED per controlType (same live-verified contract
+    // as DM controls — omitting them fails validation as `Invalid kind: "control"`).
+    if (ctrl.controlType === 'text') ctrl.mode = 'equals';
+    if (ctrl.controlType === 'number') ctrl.mode = '=';
+    if (ctrl.controlType === 'date') ctrl.mode = '=';
+    if (ctrl.controlType === 'date-range') ctrl.mode = 'between';
+    // Defaults: list controls take `values` (array), everything else scalar `value`;
+    // never emit an explicit null. Range controls: Metabase encodes defaults as
+    // relative tokens ("past30days") / "A~B" strings with no verified Sigma spec
+    // analog — dropped with a warning, set the default in the Sigma UI.
+    if (p.default != null) {
+      if (ctrl.controlType === 'date-range' || ctrl.controlType === 'number-range') {
+        warnings.push(`parameter "${p.name}": range default ${JSON.stringify(p.default)} has no verified Sigma spec shape — control emitted WITHOUT a default; set it in the UI.`);
+      } else if (ctrl.controlType === 'list') {
+        ctrl.values = Array.isArray(p.default) ? p.default : [p.default];
+      } else {
+        let v = Array.isArray(p.default) ? p.default[0] : p.default;
+        // Metabase stores number defaults as strings ("20") — Sigma number controls want numbers.
+        if (ctrl.controlType === 'number' && typeof v === 'string' && v.trim() !== '' && !isNaN(Number(v))) v = Number(v);
+        ctrl.value = v;
+      }
+    }
+    controls.push(ctrl);
+    controlBySlug.set(ctrl.controlId, ctrl);
+  }
+
+  // field-id → display name (metadata first; result_metadata fallback per card)
+  const mkCtx = (card: any, prefix: string | null): MbqlCtx => {
+    const rmById = new Map<number, any>();
+    for (const rm of card?.result_metadata || []) {
+      const fr = rm.field_ref;
+      if (Array.isArray(fr) && fr[0] === 'field' && typeof fr[1] === 'number') rmById.set(fr[1], rm);
+    }
+    const display = (ref: any): string => {
+      const idOrName = Array.isArray(ref) ? ref[1] : ref;
+      if (typeof idOrName === 'number') {
+        const f = fidx?.byId.get(idOrName);
+        if (f) return f.displayName;
+        const rm = rmById.get(idOrName);
+        if (rm) return rm.display_name || sigmaDisplayName(rm.name);
+        warnings.push(`card "${card?.name}": field ${idOrName} unresolved (pass --metadata) — emitted [Field ${idOrName}].`);
+        return `Field ${idOrName}`;
+      }
+      return sigmaDisplayName(String(idOrName ?? ''));
+    };
+    const ctx: MbqlCtx = {
+      fieldDisplay: display,
+      resolveField: (ref: any) => {
+        const opts = (Array.isArray(ref) && ref[2]) || {};
+        const disp = display(ref);
+        let out = prefix ? `[${prefix}/${disp}]` : `[${disp}]`;
+        if (opts['temporal-unit']) out = `DateTrunc("${opts['temporal-unit']}", ${out})`;
+        if (opts.binning) ctx.warn(`numeric binning on [${disp}] is flagged — recreate with BinFixed/BinCount on the element.`);
+        return out;
+      },
+      warn: (m) => warnings.push(`card "${card?.name}": ${m}`),
+      learnedRules: options.learnedRules,
+    };
+    return ctx;
+  };
+
+  // Resolve the DM-element-NAME placeholder this dashcard sources.
+  // remap-wb-to-dm-ids.mjs rewrites it to the real posted element id (matched by name).
+  const sourceNameFor = (card: any): string => {
+    const dq = card.dataset_query || {};
+    if (dq.type === 'native') {
+      warnings.push(`card "${card.name}" is a native-SQL question — its DM sql element carries NO name (Sigma derives one); wire this element's source.elementId manually after posting the DM.`);
+      return card.name || 'Custom SQL';
+    }
+    const q = dq.query || {};
+    const src = q['source-table'];
+    if (typeof src === 'string' && src.startsWith('card__')) {
+      const n = Number(src.slice('card__'.length));
+      const mapped = options.cardNameById?.[n];
+      if (mapped) return mapped;
+      // Parent card not on this dashboard and no mapping provided — the DM
+      // converter gives the NESTED card its own element (sourced from the parent),
+      // so this card's own name is the resolvable placeholder (live-verified;
+      // a "card__N" placeholder 400s at POST).
+      if (card.name) {
+        warnings.push(`card "${card.name}" sources nested card ${n} — no card-name mapping; sourced its OWN DM element by card name (the DM converter creates one per nested card). Pass cardNameById to source the parent model instead.`);
+        return card.name;
+      }
+      warnings.push(`card "${card.name}" sources nested card ${n} — no card-name mapping provided; emitted placeholder "card__${n}" (remap will report it unresolved; pass cardNameById or fix by hand).`);
+      return `card__${n}`;
+    }
+    if (typeof src === 'number') {
+      const t = fidx?.tableById.get(src);
+      if (!t) { warnings.push(`card "${card.name}": source table ${src} not in metadata — emitted placeholder "table_${src}".`); return `table_${src}`; }
+      if (Array.isArray(q.joins) && q.joins.length) {
+        // The DM converter gives every MBQL-join card its OWN join element, named
+        // after the card, with exactly the card's columns. Source that — the generic
+        // FK-derived "<Table> View" suffixes duplicate columns ("Category (PRODUCT_DIM)")
+        // so card-named refs 400 against it (live-verified "Dependency not found").
+        return card.name || `${sigmaDisplayName(t.name)} View`;
+      }
+      // Implicit FK joins (source-field refs) need the dim columns the base table
+      // doesn't have — read from the FK-derived "<Table> View" element instead.
+      if (JSON.stringify(q).includes('"source-field"')) return `${sigmaDisplayName(t.name)} View`;
+      return sigmaDisplayName(t.name);
+    }
+    warnings.push(`card "${card.name}": unrecognized source ${JSON.stringify(src)} — emitted placeholder "<element>".`);
+    return '<element>';
+  };
+
+  // column_settings → Sigma format (number_style/decimals/currency/prefix/suffix)
+  const CURRENCY_SYMBOL: Record<string, string> = { USD: '$', EUR: '€', GBP: '£', JPY: '¥', CAD: '$', AUD: '$' };
+  const formatFromColumnSettings = (s: any): Record<string, any> | undefined => {
+    if (!s) return undefined;
+    const d = s.decimals ?? 2;
+    let fmt: Record<string, any> | null = null;
+    if (s.number_style === 'currency' || s.currency) {
+      const sym = CURRENCY_SYMBOL[String(s.currency || 'USD').toUpperCase()] || '$';
+      fmt = { kind: 'number', formatString: `${sym},.${s.decimals ?? 2}f`, currencySymbol: sym };
+    } else if (s.number_style === 'percent') {
+      fmt = formatFromMask(`0${d ? '.' + '0'.repeat(d) : ''}%`);
+    } else if (s.number_style === 'decimal' || s.decimals != null) {
+      fmt = formatFromMask(`#,##0${d ? '.' + '0'.repeat(d) : ''}`);
+    }
+    if (s.suffix) fmt = { ...(fmt || { kind: 'number', formatString: ',.2f' }), suffix: s.suffix };
+    if (s.prefix) fmt = { ...(fmt || { kind: 'number', formatString: ',.2f' }), prefix: s.prefix };
+    // date_style / time_style: Sigma date-format spec shape is not yet verified
+    // against a live readback — ignored silently (display-only, data unaffected).
+    return fmt || undefined;
+  };
+
+  // table.column_formatting → Sigma conditionalFormats (single rules convert;
+  // range/gradient scales are flagged — backgroundScale spec shape unverified).
+  const CF_OPERATOR: Record<string, string> = {
+    '=': '=', '!=': '!=', '<': '<', '>': '>', '<=': '<=', '>=': '>=',
+    'is-null': 'IsNull', 'not-null': 'IsNotNull', contains: 'Contains',
+    'does-not-contain': 'NotContains', 'starts-with': 'StartsWith', 'ends-with': 'EndsWith',
+  };
+  const buildConditionalFormats = (card: any, rules: any[], byKey: Map<string, string>): any[] => {
+    const out: any[] = [];
+    for (const r of rules || []) {
+      const columnIds = (r.columns || []).map((n: string) => byKey.get(String(n).toLowerCase())).filter(Boolean);
+      if (!columnIds.length) { warnings.push(`card "${card.name}": a conditional-formatting rule targets unresolved column(s) ${JSON.stringify(r.columns)} — skipped.`); continue; }
+      if (r.type === 'single') {
+        const condition = CF_OPERATOR[String(r.operator)];
+        if (!condition) { warnings.push(`card "${card.name}": conditional-formatting operator "${r.operator}" has no Sigma mapping — rule skipped.`); continue; }
+        const cf: any = { type: 'single', columnIds, condition, style: { backgroundColor: r.color || '#509EE3' } };
+        if (r.value !== undefined && condition !== 'IsNull' && condition !== 'IsNotNull') cf.value = r.value;
+        out.push(cf);
+        if (r.highlight_row) warnings.push(`card "${card.name}": a conditional-formatting rule highlights the WHOLE ROW — Sigma's converted rule colors the matched column(s) only; extend columnIds to all columns if row highlighting is required.`);
+      } else {
+        warnings.push(`card "${card.name}": a "${r.type}" (gradient/range) conditional-formatting rule is flagged — recreate as a Sigma backgroundScale conditional format in the UI (spec shape not yet live-verified).`);
+      }
+    }
+    return out;
+  };
+
+  interface BuiltCols {
+    cols: WbColumn[]; order: string[];
+    byKey: Map<string, string>;            // result name / display name (lowercase) → col id
+    byFieldId: Map<number, string>;        // MBQL field id → col id
+    byAggIndex: Map<number, string>;       // ["aggregation", n] → col id
+    dimIds: string[]; metricIds: string[];
+    keyOfId: Map<string, string>;          // col id → result_metadata name (series_settings keys)
+  }
+
+  const buildCardColumns = (card: any, sourceName: string, ctx: MbqlCtx): BuiltCols => {
+    const out: BuiltCols = { cols: [], order: [], byKey: new Map(), byFieldId: new Map(), byAggIndex: new Map(), dimIds: [], metricIds: [], keyOfId: new Map() };
+    const dq = card.dataset_query || {};
+    const q = dq.type === 'query' ? dq.query || {} : null;
+    let rms: any[] = card.result_metadata || [];
+    if (!rms.length && q) {
+      // never-run cards may carry no result_metadata — synthesize from the MBQL itself
+      warnings.push(`card "${card.name}" has no result_metadata — columns synthesized from its MBQL (run the question once to capture exact result names).`);
+      rms = [
+        ...(q.breakout || []).map((b: any) => ({ name: ctx.fieldDisplay(b), display_name: ctx.fieldDisplay(b), field_ref: b })),
+        ...(q.aggregation || []).map((_: any, i: number) => ({ name: `agg${i}`, display_name: '', field_ref: ['aggregation', i] })),
+      ];
+    }
+    let aggSeq = 0;
+    for (const rm of rms) {
+      if (rm.name === 'pivot-grouping') continue; // Metabase-internal pivot column
+      let fr = rm.field_ref;
+      // Pivot (and some cached) result_metadata carries field_ref: null — reconstruct
+      // from the MBQL by name (agg result cols are named sum/count/avg/…; live-verified).
+      if (!Array.isArray(fr) && q) {
+        const nmLower = String(rm.name || '').toLowerCase();
+        if (q.aggregation?.length && /^(sum|count|avg|min|max|stddev|distinct|share|cum_sum|cum_count)(_\d+)?$/.test(nmLower)) {
+          fr = ['aggregation', Math.min(aggSeq++, q.aggregation.length - 1)];
+        } else {
+          const b = (q.breakout || []).find((br: any) => ctx.fieldDisplay(br).toLowerCase() === String(rm.display_name || rm.name || '').toLowerCase());
+          if (b) fr = b;
+        }
+      }
+      // Prettify ALWAYS (idempotent) — raw native aliases (x_axis_type, count(*))
+      // otherwise become the visible axis/column labels.
+      let formula = ''; let isMetric = false; let nm = sigmaDisplayName(rm.display_name || rm.name || 'Column');
+      if (Array.isArray(fr) && fr[0] === 'aggregation') {
+        const agg = q?.aggregation?.[fr[1]];
+        if (agg) {
+          const tr = translateAggregation(agg, ctx);
+          formula = tr.formula;
+          if (!nm) nm = tr.name;
+        } else { formula = `[${nm}]`; }       // native/aggregated upstream — passthrough
+        isMetric = true;
+      } else if (Array.isArray(fr) && fr[0] === 'expression') {
+        const ex = q?.expressions?.[fr[1]];
+        formula = ex ? translateMbqlExpr(ex, ctx) : `[${fr[1]}]`;
+      } else if (Array.isArray(fr) && fr[0] === 'field') {
+        formula = ctx.resolveField(fr);
+      } else {
+        formula = `[${nm}]`;                  // native result column — bare display ref
+      }
+      const id = sigmaShortId();
+      const col: WbColumn = { id, name: nm, formula };
+      out.cols.push(col); out.order.push(id);
+      if (rm.name) { out.byKey.set(String(rm.name).toLowerCase(), id); out.keyOfId.set(id, rm.name); }
+      out.byKey.set(nm.toLowerCase(), id);
+      if (Array.isArray(fr) && fr[0] === 'field' && typeof fr[1] === 'number') out.byFieldId.set(fr[1], id);
+      if (Array.isArray(fr) && fr[0] === 'aggregation') out.byAggIndex.set(fr[1], id);
+      (isMetric ? out.metricIds : out.dimIds).push(id);
+    }
+    return out;
+  };
+
+  // resolve a column_split / graph.* entry (field ref | agg ref | name string) → col id
+  const resolveEntry = (entry: any, built: BuiltCols, ctx: MbqlCtx): string | undefined => {
+    if (typeof entry === 'string') return built.byKey.get(entry.toLowerCase());
+    if (Array.isArray(entry) && entry[0] === 'aggregation') return built.byAggIndex.get(entry[1]);
+    if (Array.isArray(entry) && entry[0] === 'field') {
+      if (typeof entry[1] === 'number' && built.byFieldId.has(entry[1])) return built.byFieldId.get(entry[1]);
+      return built.byKey.get(ctx.fieldDisplay(entry).toLowerCase());
+    }
+    return undefined;
+  };
+
+  // dashboard-parameter → template-tag wirings (aggregated; see parameterWiring)
+  const tagWirings: NonNullable<MetabaseDashboardResult['parameterWiring']> = [];
+
+  // ── control-scope bookkeeping (the sidecar contract) ─────────────────────────
+  // scope = converted element names of each control's MAPPED cards (declared
+  // targets); reach = the subset the converter actually wired (bool formula,
+  // range filter target, or field-filter recreation). dmBound = controls whose
+  // only wiring is the control→DM-parameter binding (remap --dm-spec).
+  const scopeBySlug = new Map<string, Set<string>>();
+  const reachBySlug = new Map<string, Set<string>>();
+  const dmBoundSlugs = new Set<string>();
+  const record = (m: Map<string, Set<string>>, slug: string, name?: string) => {
+    if (!name) return;
+    if (!m.has(slug)) m.set(slug, new Set());
+    m.get(slug)!.add(name);
+  };
+
+  // Hidden sourcing roots for range-control filter targets. A Sigma control's
+  // `filters` target may only point at a TABLE element (chart/KPI targets 400
+  // "Dependency not found") — so a range-mapped chart is re-rooted through a
+  // base table that sources the same DM element and carries the columns the
+  // chart (and the control target) needs. Base tables live on a final "Data"
+  // page whose id starts with "data" (the cross-plugin convention the layout
+  // gates use to exempt utility pages).
+  const baseTables: WbElement[] = [];
+
+  // ── per-dashcard element builder ───────────────────────────────────────────
+  const buildElement = (dc: (typeof dcs)[number]): WbElement | null => {
+    const vs = dc.vs;
+    // text / heading dashcards (card_id null + virtual_card) → text elements
+    if (dc.cardId == null && vs.virtual_card) {
+      const display = vs.virtual_card.display;
+      if (display === 'text' || display === 'heading') {
+        // Live contract: text elements carry `body` (string), not `text` —
+        // POST 400s "body: Invalid string: undefined".
+        return { id: sigmaShortId(), kind: 'text', name: 'Text', body: vs.text || '' } as any;
+      }
+      warnings.push(`virtual card (display "${display}") is not a text/heading — skipped (link/action cards have no Sigma spec analog).`);
+      return null;
+    }
+    const card = dc.card;
+    if (!card) { warnings.push(`dashcard ${dc.raw.id}: card ${dc.cardId} not embedded in the dashboard JSON — skipped.`); return null; }
+    if (vs.click_behavior || Object.values(vs.column_settings || {}).some((c: any) => c?.click_behavior)) {
+      warnings.push(`card "${card.name}": click_behavior (cross-filter / link) is not converted — re-create as a Sigma action.`);
+    }
+
+    const display = String(card.display || 'table');
+    const sourceName = sourceNameFor(card);
+    const ctx = mkCtx(card, card.dataset_query?.type === 'native' ? null : sourceName);
+    const built = buildCardColumns(card, sourceName, ctx);
+
+    // column_settings → formats. Keys: '["name","COL"]' or '["ref",["field",72,null]]'.
+    for (const [key, setting] of Object.entries(vs.column_settings || {})) {
+      try {
+        const k = JSON.parse(key);
+        const colId = k[0] === 'name' ? built.byKey.get(String(k[1]).toLowerCase())
+          : k[0] === 'ref' ? resolveEntry(k[1], built, ctx) : undefined;
+        const fmt = formatFromColumnSettings(setting);
+        if (colId && fmt) { const c = built.cols.find((c) => c.id === colId); if (c) c.format = fmt; }
+      } catch { /* unparseable column_settings key — ignore */ }
+    }
+
+    // Cross-document DM references are kind 'data-model' (kind 'table' is for
+    // same-workbook elements — live-verified 400 "Dependency not found").
+    const source: Record<string, any> = { kind: 'data-model', elementId: sourceName };
+    if (options.dataModelId) source.dataModelId = options.dataModelId;
+    const el: WbElement = {
+      id: sigmaShortId(), kind: DISPLAY_KIND[display] || 'table', name: card.name || `Card ${card.id}`,
+      source, columns: built.cols, order: built.order,
+    };
+
+    // graph.dimensions / graph.metrics matched through result_metadata names
+    const dimIds = ((vs['graph.dimensions'] || []).filter(Boolean)
+      .map((n: string) => built.byKey.get(n.toLowerCase())).filter(Boolean) as string[]);
+    const metIds = ((vs['graph.metrics'] || []).filter(Boolean)
+      .map((n: string) => built.byKey.get(n.toLowerCase())).filter(Boolean) as string[]);
+    const xIds = dimIds.length ? dimIds : built.dimIds;
+    const yIds = metIds.length ? metIds : built.metricIds;
+
+    if (NO_ANALOG.has(display)) {
+      // never fake a viz — emit the data as a table + a LOUD warning
+      el.kind = 'table';
+      el.name = `${card.name} (was ${display})`;
+      warnings.push(`card "${card.name}" is a Metabase ${display} — Sigma has no native ${display} element; emitted its data as a TABLE. Re-pick a Sigma viz in the workbook.`);
+    } else if (display === 'object') {
+      // single-record detail view — flagged, emitted as a table (never faked)
+      el.kind = 'table';
+      el.name = `${card.name} (object detail)`;
+      warnings.push(`card "${card.name}" is a Metabase object DETAIL view (single record) — emitted its data as a flagged TABLE; recreate the detail experience with element filters / drill in Sigma.`);
+    } else if (el.kind === 'kpi-chart') {
+      const scalarField = vs['scalar.field'] ? built.byKey.get(String(vs['scalar.field']).toLowerCase()) : undefined;
+      const valId = scalarField || yIds[0] || built.metricIds[0] || built.order[0];
+      if (!valId) { warnings.push(`card "${card.name}" (scalar) resolved no value column — skipped.`); return null; }
+      el.value = { columnId: valId };   // kpi-chart wants {columnId}, NOT {id}
+      if (display === 'smartscalar' || display === 'trend') {
+        warnings.push(`card "${card.name}" is a ${display} — the VALUE converts; the auto "vs previous period" comparison does not. Add a Sigma KPI comparison manually.`);
+      }
+    } else if (el.kind === 'pie-chart') {
+      const sliceId = (vs['pie.dimension'] && built.byKey.get(String(vs['pie.dimension']).toLowerCase())) || xIds[0];
+      const valId = (vs['pie.metric'] && built.byKey.get(String(vs['pie.metric']).toLowerCase())) || yIds[0];
+      if (sliceId) el.color = { id: sliceId };
+      if (valId) el.value = { id: valId };
+      if (!sliceId || !valId) warnings.push(`card "${card.name}" (pie): could not resolve ${!sliceId ? 'slice dimension' : 'value'} — fix in the workbook.`);
+    } else if (el.kind === 'pivot-table') {
+      const split = vs['pivot_table.column_split'] || {};
+      const rowsBy = (split.rows || []).map((e: any) => resolveEntry(e, built, ctx)).filter(Boolean).map((id: string) => ({ id }));
+      const columnsBy = (split.columns || []).map((e: any) => resolveEntry(e, built, ctx)).filter(Boolean).map((id: string) => ({ id }));
+      let values = (split.values || []).map((e: any) => resolveEntry(e, built, ctx)).filter(Boolean) as string[];
+      if (!values.length) values = built.metricIds;
+      // rowsBy/columnsBy = arrays of {id} OBJECTS, values = BARE column-id strings —
+      // without rowsBy+columnsBy the pivot silently collapses to one grand-total cell.
+      el.rowsBy = rowsBy; el.columnsBy = columnsBy; el.values = values;
+      if (!rowsBy.length && !columnsBy.length) warnings.push(`card "${card.name}" (pivot): no row/column split resolved — the pivot will collapse to a single grand-total cell; set rowsBy/columnsBy.`);
+    } else if (display === 'map') {
+      const mapType = vs['map.type'] || 'region';
+      if (mapType === 'pin') {
+        const latId = built.cols.find((c) => /\blat/i.test(c.name))?.id;
+        const lonId = built.cols.find((c) => /\b(lon|lng)/i.test(c.name))?.id;
+        if (latId && lonId) {
+          el.kind = 'point-map'; el.latitude = { id: latId }; el.longitude = { id: lonId };
+        } else {
+          el.kind = 'table'; el.name = `${card.name} (was pin map)`;
+          warnings.push(`card "${card.name}" (pin map): no lat/long columns resolved — emitted its data as a table.`);
+        }
+      } else {
+        const regId = xIds[0] || built.dimIds[0];
+        if (regId) {
+          el.kind = 'region-map'; el.region = { id: regId, regionType: vs['map.region'] === 'us_states' ? 'us-state' : 'country' };
+          if (yIds[0]) el.color = { by: 'scale', column: yIds[0] };
+          warnings.push(`card "${card.name}" → region-map: regionType guessed from map.region — verify (country / us-state / us-county / us-zipcode / ca-province).`);
+        } else {
+          el.kind = 'table'; el.name = `${card.name} (was region map)`;
+          warnings.push(`card "${card.name}" (region map): no region column resolved — emitted its data as a table.`);
+        }
+      }
+    } else if (el.kind.endsWith('-chart')) {
+      // cartesian: bar / row / line / area / combo / scatter
+      if (xIds[0]) el.xAxis = { columnId: xIds[0] };
+      else warnings.push(`card "${card.name}" (${display}): no x-axis dimension resolved — set it in the workbook.`);
+      if (el.kind === 'combo-chart') {
+        // series_settings per-series display → bare-string (default mark) vs object
+        // (overridden mark / secondary axis) forms on yAxis.columnIds — the persisted
+        // dual-axis shape (feedback_sigma_combo_dual_axis).
+        const ss = vs.series_settings || {};
+        el.yAxis = {
+          columnIds: yIds.map((id) => {
+            const key = built.keyOfId.get(id);
+            const d = key ? ss[key]?.display : undefined;
+            return d && d !== 'bar' ? { columnId: id } : id;
+          }),
+        };
+        if (Object.keys(ss).length) warnings.push(`card "${card.name}" (combo): per-series marks emitted via the bare-string/object yAxis form — verify each series' mark + axis in Sigma.`);
+      } else if (yIds.length) {
+        el.yAxis = { columnIds: yIds };
+      } else {
+        warnings.push(`card "${card.name}" (${display}): no measure resolved for the value axis — add one in the workbook.`);
+      }
+      if (xIds.length > 1) el.color = { by: 'category', column: xIds[1] };  // 2nd dimension = series color
+      if (display === 'row') el.orientation = 'horizontal';  // 'horizontal' is the ONLY valid value; vertical bar OMITS the key
+      // Live-verified enum: none | stacked | normalized (Metabase's 'normalized'
+      // passes through verbatim; 'percent' is rejected "Invalid value: string").
+      const stack = vs['stackable.stack_type'];
+      if (stack === 'stacked') el.stacking = 'stacked';
+      else if (stack === 'normalized') el.stacking = 'normalized';
+    }
+    // display === 'table' → plain table element: columns + order already set.
+
+    // series_settings → series display names (rename the y columns); colors are
+    // positional-only in the Sigma spec (bar color.scheme) — flagged, not guessed.
+    if (vs.series_settings && el.kind !== 'combo-chart') {
+      let renamed = 0; let colored = 0;
+      for (const [key, s] of Object.entries(vs.series_settings as Record<string, any>)) {
+        const colId = built.byKey.get(String(key).toLowerCase());
+        const c = colId && built.cols.find((c) => c.id === colId);
+        if (c && s?.title && s.title !== c.name) { built.byKey.set(String(s.title).toLowerCase(), c.id); c.name = s.title; renamed++; }
+        if (s?.color) colored++;
+      }
+      if (colored) warnings.push(`card "${card.name}": ${colored} per-series color(s) in series_settings — Sigma's spec colors bar categories positionally (color.scheme) and pie/line series via theme only; re-apply colors in the workbook.`);
+      if (renamed) warnings.push(`card "${card.name}": ${renamed} series renamed from series_settings titles.`);
+    }
+
+    // table.column_formatting → Sigma conditionalFormats (single rules; ranges flagged)
+    if (Array.isArray(vs['table.column_formatting']) && vs['table.column_formatting'].length) {
+      const cfs = buildConditionalFormats(card, vs['table.column_formatting'], built.byKey);
+      if (cfs.length) el.conditionalFormats = cfs;
+    }
+
+    // table.columns enabled:false → hide
+    for (const tc of vs['table.columns'] || []) {
+      if (tc?.enabled === false && tc.name) {
+        const id = built.byKey.get(String(tc.name).toLowerCase());
+        const c = id && built.cols.find((c) => c.id === id);
+        if (c) c.hidden = true;
+      }
+    }
+
+    // ── parameter_mappings → control `filters` targets ─────────────────────────
+    // Every wirable mapping becomes a REAL control filter target — the verified
+    // cross-plugin wiring (refs/control-parity.md). A control reference inside a
+    // boolean match column (`[Col] = [slug]`) reads back as an error-typed
+    // column for list controls (live-caught 2026-06-12), so targets are the
+    // only honest form. Targets may only point at TABLE elements: a table
+    // dashcard is targeted directly; charts/KPIs re-root through a hidden base
+    // TABLE (collected in `pendingTargets`, materialized below). List/segmented
+    // targets on numeric or datetime columns are silently stripped at POST —
+    // those bind through a hidden Text() cast column (`cast`).
+    const pendingTargets: Array<{ slug: string; disp: string; fieldRef?: any; cast: boolean }> = [];
+    const NUMERIC_OR_DATETIME = /type\/(Integer|BigInteger|Float|Decimal|Number|DateTime|Date|Time)/;
+    const needsCast = (slug: string, baseType?: string) => {
+      const t = controlBySlug.get(slug)?.controlType;
+      return (t === 'list' || t === 'segmented' || t === 'text')
+        && !!baseType && NUMERIC_OR_DATETIME.test(baseType);
+    };
+    for (const pm of dc.parameterMappings) {
+      const p = paramById.get(pm.parameter_id);
+      if (!p) { warnings.push(`card "${card.name}": parameter_mapping references unknown parameter ${pm.parameter_id} — skipped.`); continue; }
+      const slug = p.slug || p.id;
+      record(scopeBySlug, slug, el.name);
+      let tgt = pm.target;
+      // pMBQL targets carry [op, {opts}, …] inner clauses — normalize them.
+      if (Array.isArray(tgt) && tgt.length >= 2) tgt = [tgt[0], normalizeClause(tgt[1])];
+      // native template-tag targets (the DOMINANT production pattern — 13.5k of
+      // 14.6k mappings on the reference estate): the parameter drives a {{tag}}
+      // in the card's SQL. The DM converter emits the {{tag}} control; record
+      // the wiring (aggregated into one warning per parameter, not per mapping).
+      const innerTag = Array.isArray(tgt) && Array.isArray(tgt[1]) && tgt[1][0] === 'template-tag' ? String(tgt[1][1]) : null;
+      if (innerTag && (tgt[0] === 'variable' || tgt[0] === 'dimension')) {
+        if (tgt[0] === 'variable') {
+          tagWirings.push({ parameter: p.name || slug, slug, card: card.name || String(card.id), tag: innerTag, kind: 'variable' });
+          dmBoundSlugs.add(slug);
+          continue;
+        }
+        // dimension + template-tag = the parameter drives a FIELD FILTER tag.
+        // The DM converter neutralized that tag to 1=1 — recreate the filter
+        // here when the tag's mapped column is in the card's result set.
+        tagWirings.push({ parameter: p.name || slug, slug, card: card.name || String(card.id), tag: innerTag, kind: 'field-filter' });
+        const tag = card.dataset_query?.native?.['template-tags']?.[innerTag];
+        const dimRef = tag?.dimension;
+        const dimColId = Array.isArray(dimRef) ? resolveEntry(dimRef, built, ctx) : undefined;
+        if (dimColId) {
+          const targetCol = built.cols.find((c) => c.id === dimColId)!;
+          const fieldId = Array.isArray(dimRef) && typeof dimRef[1] === 'number' ? dimRef[1] : undefined;
+          const baseType = (fieldId != null && fidx?.byId.get(fieldId)?.baseType)
+            || (card.result_metadata || []).find((rm: any) => rm.name && built.byKey.get(String(rm.name).toLowerCase()) === dimColId)?.base_type;
+          pendingTargets.push({ slug, disp: targetCol.name, fieldRef: dimRef, cast: needsCast(slug, baseType) });
+          record(reachBySlug, slug, el.name);
+        } else {
+          warnings.push(`card "${card.name}": parameter "${p.name}" drives field-filter tag {{${innerTag}}} but the tag's column is not in the card's result set — add the column to the SQL SELECT, then filter it via the "${slug}" control.`);
+        }
+        continue;
+      }
+      if (Array.isArray(tgt) && tgt[0] === 'text-tag') {
+        warnings.push(`card "${card.name}": parameter "${p.name}" targets a TEXT TAG (markdown placeholder) — Sigma text elements cannot bind controls; re-author the text or drop the binding.`);
+        continue;
+      }
+      if (!Array.isArray(tgt) || tgt[0] !== 'dimension') {
+        warnings.push(`card "${card.name}": parameter "${p.name}" targets ${JSON.stringify(tgt)} — unmappable; wire it manually.`);
+        continue;
+      }
+      const fieldRef = tgt[1];
+      const disp = ctx.fieldDisplay(fieldRef);
+      const baseType = (typeof fieldRef?.[1] === 'number' ? fidx?.byId.get(fieldRef[1])?.baseType : undefined)
+        || (Array.isArray(fieldRef) && fieldRef[2]?.['base-type']) || undefined;
+      pendingTargets.push({ slug, disp, fieldRef, cast: needsCast(slug, baseType) });
+      record(reachBySlug, slug, el.name);
+    }
+
+    // card-level MBQL filter → hidden boolean column + element filter (element is card-specific here, so this is safe)
+    const q = card.dataset_query?.type === 'query' ? card.dataset_query.query : null;
+    if (q?.filter) {
+      const formula = translateMbqlExpr(q.filter, ctx);
+      const fid = sigmaShortId();
+      built.cols.push({ id: fid, name: `Filter: ${card.name || card.id}`, formula, hidden: true });
+      (el.filters ||= []).push({ id: sigmaShortId(), columnId: fid, kind: 'list', mode: 'include', values: [true] });
+    }
+
+    // ── mapped targets → table element + control filter targets ────────────────
+    // A table dashcard is targeted DIRECTLY (it is already a table element); a
+    // chart/KPI/pivot re-roots through a hidden base TABLE (same DM source,
+    // passthrough columns) on the Data page — control targets may only point at
+    // table elements, and the element inherits the filter through the source
+    // closure. List/segmented targets on numeric/datetime columns bind through
+    // a hidden Text() cast column (silently stripped otherwise — verified).
+    if (pendingTargets.length) {
+      const isNative = card.dataset_query?.type === 'native';
+      let targetElId: string;
+      let targetCols: WbColumn[];        // column set on the TARGET table
+      let colByDisp: (disp: string) => WbColumn | undefined;
+
+      if (el.kind === 'table') {
+        // the dashcard is already a table — target it directly
+        targetElId = el.id;
+        targetCols = built.cols;
+        colByDisp = (disp) => {
+          let c = built.cols.find((cc) => cc.name === disp);
+          if (!c) {
+            const pt = pendingTargets.find((r) => r.disp === disp);
+            c = { id: sigmaShortId(), name: disp, formula: pt?.fieldRef ? ctx.resolveField(pt.fieldRef) : `[${disp}]`, hidden: true };
+            built.cols.push(c);
+            built.byKey.set(disp.toLowerCase(), c.id);
+          }
+          return c;
+        };
+      } else {
+        const baseName = `${card.name || `Card ${card.id}`} Base`;
+        // passthrough set: every source ref in the element's formulas + the targets.
+        // A "source ref" is a `[sourceName/X]`-prefixed token (MBQL cards) or, on
+        // native cards, a bare `[X]` that is either a passthrough column reading
+        // itself or a token that names no local column (a direct source read);
+        // bare refs to OTHER local columns and `[slug]` control refs stay local.
+        const needed = new Set<string>(pendingTargets.map((r) => r.disp));
+        const localNames = new Set(built.cols.map((cc) => cc.name));
+        const isPassthroughSelf = (c: WbColumn, tok: string) => c.name === tok && String(c.formula).trim() === `[${tok}]`;
+        const prefixed = new RegExp(`\\[${sourceName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/([^\\]]+)\\]`, 'g');
+        for (const c of built.cols) {
+          const f = String(c.formula || '');
+          if (isNative) {
+            for (const m of f.matchAll(/\[([^\]/]+)\]/g)) {
+              const tok = m[1];
+              if (controlBySlug.has(tok)) continue;
+              if (isPassthroughSelf(c, tok) || !localNames.has(tok)) needed.add(tok);
+            }
+          } else {
+            for (const m of f.matchAll(prefixed)) needed.add(m[1]);
+          }
+        }
+        const srcPrefix = isNative ? '' : `${sourceName}/`;
+        const baseCols: WbColumn[] = [...needed].map((n) => ({ id: sigmaShortId(), name: n, formula: `[${srcPrefix}${n}]` }));
+        const baseEl: WbElement = {
+          id: sigmaShortId(), kind: 'table', name: baseName,
+          source: { ...source }, columns: baseCols, order: baseCols.map((c) => c.id),
+        };
+        baseTables.push(baseEl);
+        // re-root the chart: source the base table, rewrite source refs through it
+        el.source = { kind: 'table', elementId: baseEl.id };
+        for (const c of built.cols) {
+          if (typeof c.formula !== 'string') continue;
+          if (isNative) {
+            const orig = c.formula;
+            c.formula = orig.replace(/\[([^\]/]+)\]/g, (whole, tok) => {
+              if (controlBySlug.has(tok)) return whole;
+              if (isPassthroughSelf(c, tok) || !localNames.has(tok)) return `[${baseName}/${tok}]`;
+              return whole;
+            });
+          } else {
+            c.formula = c.formula.split(`[${sourceName}/`).join(`[${baseName}/`);
+          }
+        }
+        targetElId = baseEl.id;
+        targetCols = baseCols;
+        colByDisp = (disp) => baseCols.find((c) => c.name === disp);
+      }
+
+      for (const pt of pendingTargets) {
+        const ctrl = controlBySlug.get(pt.slug);
+        const tc = colByDisp(pt.disp);
+        if (!ctrl || !tc) continue;
+        let columnId = tc.id;
+        if (pt.cast) {
+          // numeric/datetime list target — bind through a hidden Text() cast
+          let cast = targetCols.find((c) => c.name === `${pt.disp} (Text)`);
+          if (!cast) {
+            cast = { id: sigmaShortId(), name: `${pt.disp} (Text)`, formula: `Text([${pt.disp}])`, hidden: true };
+            targetCols.push(cast);
+            const holder = targetElId === el.id ? el : baseTables[baseTables.length - 1];
+            if (holder.order) holder.order.push(cast.id);
+          }
+          columnId = cast.id;
+        }
+        (ctrl.filters ||= []).push({ source: { kind: 'table', elementId: targetElId }, columnId });
+      }
+    }
+
+    el.columns = built.cols;
+    el.order = built.order;
+    return el;
+  };
+
+  // ── pages: one per dashboard tab (no tabs → single page) ─────────────────────
+  const tabs: any[] = dash.tabs?.length ? dash.tabs : [null];
+  const pages: WbPage[] = [];
+  const layout: DashboardLayoutHint = { grid: 24, pages: [] };
+  const builtPages: Array<{ name: string; els: WbElement[] }> = [];
+
+  for (const tab of tabs) {
+    const pageName = tab ? (tab.name || `Tab ${tab.id}`) : 'Page 1';
+    const pageDcs = dcs
+      .filter((d) => tab === null || (d.tabId ?? tabs[0]?.id) === tab.id)
+      .sort((a, b) => a.row - b.row || a.col - b.col);
+    const els: WbElement[] = [];
+    const hints: DashboardLayoutHint['pages'][number]['elements'] = [];
+    for (const dc of pageDcs) {
+      const el = buildElement(dc);
+      if (!el) continue;
+      els.push(el);
+      hints.push({ elementId: el.id, name: el.name || el.kind, row: dc.row, col: dc.col, sizeX: dc.sizeX, sizeY: dc.sizeY });
+    }
+    builtPages.push({ name: pageName, els });
+    layout.pages.push({ name: pageName, elements: hints });
+  }
+
+  // Prune controls the converter KNOWS are furniture. A control is only LIVE if
+  // it has a real Sigma wiring path: a formula reference (reachBySlug) or an
+  // element `filters` target. Two failure modes are flagged, never shipped:
+  //   1. field-filter parameters whose column is missing from every mapped
+  //      card's result set (no target to bind).
+  //   2. variable-tag parameters that only drive a DM-SQL {{tag}} (dmBoundSlugs).
+  //      LIVE-DISPROVEN 2026-06-15 on tj-wells-1989: a workbook control bound
+  //      only to a DM custom-SQL {{param}} is INERT — the export API ignores a
+  //      text grain control entirely and a numeric one mis-substitutes and
+  //      breaks the query (0 rows). The control lint rightly flags these dead.
+  //      So they are NOT emitted; they go into `unreproducibleFilters` with a
+  //      manual-remodel hint instead of shipping furniture that lies.
+  const unreproducibleFilters: Array<{ controlId: string; name: string; reason: string; hint: string }> = [];
+  const liveControls = controls.filter((c) => {
+    const wired = reachBySlug.has(c.controlId) || (c.filters || []).length > 0;
+    if (wired) return true;
+    if (dmBoundSlugs.has(c.controlId)) {
+      unreproducibleFilters.push({
+        controlId: c.controlId, name: c.name,
+        reason: 'drives a native {{tag}} consumed pre-aggregation inside custom SQL — a workbook control bound to a DM-SQL parameter is inert (live-disproven)',
+        hint: 'rebuild as a native Sigma control: surface the underlying column/date in the element and filter/group on it (date-trunc control for granularity, relative-date filter for a window, list control for a value), or sync this control to the DM parameter in the Sigma UI.',
+      });
+      warnings.push(`control "${c.name}" [${c.controlId}] only drives a DM custom-SQL {{tag}} — NOT emitted (a workbook control bound to a DM-SQL parameter is inert, live-disproven). Listed in unreproducibleFilters with a remodel hint.`);
+    } else {
+      unreproducibleFilters.push({
+        controlId: c.controlId, name: c.name,
+        reason: 'its mapped column is not in any consuming element\'s result set (consumed then aggregated away inside SQL)',
+        hint: 'add the column to the card\'s SELECT (and GROUP BY) so it lands in the result set, then this control binds as an element filter automatically.',
+      });
+      warnings.push(`control "${c.name}" [${c.controlId}] has no wirable target in any mapped card — control NOT emitted (it would be dead furniture; see the per-card warnings for the fix).`);
+    }
+    return false;
+  });
+
+  // Assemble pages: controls live on the first page, AFTER the elements they
+  // target (a control whose `filters` target appears later in the spec fails
+  // at POST — verified cross-plugin gotcha, refs/control-parity.md).
+  let placedControls = false;
+  for (const bp of builtPages) {
+    const pageEls: WbElement[] = !placedControls && liveControls.length ? [...bp.els, ...(liveControls as any)] : bp.els;
+    if (!placedControls && liveControls.length) placedControls = true;
+    pages.push({ id: sigmaShortId(), name: bp.name, elements: pageEls });
+  }
+
+  // Hidden base-table sourcing roots live on a trailing "Data" page; its id
+  // starts with "data" — the cross-plugin convention layout gates use to
+  // exempt utility pages from dashboard-layout checks.
+  if (baseTables.length) {
+    pages.push({ id: `data${sigmaShortId()}`, name: 'Data', elements: baseTables });
+  }
+
+  // one aggregated warning per parameter that drives native template tags
+  // (per-mapping warnings would be thousands of lines on production estates)
+  if (tagWirings.length) {
+    const bySlug = new Map<string, typeof tagWirings>();
+    for (const w of tagWirings) { (bySlug.get(w.slug) || bySlug.set(w.slug, []).get(w.slug)!).push(w); }
+    for (const [slug, ws] of bySlug) {
+      const tags = [...new Set(ws.map((w) => w.tag))];
+      warnings.push(`parameter "${ws[0].parameter}" (control "${slug}") drives native template tag${tags.length > 1 ? 's' : ''} {{${tags.join('}}, {{')}}} across ${ws.length} card(s) — the DM converter emits the matching {{tag}} control(s); consolidate: either reference the DM control directly or sync this workbook control's value to it (see parameterWiring in the result + refs/template-tags.md).`);
+    }
+  }
+
+  const allEls = pages.filter((p) => p.name !== 'Data').flatMap((p) => p.elements).filter((e) => e.kind !== 'control');
+  const stats = {
+    dashcards: dcs.length,
+    pages: pages.length,
+    tables: allEls.filter((e) => e.kind === 'table').length,
+    pivots: allEls.filter((e) => e.kind === 'pivot-table').length,
+    kpis: allEls.filter((e) => e.kind === 'kpi-chart').length,
+    charts: allEls.filter((e) => e.kind.endsWith('-chart') && e.kind !== 'kpi-chart').length,
+    maps: allEls.filter((e) => e.kind.endsWith('-map')).length,
+    texts: allEls.filter((e) => e.kind === 'text').length,
+    columns: allEls.reduce((n, e) => n + (e.columns?.length || 0), 0),
+    filters: allEls.reduce((n, e) => n + (e.filters?.length || 0), 0),
+    controls: liveControls.length,
+    baseTables: baseTables.length,
+  };
+
+  // control-scope.json sidecar (shared cross-plugin contract — control_lint.rb
+  // header CONTRACT + refs/control-parity.md). Signals = mapped parameters;
+  // scope = each control's DECLARED card targets (converted element names);
+  // mustReach = the subset the converter actually wired. dm-bound controls
+  // (variable-tag → control.parameters via remap --dm-spec) carry their scope
+  // as declared intent — if the org rejects the binding, post-and-readback
+  // drops them and patches this sidecar (see scripts/post-and-readback.mjs).
+  const controlScope: ControlScopeSidecar = {
+    version: 1, source: 'metabase',
+    sourceFilterSignals: [...mappingCountByParam.keys()].filter((id) => paramById.has(id)).length,
+    controls: liveControls.map((c) => ({
+      controlId: c.controlId,
+      sourceName: `Metabase parameter "${c.name}"${dmBoundSlugs.has(c.controlId) ? ' (drives native {{tag}}s via DM-parameter binding)' : ''}`,
+      scope: [...(scopeBySlug.get(c.controlId) || [])],
+      mustReach: [...(reachBySlug.get(c.controlId) || [])],
+    })),
+  };
+
+  return {
+    workbook: { name, schemaVersion: 1, pages, controls: liveControls },
+    warnings, stats, layout, controlScope,
+    ...(tagWirings.length ? { parameterWiring: tagWirings } : {}),
+    ...(unreproducibleFilters.length ? { unreproducibleFilters } : {}),
+  };
+}

--- a/metabase-migration-skills/metabase-to-sigma/converter/metabase.ts
+++ b/metabase-migration-skills/metabase-to-sigma/converter/metabase.ts
@@ -1,0 +1,1049 @@
+/**
+ * Metabase → Sigma Data Model converter.   [LIVE-VALIDATED 2026-06-11 — exact parity; see refs/design-notes.md §10]
+ *
+ * Input = plain REST JSON (see refs/rest-api.md):
+ *   { metadata?: <GET /api/database/{id}/metadata>, cards: [<GET /api/card/{id}>, …],
+ *     sandboxes?: [<GET /api/mt/gtap> entries — EE row sandboxing, detect-only] }
+ *
+ * Mapping (refs/design-notes.md decisions 1–8):
+ *   referenced warehouse table         → `warehouse-table` element (all metadata fields as raw columns)
+ *   MBQL card with `joins`             → its own element with a `join` source (left/right/inner/full)
+ *   nested question (source "card__N") → element sourced from card N's element (kind:'table')
+ *   native SQL card                    → sql-source element (statement verbatim; NO element name;
+ *                                        {{tags}} flagged with the control to create)
+ *   `expressions`                      → calculated columns (translateMbqlExpr)
+ *   `aggregation` (+ aggregation-options names) → element metrics
+ *   breakout temporal-unit             → DateTrunc calc column
+ *   fk_target_field_id (both tables present)    → DM relationship + derived join view
+ *   sandboxes                          → `security` (DETECT-ONLY — never injected into the model)
+ *
+ * MBQL arrives already parsed (nested JSON arrays), so translateMbqlExpr walks a
+ * tree — no regex DSL parsing. Every row of refs/expression-dsl.md is implemented;
+ * flagged ops (cum-sum, offset, segment, metric, binning) emit a readable
+ * "unmapped" comment placeholder + a loud warning — never silent, never faked.
+ */
+
+import {
+  resetIds, sigmaShortId, sigmaInodeId, sigmaDisplayName, sigmaColFormula,
+  inferSigmaFormat, buildDerivedElements,
+  type SigmaElement, type SigmaColumn, type SigmaMetric, type ConversionResult,
+} from './sigma-ids.js';
+// pMBQL ("lib/" MBQL) → legacy MBQL — modern instances (Cloud v1.61+) return
+// dataset_query as {"lib/type":"mbql/query","stages":[…]}; normalize at intake.
+import { normalizeCard } from './pmbql-normalize.mjs';
+
+// ── options / shared types ────────────────────────────────────────────────────
+
+export interface LearnedRule { pattern: string; template: string; flags?: string }
+
+export type WarehouseDialect = 'bigquery' | 'snowflake' | 'databricks' | 'redshift' | 'postgres' | 'mysql' | 'athena' | 'unknown';
+
+export interface MetabaseConvertOptions {
+  connectionId?: string;
+  database?: string;       // warehouse database for source paths (e.g. CSA)
+  schema?: string;         // overrides table.schema when set
+  modelName?: string;
+  warehouse?: WarehouseDialect;  // drives SQL dialect transforms (array agg, etc.)
+  // Customer-discovered translation rules (gap-scout, ~/.metabase-to-sigma/learned-rules.json).
+  // Applied BEFORE the built-in translator: a rule whose regex matches the FULL
+  // JSON serialization of an MBQL node wins (template may use $1.. captures).
+  learnedRules?: LearnedRule[];
+}
+
+/**
+ * Apply warehouse-specific SQL transforms to a native SQL statement.
+ * Called after tag rewriting, before the statement is written to the spec.
+ *
+ * Currently handles the single most common rendering failure:
+ *   Array aggregations — Sigma cannot display array/nested types in table cells.
+ *   Each warehouse has a different string-aggregation idiom.
+ */
+export function applyWarehouseTransforms(sql: string, warehouse: WarehouseDialect): string {
+  switch (warehouse) {
+    case 'bigquery':
+      // ARRAY_AGG(x [IGNORE NULLS]) → array_to_string(ARRAY_AGG(x [IGNORE NULLS]), ', ')
+      // Skip if already wrapped to avoid double-wrapping on re-runs.
+      return sql.replace(
+        /\bARRAY_AGG\s*(\([^)]+(?:\s+IGNORE\s+NULLS)?\)(?:\s+IGNORE\s+NULLS)?)/gi,
+        (m) => m.toLowerCase().includes('array_to_string') ? m : `array_to_string(${m}, ', ')`,
+      );
+    case 'snowflake':
+      // Snowflake ARRAY_AGG returns VARIANT — Sigma renders it as "[object]".
+      // LISTAGG is simpler and returns a plain string.
+      return sql.replace(
+        /\bARRAY_AGG\s*\(([^)]+)\)/gi,
+        (_m, arg) => `LISTAGG(${arg}, ', ')`,
+      );
+    case 'databricks':
+      // collect_list(x) returns an array type — wrap in array_join.
+      return sql.replace(
+        /\bcollect_list\s*\(([^)]+)\)/gi,
+        (_m, arg) => `array_join(collect_list(${arg}), ', ')`,
+      );
+    case 'redshift':
+    case 'postgres':
+      // STRING_AGG is ANSI and works on both.
+      return sql.replace(
+        /\bARRAY_AGG\s*\(([^)]+)\)/gi,
+        (_m, arg) => `STRING_AGG(CAST(${arg} AS VARCHAR), ', ')`,
+      );
+    case 'athena':
+      // Athena (Trino): array_join(array_agg(x), ', ')
+      return sql.replace(
+        /\bARRAY_AGG\s*\(([^)]+)\)/gi,
+        (_m, arg) => `array_join(array_agg(${arg}), ', ')`,
+      );
+    default:
+      return sql;
+  }
+}
+
+export interface MetabaseFieldInfo {
+  id: number; tableId: number; tableName: string; schema?: string;
+  columnName: string; displayName: string; baseType?: string;
+  fkTargetFieldId?: number | null;
+}
+export interface MetabaseTableInfo { id: number; name: string; schema?: string; fields: MetabaseFieldInfo[]; }
+export interface FieldIndex { byId: Map<number, MetabaseFieldInfo>; tableById: Map<number, MetabaseTableInfo>; tableByLeaf: Map<string, number>; }
+
+/** GET /api/database/{id}/metadata → field-id index (MBQL refs columns by integer id). */
+export function buildFieldIndex(metadata: any): FieldIndex {
+  const byId = new Map<number, MetabaseFieldInfo>();
+  const tableById = new Map<number, MetabaseTableInfo>();
+  const tableByLeaf = new Map<string, number>();
+  for (const t of metadata?.tables || []) {
+    const ti: MetabaseTableInfo = { id: t.id, name: t.name, schema: t.schema, fields: [] };
+    for (const f of t.fields || []) {
+      const fi: MetabaseFieldInfo = {
+        id: f.id, tableId: t.id, tableName: t.name, schema: t.schema,
+        columnName: f.name,
+        // Sigma-derived display name (NOT Metabase's display_name) so sibling
+        // bracket refs resolve against the raw-column auto-derived name.
+        displayName: sigmaDisplayName(f.name),
+        baseType: f.base_type, fkTargetFieldId: f.fk_target_field_id ?? null,
+      };
+      ti.fields.push(fi); byId.set(f.id, fi);
+    }
+    tableById.set(t.id, ti);
+    if (t.name) tableByLeaf.set(String(t.name).toLowerCase(), t.id);
+  }
+  return { byId, tableById, tableByLeaf };
+}
+
+// ── simple native-SQL → native-model recognizer ─────────────────────────────
+// A native-SQL card that is just a single SELECT over warehouse table(s) is
+// re-expressed as a structured (MBQL) query so it converts to a NATIVE Sigma
+// data model (table/join source, raw columns, aggregation metrics) instead of a
+// custom-SQL element. That is what makes its dashboard filters reproducible: the
+// underlying columns are exposed, so Sigma controls/element-filters work natively
+// (custom-SQL {{param}} filtering is inert from the workbook — live-disproven).
+// Returns a synthetic { 'source-table', joins?, aggregation?, breakout? } query,
+// or null when the SQL is too complex (CTE / subquery / CASE / window / set-op /
+// non-field-filter variable tag) — those fall back to a flagged custom-SQL element.
+const LEAF = (path: string) => String(path).trim().replace(/[`"\];]/g, '').split('.').pop()!.toLowerCase();
+const AGG_FN: Record<string, string> = { sum: 'sum', avg: 'avg', count: 'count', min: 'min', max: 'max', 'count_distinct': 'distinct', median: 'median', stddev: 'stddev' };
+
+export function recognizeSimpleNativeSql(card: any, fidx?: FieldIndex): any | null {
+  if (!fidx) return null;
+  const dq = card?.dataset_query;
+  if (!dq || dq.type !== 'native') return null;
+  let sql = String(dq.native?.query || '');
+  const tags: Record<string, any> = dq.native?.['template-tags'] || {};
+  if (!sql.trim()) return null;
+  sql = sql.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/--[^\n]*/g, ' ').replace(/\s+/g, ' ').trim();
+  // bail on anything we will not model faithfully
+  if (/^\s*with\b/i.test(sql)) return null;
+  if (/\b(union|intersect|except|having)\b/i.test(sql)) return null;
+  if (/\bover\s*\(/i.test(sql) || /\bcase\b/i.test(sql) || /\(\s*select\b/i.test(sql)) return null;
+  // only field-filter (dimension) tags are reproducible without custom SQL;
+  // a bare {{value}} variable tag needs SQL substitution → keep as custom SQL.
+  for (const t of Object.values(tags)) if (String(t?.type).toLowerCase() !== 'dimension') return null;
+
+  // split top-level clauses (safe: no subqueries past the guards above)
+  const find = (kw: RegExp) => { const m = kw.exec(sql); return m ? m.index : -1; };
+  if (!/^\s*select\b/i.test(sql)) return null;
+  const iFrom = find(/\bfrom\b/i); if (iFrom < 0) return null;
+  const iWhere = find(/\bwhere\b/i);
+  const iGroup = find(/\bgroup\s+by\b/i);
+  const iOrder = find(/\border\s+by\b/i);
+  const bound = (start: number) => {
+    const ends = [iWhere, iGroup, iOrder].filter((x) => x > start);
+    return ends.length ? Math.min(...ends) : sql.length;
+  };
+  const selectList = sql.slice(sql.search(/select\b/i) + 6, iFrom).trim();
+  const fromClause = sql.slice(iFrom + 4, bound(iFrom)).trim();
+  const groupClause = iGroup >= 0 ? sql.slice(iGroup + sql.slice(iGroup).match(/^group\s+by/i)![0].length, bound(iGroup)).trim() : '';
+  // WHERE must contain ONLY field-filter tags (which we surface as Sigma controls/
+  // element-filters) and trivial 1=1 / [[optional]] markers — anything else is a
+  // real predicate that the remodel would SILENTLY DROP (wrong numbers). Bail to
+  // custom SQL in that case (never silently mistranslate). Also bail on LIMIT.
+  const whereClause = iWhere >= 0 ? sql.slice(iWhere + 5, bound(iWhere)).trim() : '';
+  if (whereClause) {
+    const residual = whereClause
+      .replace(/\{\{\s*[^}]+\s*\}\}/g, ' ').replace(/\[\[|\]\]/g, ' ')
+      .replace(/\b1\s*=\s*1\b/g, ' ').replace(/\b(and|or)\b/gi, ' ')
+      .replace(/[()\s]+/g, '');
+    if (residual) return null;
+  }
+  if (/\blimit\b\s+\d/i.test(sql)) return null;
+
+  // FROM + JOINs → alias→tableId map (first source = base)
+  const aliasTable = new Map<string, number>();
+  let baseTableId: number | null = null;
+  const joins: any[] = [];
+  // tokenize: base then repeated "[type] join <path> [as] <alias> on <cond>"
+  const joinRe = /\b(?:(inner|left|right|full)\s+)?(?:outer\s+)?join\b/gi;
+  const firstJoin = sql.slice(iFrom).search(joinRe);
+  const baseSeg = (firstJoin < 0 ? fromClause : sql.slice(iFrom + 4, iFrom + firstJoin)).trim();
+  const parseRef = (seg: string): { tid: number; alias?: string } | null => {
+    const parts = seg.trim().split(/\s+/);
+    const tid = fidx.tableByLeaf?.get(LEAF(parts[0]));
+    if (tid == null) return null;
+    let alias: string | undefined;
+    if (parts.length >= 3 && /^as$/i.test(parts[1])) alias = parts[2];
+    else if (parts.length === 2) alias = parts[1];
+    return { tid, alias };
+  };
+  const baseRef = parseRef(baseSeg); if (!baseRef) return null;
+  baseTableId = baseRef.tid; if (baseRef.alias) aliasTable.set(baseRef.alias.toLowerCase(), baseRef.tid);
+  // walk joins
+  const joinClause = firstJoin < 0 ? '' : sql.slice(iFrom + firstJoin, bound(iFrom));
+  if (joinClause) {
+    const segRe = /\b(?:(inner|left|right|full)\s+)?(?:outer\s+)?join\b\s+([\s\S]+?)\s+on\s+([\s\S]+?)(?=\b(?:inner\s+|left\s+|right\s+|full\s+)?(?:outer\s+)?join\b|$)/gi;
+    let jm: RegExpExecArray | null;
+    while ((jm = segRe.exec(joinClause))) {
+      const [, jtype, jref, jcond] = jm;
+      const r = parseRef(jref); if (!r) return null;
+      if (r.alias) aliasTable.set(r.alias.toLowerCase(), r.tid);
+      const cm = /([\w.]+)\s*=\s*([\w.]+)/.exec(jcond); if (!cm) return null;
+      const resolveCol = (tok: string): any | null => {
+        const [a, c] = tok.includes('.') ? tok.split('.') : [undefined, tok];
+        const tid = a ? aliasTable.get(a.toLowerCase()) ?? baseTableId : baseTableId;
+        const f = tid != null ? fidx.tableById.get(tid)?.fields.find((x) => x.columnName.toLowerCase() === c.toLowerCase()) : undefined;
+        return f ? ['field', f.id, a && aliasTable.get(a.toLowerCase()) !== baseTableId ? { 'join-alias': a } : null] : null;
+      };
+      const L = resolveCol(cm[1]), R = resolveCol(cm[2]); if (!L || !R) return null;
+      joins.push({ 'source-table': r.tid, strategy: `${(jtype || 'left').toLowerCase()}-join`, alias: r.alias,
+        condition: ['=', L, R] });
+    }
+  }
+
+  // resolve a "[alias.]col" token to a field ref
+  const colRef = (tok: string): any | null => {
+    const [a, c] = tok.includes('.') ? tok.split('.') : [undefined, tok];
+    const tid = a ? aliasTable.get(a.toLowerCase()) : baseTableId;
+    if (tid == null) return null;
+    const f = fidx.tableById.get(tid)?.fields.find((x) => x.columnName.toLowerCase() === c.replace(/[`"]/g, '').toLowerCase());
+    return f ? ['field', f.id, a && tid !== baseTableId ? { 'join-alias': a } : null] : null;
+  };
+
+  // SELECT list → aggregations + plain dimensions. Track each item's output ALIAS
+  // (explicit `as X`, else the column/function name) so the dashboard can re-map
+  // the card's viz settings (graph.dimensions/metrics reference these aliases).
+  const items = selectList.split(/,(?![^(]*\))/).map((s) => s.trim());
+  if (items.some((s) => !s)) return null;   // trailing/empty comma (e.g. BQ `…, from`) — don't trust the parse; keep verbatim SQL
+  const aggregation: any[] = [];
+  const breakout: any[] = [];
+  const resultMetadata: any[] = [];
+  const explicitAlias = (it: string): string | null => { const m = /\s+as\s+(["`\w]+)\s*$/i.exec(it); return m ? m[1].replace(/["`]/g, '') : null; };
+  for (const it of items) {
+    const expr = it.replace(/\s+as\s+["`\w]+\s*$/i, '').trim();
+    const am = /^(\w+)\s*\(\s*(distinct\s+)?(.+?)\s*\)$/i.exec(expr);
+    if (am && AGG_FN[am[1].toLowerCase()]) {
+      const fn = AGG_FN[(am[2] ? 'count_distinct' : am[1]).toLowerCase()] || AGG_FN[am[1].toLowerCase()];
+      const arg = am[3].trim();
+      const aggIdx = aggregation.length;
+      if (arg === '*' || /^\d+$/.test(arg)) aggregation.push(['count']);
+      else { const ref = colRef(arg); if (!ref) return null; aggregation.push([fn, ref]); }
+      const alias = explicitAlias(it) || am[1].toLowerCase();
+      resultMetadata.push({ name: alias, display_name: alias, field_ref: ['aggregation', aggIdx] });
+      continue;
+    }
+    if (!/^[\w.`"]+$/.test(expr)) return null;       // reject non-trivial expressions
+    const ref = colRef(expr); if (!ref) return null;
+    const alias = explicitAlias(it) || expr.split('.').pop()!.replace(/[`"]/g, '');
+    breakout.push(ref);
+    resultMetadata.push({ name: alias, display_name: alias, field_ref: ref });
+  }
+  // If a GROUP BY is present it defines the dimension grain; honor it (ordinals
+  // map to the Nth select item). Otherwise the SELECT dims are the breakout.
+  if (groupClause) {
+    breakout.length = 0;
+    for (const g of groupClause.split(/,(?![^(]*\))/).map((s) => s.trim()).filter(Boolean)) {
+      if (/^\d+$/.test(g)) { const rm = resultMetadata[Number(g) - 1]; if (rm && Array.isArray(rm.field_ref) && rm.field_ref[0] === 'field') breakout.push(rm.field_ref); continue; }
+      const ref = colRef(g); if (!ref) return null;
+      breakout.push(ref);
+    }
+  }
+  // Surface every field-filter tag's mapped column as an extra breakout dimension
+  // (so it lands in the result set + the element exposes it) — that is what lets
+  // the dashboard reproduce the filter as a native Sigma control/element-filter.
+  // It is NOT added to the viz, so it never becomes an unwanted chart axis.
+  for (const t of Object.values(tags)) {
+    const dim = (t as any).dimension;
+    const fid = Array.isArray(dim) && dim[0] === 'field' && typeof dim[1] === 'number' ? dim[1] : null;
+    if (fid == null || resultMetadata.some((rm) => Array.isArray(rm.field_ref) && rm.field_ref[1] === fid)) continue;
+    const f = fidx.byId.get(fid); if (!f) continue;
+    breakout.push(dim);
+    resultMetadata.push({ name: f.columnName, display_name: f.columnName, field_ref: dim });
+  }
+
+  const query = { database: dq.database, 'source-table': baseTableId, ...(joins.length ? { joins } : {}),
+    ...(aggregation.length ? { aggregation } : {}), ...(breakout.length ? { breakout } : {}) };
+  return { query, resultMetadata };
+}
+
+// ── MBQL expression tree → Sigma formula ─────────────────────────────────────
+
+export interface MbqlCtx {
+  /** ["field", id|name, opts] → bracketed Sigma ref (DateTrunc-wrapped if temporal-unit). */
+  resolveField: (ref: any) => string;
+  /** Same ref → bare display name (for naming metrics/columns). */
+  fieldDisplay: (ref: any) => string;
+  warn: (msg: string) => void;
+  learnedRules?: LearnedRule[];
+}
+
+const DATEPART: Record<string, string> = {
+  'get-year': 'year', 'get-quarter': 'quarter', 'get-month': 'month', 'get-week': 'week',
+  'get-day': 'day', 'get-day-of-week': 'dayofweek', 'get-hour': 'hour',
+  'get-minute': 'minute', 'get-second': 'second',
+};
+
+export function translateMbqlExpr(node: any, ctx: MbqlCtx): string {
+  // Learned rules first — a validated customer rule beats the built-in translation.
+  // Contract mirrors cognos applyLearnedRules: regex pattern → template, but matched
+  // against the FULL JSON serialization of the node (MBQL is a tree, not a string).
+  if (ctx.learnedRules?.length && typeof node === 'object' && node !== null) {
+    const json = JSON.stringify(node);
+    for (const r of ctx.learnedRules) {
+      try {
+        const re = new RegExp(r.pattern, r.flags || '');
+        const m = json.match(re);
+        if (m && m.index === 0 && m[0].length === json.length) return json.replace(re, r.template);
+      } catch { /* bad rule — skip */ }
+    }
+  }
+  if (node === null || node === undefined) return 'Null';
+  if (typeof node === 'number') return String(node);
+  if (typeof node === 'boolean') return node ? 'True' : 'False';
+  if (typeof node === 'string') return `"${node.replace(/"/g, '\\"')}"`;
+  if (!Array.isArray(node)) {
+    ctx.warn(`unrecognized MBQL node ${JSON.stringify(node).slice(0, 60)} — emitted a placeholder.`);
+    return `/* unmapped: ${JSON.stringify(node).slice(0, 40)} */`;
+  }
+
+  const op = String(node[0]).toLowerCase();
+  const t = (x: any) => translateMbqlExpr(x, ctx);
+  const args = () => node.slice(1).map(t);
+
+  switch (op) {
+    case 'field': return ctx.resolveField(node);
+    case 'expression': return `[${node[1]}]`;                 // sibling custom-column ref
+    case 'value': return t(node[1]);                          // literal wrapper unwraps transparently
+
+    // n-ary arithmetic → left-fold binary
+    case '+': case '-': case '*': case '/': {
+      const a = args();
+      return a.length === 1 ? a[0] : a.reduce((acc, x) => `(${acc} ${op} ${x})`);
+    }
+
+    case 'case': {
+      const clauses: any[] = node[1] || [];
+      const dflt = node[2] && typeof node[2] === 'object' && 'default' in node[2] ? t(node[2].default) : 'Null';
+      let out = dflt;
+      for (let i = clauses.length - 1; i >= 0; i--) out = `If(${t(clauses[i][0])}, ${t(clauses[i][1])}, ${out})`;
+      return out;
+    }
+
+    case 'coalesce': return `Coalesce(${args().join(', ')})`;
+    case 'concat': return `Concat(${args().join(', ')})`;
+    case 'substring': return node[3] !== undefined
+      ? `Mid(${t(node[1])}, ${t(node[2])}, ${t(node[3])})` : `Mid(${t(node[1])}, ${t(node[2])})`;
+    case 'trim': return `Trim(${t(node[1])})`;
+    case 'ltrim': return `LTrim(${t(node[1])})`;
+    case 'rtrim': return `RTrim(${t(node[1])})`;
+    case 'upper': return `Upper(${t(node[1])})`;
+    case 'lower': return `Lower(${t(node[1])})`;
+    case 'length': return `Len(${t(node[1])})`;
+    case 'replace': return `Replace(${t(node[1])}, ${t(node[2])}, ${t(node[3])})`;
+    case 'regex-match-first': return `RegexpExtract(${t(node[1])}, ${t(node[2])})`;
+    case 'split-part': return `SplitPart(${t(node[1])}, ${t(node[2])}, ${t(node[3])})`;
+
+    case 'round': return `Round(${args().join(', ')})`;
+    case 'floor': return `Floor(${t(node[1])})`;
+    case 'ceil': return `Ceiling(${t(node[1])})`;
+    case 'abs': return `Abs(${t(node[1])})`;
+    case 'sqrt': return `Sqrt(${t(node[1])})`;
+    case 'exp': return `Exp(${t(node[1])})`;
+    case 'power': return `Power(${t(node[1])}, ${t(node[2])})`;
+    case 'log': return `Log(${t(node[1])}, 10)`;              // Metabase log is base-10
+
+    case 'datetime-add': return `DateAdd("${node[3]}", ${t(node[2])}, ${t(node[1])})`;
+    case 'datetime-subtract': {
+      const n = node[2];
+      const neg = typeof n === 'number' ? String(-n) : `-(${t(n)})`;
+      return `DateAdd("${node[3]}", ${neg}, ${t(node[1])})`;
+    }
+    case 'datetime-diff': return `DateDiff("${node[3]}", ${t(node[1])}, ${t(node[2])})`;
+    case 'get-year': case 'get-quarter': case 'get-month': case 'get-week':
+    case 'get-day': case 'get-day-of-week': case 'get-hour': case 'get-minute': case 'get-second':
+      return `DatePart("${DATEPART[op]}", ${t(node[1])})`;
+    case 'now': return 'Now()';
+    case 'relative-datetime':
+      return node[1] === 'current' ? 'Today()' : `DateAdd("${node[2]}", ${t(node[1])}, Today())`;
+
+    // type casts (Metabase 50+ expression functions)
+    case 'text': return `Text(${t(node[1])})`;
+    case 'integer': return `Int(${t(node[1])})`;
+    case 'float': return `Number(${t(node[1])})`;
+    case 'date': return `DateTrunc("day", ${t(node[1])})`;   // date(x) = day-truncated datetime
+
+    // comparisons — multi-value `=` ⇒ infix `or` chain; multi `!=` ⇒ infix `and` chain.
+    // Sigma has NO IsIn, and NO Or()/And() FUNCTIONS either — `Or(a, b)` returns
+    // "Invalid formula" at POST (live-verified 2026-06-12); and/or are infix only.
+    // (pMBQL `in`/`not-in` are normalized to multi-value =/!= upstream; aliased here too)
+    case 'in': case 'not-in': case '=': case '!=': {
+      const eq = op === '=' || op === 'in' ? '=' : '!=';
+      const a = t(node[1]);
+      const vals = node.slice(2).map(t);
+      if (vals.length <= 1) return `${a} ${eq} ${vals[0] ?? 'Null'}`;
+      const parts = vals.map((v: string) => `${a} ${eq} ${v}`);
+      return eq === '=' ? `(${parts.join(' or ')})` : `(${parts.join(' and ')})`;
+    }
+    case '<': case '<=': case '>': case '>=':
+      return `${t(node[1])} ${op} ${t(node[2])}`;
+    case 'between': return `Between(${t(node[1])}, ${t(node[2])}, ${t(node[3])})`;
+    case 'and': return `(${args().join(' and ')})`;
+    case 'or': return `(${args().join(' or ')})`;
+    case 'not': return `Not(${t(node[1])})`;
+    case 'is-null': return `IsNull(${t(node[1])})`;
+    case 'not-null': return `IsNotNull(${t(node[1])})`;
+    case 'is-empty': return `(IsNull(${t(node[1])}) or ${t(node[1])} = "")`;
+    case 'not-empty': return `(IsNotNull(${t(node[1])}) and ${t(node[1])} != "")`;
+
+    case 'starts-with': case 'ends-with': case 'contains': case 'does-not-contain': {
+      const fn = op === 'starts-with' ? 'StartsWith' : op === 'ends-with' ? 'EndsWith' : 'Contains';
+      const opts = node[3] && typeof node[3] === 'object' ? node[3] : {};
+      const caseSensitive = opts['case-sensitive'] === true;
+      const s = t(node[1]), sub = t(node[2]);
+      // Metabase string matching is case-INSENSITIVE by default — wrap in Lower()
+      const body = caseSensitive ? `${fn}(${s}, ${sub})` : `${fn}(Lower(${s}), Lower(${sub}))`;
+      return op === 'does-not-contain' ? `Not(${body})` : body;
+    }
+
+    case 'time-interval': {
+      const f = t(node[1]); const n = node[2]; const unit = node[3];
+      if (n === 'current') return `DateTrunc("${unit}", ${f}) = DateTrunc("${unit}", Today())`;
+      return typeof n === 'number' && n > 0
+        ? `${f} <= DateAdd("${unit}", ${n}, Today())`
+        : `${f} >= DateAdd("${unit}", ${typeof n === 'number' ? n : t(n)}, Today())`;
+    }
+    case 'inside': {
+      // ["inside", latField, lonField, latMax, lonMin, latMin, lonMax] → lat/lon Between pair
+      const [lat, lon, latMax, lonMin, latMin, lonMax] = node.slice(1).map(t);
+      return `(Between(${lat}, ${latMin}, ${latMax}) and Between(${lon}, ${lonMin}, ${lonMax}))`;
+    }
+
+    // ── aggregations (legal at the top of an aggregation clause) ──────────────
+    case 'count': return 'Count()';
+    case 'sum': return `Sum(${t(node[1])})`;
+    case 'avg': return `Avg(${t(node[1])})`;
+    case 'min': return `Min(${t(node[1])})`;
+    case 'max': return `Max(${t(node[1])})`;
+    case 'median': return `Median(${t(node[1])})`;
+    case 'distinct': return `CountDistinct(${t(node[1])})`;
+    case 'stddev': return `StdDev(${t(node[1])})`;
+    case 'var': return `Variance(${t(node[1])})`;
+    case 'percentile': return `Percentile(${t(node[1])}, ${t(node[2])})`;
+    case 'count-where': return `CountIf(${t(node[1])})`;            // condition only — no field arg
+    case 'sum-where': return `SumIf(${t(node[1])}, ${t(node[2])})`; // FIELD FIRST
+    case 'share': return `CountIf(${t(node[1])}) / Count()`;
+    case 'aggregation-options': return t(node[1]);                  // wrapper only supplies the name
+
+    // ── flagged — never faked ──────────────────────────────────────────────────
+    case 'cum-sum': case 'cum-count':
+      ctx.warn(`"${op}" is a running total — rebuild with CumulativeSum in the date-grouped workbook element (window scope lives on the consuming element).`);
+      return `/* unmapped: ${op} */`;
+    case 'offset':
+      ctx.warn('"offset" is a lag/lead window function — rebuild with Lag/window calc in the consuming element.');
+      return '/* unmapped: offset */';
+    case 'segment':
+      ctx.warn(`["segment", ${node[1]}] references a saved segment — inline its MBQL from GET /api/segment/${node[1]} and re-run.`);
+      return `/* unmapped: segment ${node[1]} */`;
+    case 'metric':
+      ctx.warn(`["metric", ${node[1]}] references a saved (legacy) metric — inline its MBQL from GET /api/legacy-metric/${node[1]} and re-run.`);
+      return `/* unmapped: metric ${node[1]} */`;
+    case 'aggregation':
+      ctx.warn(`["aggregation", ${node[1]}] positional ref outside order-by — not resolvable here.`);
+      return `/* unmapped: aggregation ${node[1]} */`;
+
+    default:
+      ctx.warn(`MBQL op "${op}" has no confirmed Sigma mapping — emitted a placeholder; review/translate manually.`);
+      return `/* unmapped: ${op} */`;
+  }
+}
+
+const AGG_LABEL: Record<string, (d: string) => string> = {
+  count: () => 'Count',
+  sum: (d) => `Sum of ${d}`, avg: (d) => `Average of ${d}`, min: (d) => `Min of ${d}`,
+  max: (d) => `Max of ${d}`, median: (d) => `Median of ${d}`,
+  distinct: (d) => `Distinct Count of ${d}`, stddev: (d) => `StdDev of ${d}`,
+  var: (d) => `Variance of ${d}`, percentile: (d) => `Percentile of ${d}`,
+  'count-where': () => 'Count of Matching Rows', 'sum-where': (d) => `Sum of ${d} (Filtered)`,
+  share: () => 'Share of Matching Rows',
+  'cum-sum': (d) => `Cumulative Sum of ${d}`, 'cum-count': () => 'Cumulative Count',
+};
+
+/** Aggregation clause → { formula, name } — named via aggregation-options, else derived ("Sum of Revenue"). */
+export function translateAggregation(node: any, ctx: MbqlCtx): { formula: string; name: string } {
+  let inner = node; let name: string | undefined;
+  if (Array.isArray(node) && String(node[0]).toLowerCase() === 'aggregation-options') {
+    inner = node[1];
+    const o = node[2] || {};
+    name = o['display-name'] || (o.name ? sigmaDisplayName(o.name) : undefined);
+  }
+  const formula = translateMbqlExpr(inner, ctx);
+  if (!name) {
+    const op = Array.isArray(inner) ? String(inner[0]).toLowerCase() : '';
+    const fieldRef = Array.isArray(inner) ? inner.find((x: any) => Array.isArray(x) && x[0] === 'field') : undefined;
+    const disp = fieldRef ? ctx.fieldDisplay(fieldRef) : '';
+    name = AGG_LABEL[op] ? AGG_LABEL[op](disp) : sigmaDisplayName(op || 'Metric');
+  }
+  return { formula, name };
+}
+
+// ── convert ───────────────────────────────────────────────────────────────────
+
+// Live-verified enum: inner | left-outer | right-outer | full-outer | lookup.
+const JOIN_TYPE: Record<string, string> = {
+  'left-join': 'left-outer', 'right-join': 'right-outer', 'inner-join': 'inner', 'full-join': 'full-outer',
+};
+const titleCase = (s: string) => (s ? s.charAt(0).toUpperCase() + s.slice(1) : s);
+
+function normalizeInput(input: any): { metadata?: any; cards: any[]; sandboxes?: any[] } {
+  const root = typeof input === 'string' ? JSON.parse(input) : input;
+  // pMBQL → legacy at extraction intake; per-card sniff (a list may mix formats).
+  const norm = (cs: any[]) => (cs || []).map((c) => normalizeCard(c));
+  if (Array.isArray(root)) return { cards: norm(root) };
+  if (root?.cards) return { metadata: root.metadata, cards: norm(root.cards), sandboxes: root.sandboxes };
+  if (root?.dataset_query) return { cards: norm([root]) };
+  return { metadata: root?.metadata, cards: [], sandboxes: root?.sandboxes };
+}
+
+export function convertMetabaseToSigma(input: string | object, options: MetabaseConvertOptions = {}): ConversionResult {
+  resetIds();
+  const { connectionId = '<CONNECTION_ID>', database = '', schema = '' } = options;
+  const warnings: string[] = [];
+  const inp = normalizeInput(input);
+  const fidx = inp.metadata ? buildFieldIndex(inp.metadata) : null;
+  if (!fidx) warnings.push("no database metadata provided — falling back to each card's result_metadata names (table qualifiers are lost); pass GET /api/database/{id}/metadata as input.metadata.");
+
+  // Engine-aware database default when --database is omitted: Metabase metadata
+  // carries the warehouse identifier in engine-specific `details` keys
+  // (Snowflake `db`; BigQuery `project-id` — Sigma BQ paths are [project, dataset, table]).
+  const metaEngine: string = inp.metadata?.engine || '';
+  const metaDb: string = (() => {
+    const d = inp.metadata?.details || {};
+    const keys = /bigquery/.test(metaEngine)
+      ? ['project-id', 'project-id-from-credentials']
+      : ['db', 'dbname', 'database'];
+    for (const k of keys) if (typeof d[k] === 'string' && d[k]) return d[k];
+    return '';
+  })();
+
+  interface ElemCtx {
+    element: SigmaElement; columns: SigmaColumn[]; metrics: SigmaMetric[]; order: string[];
+    colIdByName: Map<string, string>; colIdByFieldId: Map<number, string>;
+    ownedByCard: boolean;   // card-specific element (join/nested/sql) — safe for element filters
+  }
+  const elemCtxs: ElemCtx[] = [];
+  const tableCtxByTableId = new Map<number, ElemCtx>();
+  const newCtx = (element: SigmaElement, ownedByCard: boolean): ElemCtx => {
+    const c: ElemCtx = {
+      element, columns: element.columns as SigmaColumn[], metrics: [], order: element.order as string[],
+      colIdByName: new Map(), colIdByFieldId: new Map(), ownedByCard,
+    };
+    elemCtxs.push(c); return c;
+  };
+
+  const tablePath = (t: MetabaseTableInfo): string[] => {
+    const path: string[] = [database || metaDb || '<DATABASE>'];
+    // Per-table schema FIRST — estates span schemas/datasets; --schema is only a
+    // fallback for metadata that omits it.
+    const sch = t.schema || schema || '';
+    if (sch) path.push(sch);
+    // Preserve case: Snowflake metadata reports uppercase physical names already;
+    // BigQuery (case-sensitive) reports lowercase — uppercasing breaks BQ paths
+    // AND the formula prefixes that must match the path tail (live-verified:
+    // [accounts/Account Id] on path […, 'accounts'] resolves; ACCOUNTS would not).
+    path.push(t.name);
+    return path;
+  };
+
+  // Referenced warehouse table → warehouse-table element (one per table, deduped).
+  const ensureTableElement = (tableId: number): ElemCtx | null => {
+    const existing = tableCtxByTableId.get(tableId);
+    if (existing) return existing;
+    const t = fidx?.tableById.get(tableId);
+    if (!t) { warnings.push(`table ${tableId} is not in the database metadata — cannot emit a warehouse-table element for it.`); return null; }
+    // Case-preserved: the warehouse-element column prefix must match the path tail
+    // exactly (BQ is lowercase; Snowflake metadata is already uppercase).
+    const tableTail = t.name;
+    const element: SigmaElement = {
+      id: sigmaShortId(), kind: 'table', name: sigmaDisplayName(t.name),
+      source: { connectionId, kind: 'warehouse-table', path: tablePath(t) },
+      columns: [], order: [],
+    };
+    const ctx = newCtx(element, false);
+    tableCtxByTableId.set(tableId, ctx);
+    for (const f of t.fields) {
+      const id = sigmaInodeId(f.columnName);
+      ctx.columns.push({ id, formula: sigmaColFormula(tableTail, f.columnName) });
+      ctx.order.push(id);
+      ctx.colIdByName.set(f.displayName.toLowerCase(), id);
+      ctx.colIdByFieldId.set(f.id, id);
+    }
+    return ctx;
+  };
+
+  // Per-card MBQL translation context: field-id resolution via metadata, falling
+  // back to the card's result_metadata names (with a warning — decision 1).
+  const mkMbqlCtx = (card: any): MbqlCtx => {
+    const rmById = new Map<number, any>();
+    for (const rm of card.result_metadata || []) {
+      const fr = rm.field_ref;
+      if (Array.isArray(fr) && fr[0] === 'field' && typeof fr[1] === 'number') rmById.set(fr[1], rm);
+    }
+    const display = (ref: any): string => {
+      const idOrName = Array.isArray(ref) ? ref[1] : ref;
+      if (typeof idOrName === 'number') {
+        const f = fidx?.byId.get(idOrName);
+        if (f) return f.displayName;
+        const rm = rmById.get(idOrName);
+        if (rm) return rm.display_name || sigmaDisplayName(rm.name);
+        warnings.push(`card "${card.name}": field ${idOrName} could not be resolved (no metadata match, no result_metadata match) — emitted [Field ${idOrName}]. Fallback chain: pass /api/database/{id}/metadata; if that 403s on a scoped key, GET /api/field/${idOrName} works even for restricted DBs.`);
+        return `Field ${idOrName}`;
+      }
+      return sigmaDisplayName(String(idOrName ?? ''));
+    };
+    const ctx: MbqlCtx = {
+      fieldDisplay: display,
+      resolveField: (ref: any) => {
+        const opts = (Array.isArray(ref) && ref[2]) || {};
+        // Implicit FK join ([field, dimField, {source-field}]) — the dim table must
+        // exist as an element or the FK relationship (and the derived view column
+        // the consuming chart needs) is silently dropped (live-verified).
+        if (opts['source-field'] && Array.isArray(ref) && typeof ref[1] === 'number') {
+          const f = fidx?.byId.get(ref[1]);
+          if (f) ensureTableElement(f.tableId);
+        }
+        let out = `[${display(ref)}]`;
+        if (opts['temporal-unit']) out = `DateTrunc("${opts['temporal-unit']}", ${out})`;
+        if (opts.binning) ctx.warn(`numeric binning on [${display(ref)}] is flagged — recreate with BinFixed/BinCount in the workbook element.`);
+        return out;
+      },
+      warn: (m) => warnings.push(`card "${card.name}": ${m}`),
+      learnedRules: options.learnedRules,
+    };
+    return ctx;
+  };
+
+  const parseJoinCondition = (cond: any, ctxM: MbqlCtx): Array<{ left: string; right: string }> => {
+    // Join-condition refs are bare [Column] scoped to each side, using Sigma's
+    // PRETTIFIED display name of the physical column ('[Product Key]'; the physical
+    // '[PRODUCT_KEY]' 400s "Column reference not found" — live-verified).
+    const rawCol = (ref: any): string => {
+      if (Array.isArray(ref) && ref[0] === 'field' && typeof ref[1] === 'number') {
+        const f = fidx?.byId.get(ref[1]);
+        if (f) return `[${sigmaDisplayName(f.columnName)}]`;
+      }
+      return `[${ctxM.fieldDisplay(ref)}]`;
+    };
+    const out: Array<{ left: string; right: string }> = [];
+    const walk = (c: any) => {
+      if (!Array.isArray(c)) return;
+      const op = String(c[0]).toLowerCase();
+      if (op === 'and') { c.slice(1).forEach(walk); return; }
+      if (op === '=' && c.length === 3) out.push({ left: rawCol(c[1]), right: rawCol(c[2]) });
+    };
+    walk(cond);
+    return out;
+  };
+
+  // MBQL card with `joins` → its own element with a join source.
+  const buildJoinElement = (card: any, q: any, ctxM: MbqlCtx): ElemCtx | null => {
+    const baseId = q['source-table'];
+    const baseT = typeof baseId === 'number' ? fidx?.tableById.get(baseId) : undefined;
+    if (!baseT) { warnings.push(`card "${card.name}" joins from table ${JSON.stringify(baseId)}, which is not in the metadata — join element skipped.`); return null; }
+    ensureTableElement(baseId);  // base + joined tables also get warehouse-table elements (FK relationships, reuse)
+    const joins: any[] = [];
+    const joinedTables: MetabaseTableInfo[] = [];
+    for (const j of q.joins || []) {
+      const jt = typeof j['source-table'] === 'number' ? fidx?.tableById.get(j['source-table']) : undefined;
+      if (!jt) { warnings.push(`card "${card.name}": join to ${JSON.stringify(j['source-table'])} not resolvable (card-source join or missing metadata) — that join was skipped.`); continue; }
+      ensureTableElement(j['source-table']);
+      joinedTables.push(jt);
+      const on = parseJoinCondition(j.condition, ctxM);
+      if (!on.length) warnings.push(`card "${card.name}": join condition for ${jt.name} is not a simple equi-join — author the ON clause in Sigma.`);
+      joins.push({
+        // connectionId is REQUIRED on each join side (nested sources carry their own
+        // connection — live-verified 400 "joins[0].left.connectionId: Invalid string").
+        // Conditions live in `columns` (not `on`), and the relationship `name` is the
+        // formula prefix for this right source's columns ([NAME/Col]).
+        left: { kind: 'warehouse-table', connectionId, path: tablePath(baseT) },
+        right: { kind: 'warehouse-table', connectionId, path: tablePath(jt) },
+        joinType: JOIN_TYPE[j.strategy || 'left-join'] || 'left-outer',
+        columns: on,
+        name: jt.name,
+      });
+    }
+    const element: SigmaElement = {
+      id: sigmaShortId(), kind: 'table', name: card.name || `Card ${card.id}`,
+      // source.name is the formula prefix for the head source's columns.
+      source: { kind: 'join', name: baseT.name, connectionId, joins },
+      columns: [], order: [],
+    };
+    const ctx = newCtx(element, true);
+    const addRaw = (t: MetabaseTableInfo) => {
+      for (const f of t.fields) {
+        const key = f.displayName.toLowerCase();
+        if (ctx.colIdByName.has(key)) continue; // duplicate display name (e.g. the join key on both sides) — first wins
+        const id = sigmaInodeId(f.columnName);
+        ctx.columns.push({ id, formula: sigmaColFormula(t.name, f.columnName) });
+        ctx.order.push(id);
+        ctx.colIdByName.set(key, id);
+        ctx.colIdByFieldId.set(f.id, id);
+      }
+    };
+    addRaw(baseT);
+    for (const jt of joinedTables) addRaw(jt);
+    return ctx;
+  };
+
+  const addCalc = (ctx: ElemCtx, name: string, formula: string): void => {
+    if (ctx.colIdByName.has(name.toLowerCase())) return; // same-named calc already on this (shared) element
+    const id = sigmaShortId();
+    ctx.columns.push({ id, name, formula });
+    ctx.order.push(id);
+    ctx.colIdByName.set(name.toLowerCase(), id);
+  };
+  const addMetric = (ctx: ElemCtx, name: string, formula: string): void => {
+    if (ctx.metrics.some((m) => m.name === name)) return;
+    const m: SigmaMetric = { id: sigmaShortId(), name, formula };
+    const fmt = inferSigmaFormat(formula, name);
+    if (fmt) (m as any).format = fmt;
+    ctx.metrics.push(m);
+  };
+
+  const cards: any[] = inp.cards || [];
+  const cardById = new Map<number, any>(cards.filter((c) => c?.id != null).map((c) => [c.id, c]));
+  const cardElemId = new Map<number, string>();
+  const inFlight = new Set<number>();
+  let sqlElements = 0;
+
+  // ── template tags → Sigma controls (45% of cards on the reference estate) ────
+  // Plain variable tags keep their {{tag}} verbatim — Sigma custom SQL uses the
+  // SAME {{control-id}} parameter syntax — and get a matching control element.
+  // Field-filter (dimension) tags expand to a whole SQL predicate at runtime, so
+  // the {{tag}} is replaced with a documented `1=1 /* … */` and the filter is
+  // recreated as a control + element filter on the consuming workbook element.
+  // See refs/template-tags.md for the full mapping table.
+  const TAG_CONTROL_TYPE: Record<string, string> = { text: 'text', number: 'number', date: 'date', boolean: 'switch' };
+  const controlElements: SigmaElement[] = [];
+  const controlByControlId = new Map<string, any>();
+  const ensureControl = (controlId: string, name: string, controlType: string, value: any): void => {
+    const existing = controlByControlId.get(controlId);
+    if (existing) {
+      if (existing.controlType !== controlType) {
+        warnings.push(`template tag "${controlId}" appears with conflicting types (${existing.controlType} vs ${controlType}) across cards — one control was emitted with type ${existing.controlType}; review.`);
+      }
+      return;
+    }
+    // Each controlType variant has REQUIRED discriminant fields (live-verified: omitting
+    // text's `mode` fails the union match and surfaces as `Invalid kind: "control"`).
+    const ctrl: any = { id: sigmaShortId(), kind: 'control', controlId, name, controlType };
+    if (controlType === 'text') ctrl.mode = 'equals';
+    if (controlType === 'number') ctrl.mode = '=';
+    if (controlType === 'date') ctrl.mode = '=';
+    if (controlType === 'switch') ctrl.mode = 'True/All';
+    if (value != null) ctrl.value = value;
+    controlByControlId.set(controlId, ctrl);
+    controlElements.push(ctrl);
+  };
+  const TAG_RE = (tag: string) => new RegExp(`\\{\\{\\s*${tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\}\\}`, 'g');
+
+  /** Rewrite a native statement per its template tags; returns the SQL to emit. */
+  const processNativeSql = (card: any, statement: string, tags: Record<string, any>): string => {
+    let sql = statement;
+    const tagType = (n: string) => String(tags[n]?.type || 'text').toLowerCase();
+    // 1. Optional [[ … ]] blocks (Metabase: included only when the tag has a value).
+    sql = sql.replace(/\[\[([\s\S]*?)\]\]/g, (_m, body: string) => {
+      const inner = [...body.matchAll(/\{\{\s*([^{}\s]+)\s*\}\}/g)].map((m) => m[1]);
+      const keep = inner.length > 0 && inner.every((n) =>
+        tagType(n) === 'dimension' || tags[n]?.default != null);
+      if (keep) {
+        warnings.push(`card "${card.name}": optional [[…]] block kept ACTIVE (its tag${inner.length > 1 ? 's' : ''} {{${inner.join('}}, {{')}}} ${inner.every((n) => tagType(n) === 'dimension') ? 'are field filters that neutralize to 1=1' : 'have defaults'}) — verify the always-on semantics.`);
+        return body;
+      }
+      warnings.push(`card "${card.name}": optional [[…]] block DROPPED (tag has no default — Metabase omits it when empty; Sigma has no optional-clause syntax). Re-add the clause around the control if the filter must be available: ${body.trim().slice(0, 80)}`);
+      return '';
+    });
+    // 2. Per-tag handling.
+    for (const [tagName, tagRaw] of Object.entries(tags)) {
+      const tag: any = tagRaw;
+      const ttype = String(tag?.type || 'text').toLowerCase();
+      const display = tag?.['display-name'] || sigmaDisplayName(tagName);
+      if (ttype === 'dimension') {
+        // field filter — expands to a whole WHERE predicate at runtime
+        const dim = tag.dimension;
+        const fieldId = Array.isArray(dim) && dim[0] === 'field' && typeof dim[1] === 'number' ? dim[1] : null;
+        const f = fieldId != null ? fidx?.byId.get(fieldId) : undefined;
+        const colDesc = f ? `[${f.displayName}] (${f.tableName})` : `the tag's mapped column (field ${fieldId ?? '?'} — resolve via GET /api/field/{id})`;
+        // NO {{braces}} in the comment — Sigma resolves {{…}} refs even inside SQL
+        // comments and 400s on the missing control (live-verified).
+        sql = sql.replace(TAG_RE(tagName), `1=1 /* Metabase field filter '${tagName}' → filter ${f ? `[${f.displayName}]` : 'the mapped column'} on the consuming Sigma element */`);
+        warnings.push(`card "${card.name}": native {{${tagName}}} is a FIELD FILTER (widget ${tag['widget-type'] || '?'}) on ${colDesc} — the predicate was neutralized to 1=1 in the SQL; recreate it as a Sigma control + element filter on that column in the workbook (field filters expand to a whole WHERE clause, not a scalar).`);
+      } else if (ttype === 'card') {
+        // {{#N}} sub-question — inline its SQL when the referenced card is available
+        const refId = tag['card-id'];
+        const ref = refId != null ? cardById.get(refId) : undefined;
+        const refDq = ref?.dataset_query;
+        const refTags = refDq?.native?.['template-tags'] || {};
+        if (refDq?.type === 'native' && Object.keys(refTags).length === 0) {
+          sql = sql.replace(TAG_RE(tagName), `(\n${refDq.native?.query || ''}\n)`);
+          warnings.push(`card "${card.name}": native {{${tagName}}} (sub-question card ${refId}) was INLINED as a sub-select from card ${refId}'s SQL — verify.`);
+        } else {
+          warnings.push(`card "${card.name}": native {{${tagName}}} references card ${refId ?? '?'} — ${ref ? 'it is not a tag-free native card, so it was NOT inlined automatically' : `fetch GET /api/card/${refId ?? '{id}'}, add it to the input set, and re-run to inline it`}; resolve manually before posting.`);
+        }
+      } else if (ttype === 'snippet') {
+        warnings.push(`card "${card.name}": native {{${tagName}}} splices a SQL snippet — inline it (GET /api/native-query-snippet) into the statement before posting; Sigma has no snippet library.`);
+      } else {
+        // text / number / date / boolean variable — SAME {{name}} syntax in Sigma custom SQL
+        const controlType = TAG_CONTROL_TYPE[ttype] || 'text';
+        ensureControl(tagName, display, controlType, tag?.default);
+        warnings.push(`card "${card.name}": native {{${tagName}}} (${ttype}) — a Sigma ${controlType} control "${display}" (controlId "${tagName}") was emitted; the {{${tagName}}} reference is kept verbatim (Sigma custom SQL uses the same {{control-id}} parameter syntax). Verify the control's default${tag?.required ? ' (tag is REQUIRED — set a default or the element errors until set)' : ''}.`);
+      }
+    }
+    // 3. Warehouse-specific SQL transforms (array agg → string agg, etc.)
+    if (opts.warehouse && opts.warehouse !== 'unknown') {
+      sql = applyWarehouseTransforms(sql, opts.warehouse);
+    }
+    // 4. Strip trailing semicolon(s): Sigma wraps a custom-SQL element's statement
+    // as a subquery `( … )`, so a trailing `;` is a syntax error at POST
+    // (live-verified on BigQuery: `Expected ")" but got ";"`). Metabase tolerates it.
+    sql = sql.replace(/;\s*$/, '').trimEnd();
+    return sql;
+  };
+
+  const processCard = (card: any): void => {
+    if (!card) return;
+    if (card.id != null && cardElemId.has(card.id)) return;
+    if (card.id != null && inFlight.has(card.id)) { warnings.push(`card ${card.id} participates in a circular card__ reference chain — skipped.`); return; }
+    if (card.id != null) inFlight.add(card.id);
+    const done = () => { if (card.id != null) inFlight.delete(card.id); };
+    let dq = card.dataset_query || {};
+    // Simple native SQL → native Sigma data model (so filters are reproducible
+    // natively — see recognizeSimpleNativeSql). Complex SQL stays custom SQL below.
+    if (dq.type === 'native') {
+      const remodeled = recognizeSimpleNativeSql(card, fidx);
+      if (remodeled) {
+        dq = { type: 'query', database: dq.database, query: remodeled.query };
+        warnings.push(`card "${card.name}": simple native SQL auto-remodeled to a NATIVE Sigma data model (table/join source + aggregation) — its columns are exposed so dashboard filters reproduce as native Sigma controls/element-filters (no custom SQL).`);
+      }
+    }
+    const ctxM = mkMbqlCtx(card);
+
+    // ── native SQL card → sql-source element (statement near-verbatim, NO element name) ──
+    // SQL dialect passes through to Sigma custom SQL untouched — same-warehouse
+    // migrations (e.g. BigQuery→BigQuery) are near-verbatim.
+    if (dq.type === 'native') {
+      const statement = processNativeSql(card, dq.native?.query || '', dq.native?.['template-tags'] || {});
+      const element: SigmaElement = {
+        // No `name` field: Sigma derives the sql element's own identifier.
+        id: sigmaShortId(), kind: 'table',
+        source: { kind: 'sql', connectionId, statement },
+        columns: [], order: [],
+      };
+      const ctx = newCtx(element, true);
+      for (const rm of card.result_metadata || []) {
+        // Prettify ALWAYS (sigmaDisplayName is idempotent): native-card display_name
+        // is the raw alias (x_axis_type), which otherwise becomes the chart label.
+        const disp = sigmaDisplayName(rm.display_name || rm.name);
+        const id = sigmaShortId();
+        // sql-element column refs MUST be [Custom SQL/ALIAS] (raw SQL output alias).
+        // Bare [Display Name] refs POST 200 but resolve to type "error" at query
+        // time (live-verified — the readback gate exists for exactly this).
+        ctx.columns.push({ id, name: disp, formula: `[Custom SQL/${rm.name || disp}]` });
+        ctx.order.push(id);
+        ctx.colIdByName.set(disp.toLowerCase(), id);
+      }
+      if (card.id != null) cardElemId.set(card.id, element.id);
+      sqlElements++;
+      done();
+      return;
+    }
+
+    // ── MBQL card ────────────────────────────────────────────────────────────────
+    const q = dq.query || {};
+    if (q['source-query']) {
+      // multi-stage query (pMBQL stages>1 / legacy nested source-query) — rare
+      // (14 of 7,023 on the reference estate) and structurally a sub-query;
+      // flagged, never silently mistranslated.
+      warnings.push(`card "${card.name}" is a MULTI-STAGE query (nested source-query) — not auto-converted; rebuild as a chain of Sigma elements (inner stage → element, outer stage → child element) or a custom-SQL element. Card skipped.`);
+      done(); return;
+    }
+    const src = q['source-table'];
+    let target: ElemCtx | null = null;
+
+    if (typeof src === 'string' && src.startsWith('card__')) {
+      // Nested question — sourced from card N's element when card N is in the input set.
+      const n = Number(src.slice('card__'.length));
+      const parent = cardById.get(n);
+      if (!parent) { warnings.push(`card "${card.name}" is a nested question on card ${n}, which is NOT in the input set — fetch GET /api/card/${n}, add it, and re-run; card skipped.`); done(); return; }
+      processCard(parent);
+      const parentElemId = cardElemId.get(n);
+      if (!parentElemId) { warnings.push(`card "${card.name}": its source card ${n} did not produce an element — skipped.`); done(); return; }
+      const element: SigmaElement = {
+        id: sigmaShortId(), kind: 'table', name: card.name || `Card ${card.id}`,
+        source: { kind: 'table', elementId: parentElemId },
+        columns: [], order: [],
+      };
+      target = newCtx(element, true);
+      // Passthrough the parent's columns — a table-sourced element starts EMPTY
+      // (zero queryable columns live-verified), so anything consuming this element
+      // (the workbook chart for this very card) has nothing to reference without them.
+      const parentCtx = elemCtxs.find((c) => c.element.id === parentElemId);
+      const parentName = parentCtx?.element.name || 'Parent';
+      for (const pc of parentCtx?.columns || []) {
+        const tail = pc.name || /\/([^\]/]+)\]$/.exec(String(pc.formula || ''))?.[1];
+        if (!tail || target.colIdByName.has(tail.toLowerCase())) continue;
+        const id = sigmaShortId();
+        target.columns.push({ id, name: tail, formula: `[${parentName}/${tail}]` });
+        target.order.push(id);
+        target.colIdByName.set(tail.toLowerCase(), id);
+      }
+    } else if (Array.isArray(q.joins) && q.joins.length) {
+      target = buildJoinElement(card, q, ctxM);
+    } else if (typeof src === 'number') {
+      target = ensureTableElement(src);
+      if (!target) warnings.push(`card "${card.name}" skipped — its source table ${src} is unknown.`);
+    } else if (src !== undefined) {
+      warnings.push(`card "${card.name}": unrecognized source-table ${JSON.stringify(src)} — skipped.`);
+    }
+    if (!target) { done(); return; }
+    if (card.id != null) cardElemId.set(card.id, target.element.id);
+
+    // expressions → calculated columns
+    for (const [name, expr] of Object.entries(q.expressions || {})) {
+      addCalc(target, String(name), translateMbqlExpr(expr, ctxM));
+    }
+    // breakout temporal-unit → DateTrunc calc column (plain breakouts are already raw columns)
+    for (const b of q.breakout || []) {
+      const unit = Array.isArray(b) && b[2]?.['temporal-unit'];
+      if (unit) addCalc(target, `${ctxM.fieldDisplay(b)} (${titleCase(String(unit))})`, ctxM.resolveField(b));
+      else if (Array.isArray(b) && b[2]?.binning) ctxM.resolveField(b); // emits the binning warning
+      // implicit FK breakout ([field, dim, {source-field}]) — resolveField ensures the
+      // dim TABLE element exists, so the FK relationship + derived-view column survive
+      else if (Array.isArray(b) && b[2]?.['source-field']) ctxM.resolveField(b);
+    }
+    // aggregations → element metrics
+    for (const a of q.aggregation || []) {
+      const { formula, name } = translateAggregation(a, ctxM);
+      addMetric(target, name, formula);
+    }
+    // card filter: safe on a card-owned element; NEVER on a shared table element
+    // (an element filter on a shared-source element propagates into every consumer).
+    if (q.filter) {
+      const formula = translateMbqlExpr(q.filter, ctxM);
+      if (target.ownedByCard) {
+        const id = sigmaShortId();
+        target.columns.push({ id, name: `Filter: ${card.name || card.id}`, formula, hidden: true });
+        ((target.element as any).filters ||= []).push({ id: sigmaShortId(), columnId: id, kind: 'list', mode: 'include', values: [true] });
+      } else {
+        warnings.push(`card "${card.name}": its MBQL filter translates to ${formula} — NOT applied to the shared "${target.element.name}" element (a filter there would propagate to every consumer); apply it on the consuming workbook element.`);
+      }
+    }
+    if (q.limit != null && !target.ownedByCard) {
+      warnings.push(`card "${card.name}": row limit ${q.limit} not ported — never cap a shared DM element; apply a top-N on the consuming workbook element if needed.`);
+    }
+    done();
+  };
+
+  for (const card of cards) processCard(card);
+
+  // ── FK metadata → relationships on the fact-side element (both tables present) ──
+  let relationshipCount = 0;
+  for (const [tableId, ctx] of tableCtxByTableId) {
+    const t = fidx?.tableById.get(tableId);
+    if (!t) continue;
+    for (const f of t.fields) {
+      if (!f.fkTargetFieldId) continue;
+      const tgtField = fidx!.byId.get(f.fkTargetFieldId);
+      if (!tgtField) continue;
+      const tgtCtx = tableCtxByTableId.get(tgtField.tableId);
+      if (!tgtCtx) continue;  // both tables must be present in the model
+      const sourceColumnId = ctx.colIdByFieldId.get(f.id);
+      const targetColumnId = tgtCtx.colIdByFieldId.get(tgtField.id);
+      if (!sourceColumnId || !targetColumnId) continue;
+      (ctx.element.relationships ||= []).push({
+        id: sigmaShortId(),
+        name: tgtField.tableName,   // relationship name = target table tail, case-preserved
+        targetElementId: tgtCtx.element.id,
+        keys: [{ sourceColumnId, targetColumnId }],
+      });
+      relationshipCount++;
+    }
+  }
+
+  // ── finalize ──────────────────────────────────────────────────────────────────
+  const elements: SigmaElement[] = [];
+  for (const ctx of elemCtxs) {
+    if (ctx.metrics.length) (ctx.element as any).metrics = ctx.metrics;
+    elements.push(ctx.element);
+  }
+  for (const de of buildDerivedElements(elements)) elements.push(de);
+  // template-tag controls last (so {{tag}} refs in sql elements have a target)
+  for (const ctrl of controlElements) elements.push(ctrl);
+
+  // ── Metabase sandboxing (EE row security) — DETECT-ONLY, never injected ───────
+  const security = (inp.sandboxes || []).map((s: any) => {
+    const tname = fidx?.tableById.get(s.table_id)?.name || `table ${s.table_id}`;
+    const parts = Object.entries(s.attribute_remappings || {}).map(([attr, tgt]: [string, any]) => {
+      const tgtRef = Array.isArray(tgt) && tgt[0] === 'dimension' ? tgt[1] : tgt;
+      const col = Array.isArray(tgtRef) && tgtRef[0] === 'field'
+        ? (fidx?.byId.get(tgtRef[1])?.displayName || `field ${tgtRef[1]}`)
+        : JSON.stringify(tgt);
+      return `[${col}] = user attribute "${attr}"`;
+    });
+    return {
+      type: 'row-filter',
+      name: s.name || `Sandbox: ${tname}`,
+      expression: parts.length ? parts.join(' AND ') : (s.card_id != null ? `rows restricted to saved question ${s.card_id}` : '(no attribute remappings found)'),
+      groups: [s.group_id].filter((g: any) => g != null),
+    };
+  });
+  if (security.length) {
+    warnings.push(`SECURITY: ${security.length} Metabase sandbox(es) detected — NOT ported into the model spec. ` +
+      `Run the skill's RLS flow (scripts/apply_sigma_rls.py) after posting the model; skipping leaves ALL rows visible to everyone.`);
+  }
+
+  const stats = {
+    cards: cards.length,
+    elements: elements.length,
+    sqlElements,
+    controls: controlElements.length,
+    columns: elements.reduce((n, e) => n + (e.columns?.length || 0), 0),
+    metrics: elements.reduce((n, e) => n + ((e as any).metrics?.length || 0), 0),
+    relationships: relationshipCount,
+  };
+  return {
+    model: {
+      name: options.modelName || inp.metadata?.name || 'Metabase Data Model',
+      schemaVersion: 1,
+      pages: [{ id: sigmaShortId(), name: 'Page 1', elements }],
+    },
+    warnings, stats,
+    ...(security.length ? { security } : {}),
+  };
+}

--- a/metabase-migration-skills/metabase-to-sigma/converter/package-lock.json
+++ b/metabase-migration-skills/metabase-to-sigma/converter/package-lock.json
@@ -1,0 +1,552 @@
+{
+  "name": "metabase-to-sigma-converter",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "metabase-to-sigma-converter",
+      "version": "0.1.0",
+      "license": "MIT",
+      "bin": {
+        "metabase-to-sigma": "cli.ts"
+      },
+      "devDependencies": {
+        "tsx": "^4.19.0",
+        "typescript": "^5.6.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/metabase-migration-skills/metabase-to-sigma/converter/package.json
+++ b/metabase-migration-skills/metabase-to-sigma/converter/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "metabase-to-sigma-converter",
+  "version": "0.1.0",
+  "description": "Metabase → Sigma converter (cards/models JSON → data model; dashboard JSON → workbook). Zero runtime dependencies — every input is plain REST JSON.",
+  "type": "module",
+  "license": "MIT",
+  "bin": { "metabase-to-sigma": "cli.ts" },
+  "scripts": {
+    "convert": "node --import tsx/esm cli.ts",
+    "test": "node --import tsx/esm test.ts"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0"
+  }
+}

--- a/metabase-migration-skills/metabase-to-sigma/converter/pmbql-normalize.mjs
+++ b/metabase-migration-skills/metabase-to-sigma/converter/pmbql-normalize.mjs
@@ -1,0 +1,228 @@
+/**
+ * pMBQL ("lib/" MBQL, Metabase Lib) → legacy MBQL normalizer.
+ *
+ * Modern Metabase instances (observed: Metabase Cloud v1.61.x; 100% of a
+ * 7k-card production estate) return `dataset_query` in pMBQL form:
+ *
+ *   { "lib/type": "mbql/query", "database": N, "stages": [ ... ] }
+ *
+ * instead of the legacy `{ "type": "native"|"query", ... }` the converter and
+ * scorer were built against. A single card-list response may contain EITHER
+ * format depending on instance version — sniff the `lib/type` key, never the
+ * version string.
+ *
+ * Shape differences handled here (all verified against production payloads):
+ *   query    {lib/type:"mbql/query", stages:[…]}     → {type, database, native|query}
+ *   stage    mbql.stage/native {native:"sql", template-tags} → {native:{query, template-tags}}
+ *   stage    mbql.stage/mbql   {aggregation, breakout, filters, joins, …}
+ *   clause   [op, {opts}, …args]                     → [op, …args] (opts map is ALWAYS
+ *            the 2nd element in pMBQL; legacy puts it last, or 3rd for "field")
+ *   field    ["field", {opts}, idOrName]             → ["field", idOrName, opts|null]
+ *   filters  array (implicit AND)                    → single `filter` (["and", …])
+ *   in/not-in                                        → multi-value "="/"!=" (the
+ *            converter renders those as Or/And chains — Sigma has no IsIn)
+ *   named aggregation (name/display-name in opts)    → ["aggregation-options", inner, {…}]
+ *   expressions list (lib/expression-name in opts)   → {name: clause} map
+ *   source-card N                                    → source-table "card__N"
+ *   joins {stages:[{source-table}], conditions:[…]}  → {source-table, condition, …}
+ *   multi-stage (rare but real: 14 of 7,023 cards)   → legacy source-query nesting
+ *   template-tags dimension clauses                  → legacy field refs
+ *
+ * `normalizeCard` prefers the server-provided `legacy_query` JSON string when
+ * present and parseable (the instance's own down-conversion — authoritative),
+ * falling back to this normalizer. Zero dependencies; usable from Node ≥18.
+ *
+ * NOTE: this file exists in two locations (converter + assessment scripts) so
+ * each skill stays self-contained. The converter test suite asserts the two
+ * copies are byte-identical — edit one, copy to the other.
+ */
+
+const isOptsMap = (x) => x !== null && typeof x === 'object' && !Array.isArray(x);
+
+/** A pMBQL clause is [op:string, optsMap, ...args] — opts ALWAYS second. */
+const isPmbqlClause = (n) => Array.isArray(n) && typeof n[0] === 'string' && isOptsMap(n[1]);
+
+function cleanOpts(opts) {
+  const out = {};
+  for (const [k, v] of Object.entries(opts || {})) {
+    if (k.startsWith('lib/') || k === 'effective-type' || k === 'ident') continue;
+    out[k] = v;
+  }
+  return out;
+}
+
+const STRING_MATCH_OPS = new Set(['starts-with', 'ends-with', 'contains', 'does-not-contain']);
+
+/** Recursively normalize a pMBQL clause tree into legacy MBQL. */
+export function normalizeClause(node) {
+  if (!Array.isArray(node)) return node;
+  if (!isPmbqlClause(node)) return node.map(normalizeClause); // e.g. case clause-pair lists
+  const op = node[0];
+  const opts = cleanOpts(node[1]);
+  const args = node.slice(2);
+  const hasOpts = Object.keys(opts).length > 0;
+
+  switch (op) {
+    case 'field':
+      // ["field", {opts}, idOrName] → ["field", idOrName, opts|null]
+      return ['field', args[0], hasOpts ? opts : null];
+    case 'expression':
+      return hasOpts ? ['expression', args[0], opts] : ['expression', args[0]];
+    case 'aggregation':
+      return ['aggregation', args[0]];
+    case 'template-tag':
+      return ['template-tag', args[0]];
+    case 'value':
+      return normalizeClause(args[0]); // literal wrapper — unwrap
+    case 'absolute-datetime':
+      return normalizeClause(args[0]); // legacy filters carry the bare ISO string
+    case 'case':
+    case 'if': {
+      // ["case", {opts}, [[pred, expr], …], default?] → ["case", [[…]], {default}?]
+      const pairs = (args[0] || []).map((p) =>
+        Array.isArray(p) ? [normalizeClause(p[0]), normalizeClause(p[1])] : p);
+      const out = ['case', pairs];
+      if (args.length > 1 && args[1] !== undefined) out.push({ default: normalizeClause(args[1]) });
+      return out;
+    }
+    case 'in':
+      return ['=', ...args.map(normalizeClause)];
+    case 'not-in':
+      return ['!=', ...args.map(normalizeClause)];
+    case 'time-interval':
+    case 'relative-time-interval': {
+      // ["time-interval", {opts}, field, n, unit] → ["time-interval", field, n, unit, opts?]
+      const rest = args.map(normalizeClause);
+      return hasOpts ? ['time-interval', ...rest, opts] : ['time-interval', ...rest];
+    }
+    case 'segment':
+    case 'metric':
+      return [op, args[0]];
+    default: {
+      const rest = args.map(normalizeClause);
+      // string-match ops carry case-sensitive in opts — legacy puts it last
+      if (STRING_MATCH_OPS.has(op) && hasOpts) return [op, ...rest, opts];
+      return [op, ...rest];
+    }
+  }
+}
+
+/** Aggregation clause — pMBQL names live in opts → legacy aggregation-options wrapper. */
+function normalizeAggregation(a) {
+  if (!isPmbqlClause(a)) return normalizeClause(a);
+  const o = a[1];
+  const norm = normalizeClause(a);
+  const nm = o['display-name'] || o.name;
+  if (!nm) return norm;
+  const wrap = {};
+  if (o.name) wrap.name = o.name;
+  if (o['display-name']) wrap['display-name'] = o['display-name'];
+  return ['aggregation-options', norm, wrap];
+}
+
+function normalizeJoin(j) {
+  const out = {};
+  const st0 = (j.stages && j.stages[0]) || {};
+  if (st0['source-card'] != null) out['source-table'] = `card__${st0['source-card']}`;
+  else if (st0['source-table'] != null) out['source-table'] = st0['source-table'];
+  else if (j['source-table'] != null) out['source-table'] = j['source-table'];
+  if (j.alias != null) out.alias = j.alias;
+  if (j.strategy != null) out.strategy = j.strategy;
+  if (Array.isArray(j.conditions)) {
+    const cs = j.conditions.map(normalizeClause);
+    out.condition = cs.length === 1 ? cs[0] : ['and', ...cs];
+  } else if (j.condition) {
+    out.condition = normalizeClause(j.condition);
+  }
+  if (j.fields != null) out.fields = Array.isArray(j.fields) ? j.fields.map(normalizeClause) : j.fields;
+  return out;
+}
+
+function normalizeTemplateTags(tags) {
+  if (!tags) return tags;
+  const out = {};
+  for (const [k, t] of Object.entries(tags)) {
+    out[k] = t && t.dimension ? { ...t, dimension: normalizeClause(t.dimension) } : t;
+  }
+  return out;
+}
+
+/** One pMBQL stage → legacy query object (native stages return {__native}). */
+function normalizeStage(stage, prev) {
+  if (stage['lib/type'] === 'mbql.stage/native') {
+    const native = { query: stage.native ?? stage.query ?? '' };
+    if (stage['template-tags']) native['template-tags'] = normalizeTemplateTags(stage['template-tags']);
+    if (stage.collection) native.collection = stage.collection; // MongoDB
+    return { __native: native };
+  }
+  const q = {};
+  if (prev) {
+    q['source-query'] = prev.__native
+      ? { native: prev.__native.query, 'template-tags': prev.__native['template-tags'] || {} }
+      : prev;
+  } else if (stage['source-card'] != null) {
+    q['source-table'] = `card__${stage['source-card']}`;
+  } else if (stage['source-table'] != null) {
+    q['source-table'] = stage['source-table'];
+  }
+  if (Array.isArray(stage.joins)) q.joins = stage.joins.map(normalizeJoin);
+  if (Array.isArray(stage.expressions)) {
+    q.expressions = {};
+    for (const e of stage.expressions) {
+      const nm = (isPmbqlClause(e) && e[1]['lib/expression-name']) || `expr_${Object.keys(q.expressions).length}`;
+      q.expressions[nm] = normalizeClause(e);
+    }
+  }
+  if (Array.isArray(stage.aggregation)) q.aggregation = stage.aggregation.map(normalizeAggregation);
+  if (Array.isArray(stage.breakout)) q.breakout = stage.breakout.map(normalizeClause);
+  if (Array.isArray(stage.filters) && stage.filters.length) {
+    const fs = stage.filters.map(normalizeClause);
+    q.filter = fs.length === 1 ? fs[0] : ['and', ...fs];
+  } else if (stage.filter) {
+    q.filter = normalizeClause(stage.filter);
+  }
+  if (Array.isArray(stage['order-by'])) {
+    q['order-by'] = stage['order-by'].map((o) =>
+      Array.isArray(o) && isOptsMap(o[1]) ? [o[0], normalizeClause(o[2])] : normalizeClause(o));
+  }
+  if (stage.limit != null) q.limit = stage.limit;
+  if (Array.isArray(stage.fields)) q.fields = stage.fields.map(normalizeClause);
+  return q;
+}
+
+export function isPmbqlQuery(dq) {
+  return !!dq && typeof dq === 'object' && dq['lib/type'] === 'mbql/query';
+}
+
+/**
+ * pMBQL dataset_query → legacy dataset_query. Legacy input passes through
+ * untouched (format-sniffing: a list endpoint may return either).
+ */
+export function normalizeDatasetQuery(dq) {
+  if (!isPmbqlQuery(dq)) return dq;
+  const stages = Array.isArray(dq.stages) ? dq.stages : [];
+  let acc = null;
+  for (const s of stages) acc = normalizeStage(s, acc);
+  if (acc && acc.__native) return { type: 'native', database: dq.database, native: acc.__native };
+  return { type: 'query', database: dq.database, query: acc || {} };
+}
+
+/**
+ * Normalize a full card object (non-mutating). Prefers the server-provided
+ * `legacy_query` (a JSON string — the instance's own down-conversion, present
+ * on ~70% of cards observed) and falls back to normalizeDatasetQuery.
+ */
+export function normalizeCard(card) {
+  if (!card || typeof card !== 'object') return card;
+  if (!isPmbqlQuery(card.dataset_query)) return card;
+  if (typeof card.legacy_query === 'string' && card.legacy_query.trim().startsWith('{')) {
+    try {
+      const lq = JSON.parse(card.legacy_query);
+      if (lq && (lq.type === 'native' || lq.type === 'query')) return { ...card, dataset_query: lq };
+    } catch { /* fall through to the normalizer */ }
+  }
+  if (isOptsMap(card.legacy_query) && (card.legacy_query.type === 'native' || card.legacy_query.type === 'query')) {
+    return { ...card, dataset_query: card.legacy_query };
+  }
+  return { ...card, dataset_query: normalizeDatasetQuery(card.dataset_query) };
+}

--- a/metabase-migration-skills/metabase-to-sigma/converter/sigma-ids.ts
+++ b/metabase-migration-skills/metabase-to-sigma/converter/sigma-ids.ts
@@ -1,0 +1,352 @@
+/**
+ * Shared Sigma Computing ID generation and naming utilities.
+ * Extracted from the Sigma Data Model Manager tool.
+ */
+
+const SIGMA_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const _usedIds = new Set<string>();
+
+/** Small words that Sigma keeps lowercase in display names (unless first word) */
+const SIGMA_LOWERCASE_WORDS = new Set([
+  'a','an','the','and','but','or','for','nor','so','yet',
+  'at','by','in','of','on','to','up','as','into','via','per'
+]);
+
+/** Reset the ID registry — call at the start of each conversion run */
+export function resetIds(): void {
+  _usedIds.clear();
+}
+
+/** Generate a unique short random ID (base62) */
+export function sigmaShortId(len = 10): string {
+  let id: string;
+  do {
+    id = Array.from({ length: len }, () =>
+      SIGMA_CHARS[Math.floor(Math.random() * SIGMA_CHARS.length)]
+    ).join('');
+  } while (_usedIds.has(id));
+  _usedIds.add(id);
+  return id;
+}
+
+/** Column IDs use Sigma's inode format: inode-{22-char base62}/{IDENTIFIER} */
+export function sigmaInodeId(identifier: string): string {
+  return `inode-${sigmaShortId(22)}/${identifier.toUpperCase()}`;
+}
+
+/**
+ * SNAKE_CASE or camelCase → "Title Case" display name.
+ *
+ * Matches Sigma's OWN derivation rule for warehouse column names (verified
+ * empirically against live DM readbacks, 2026-06-10): Sigma splits words at
+ * underscores, camelCase boundaries, AND every letter↔digit boundary — in BOTH
+ * directions. E.g. CY_Q1_REVENUE → "Cy Q 1 Revenue" (NOT "Cy Q1 Revenue"),
+ * FY2024 → "Fy 2024", PY_Q4 → "Py Q 4". Raw-column formula refs
+ * ([TABLE/Display Name]) must reproduce this exactly or the POST fails with
+ * "dependency not found" (beads-sigma-c31q).
+ */
+export function sigmaDisplayName(s: string): string {
+  // Insert underscores at camelCase + letter↔digit boundaries so OrderDate →
+  // Order_Date and CY_Q1 → CY_Q_1 (Sigma splits BOTH letters→digits and
+  // digits→letters).
+  const normalized = (s || '')
+    .replace(/([a-z])([A-Z])/g, '$1_$2')        // camelCase → camel_Case
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1_$2')  // HTMLParser → HTML_Parser
+    .replace(/([A-Za-z])([0-9])/g, '$1_$2')     // Q1 → Q_1, FY2024 → FY_2024
+    .replace(/([0-9])([A-Za-z])/g, '$1_$2');    // 2024FY → 2024_FY
+  // Split on underscores AND whitespace so the function is IDEMPOTENT:
+  // sigmaDisplayName("Cyq Rev") === "Cyq Rev". Formulas pass through the expression
+  // translator more than once, and same-element sibling refs are resolved
+  // case-SENSITIVELY by Sigma — a non-idempotent derivation ("Cyq Rev" → "Cyq rev")
+  // breaks the ref and the column compiles to type "error".
+  // AP-style: FIRST and LAST words always capitalize, stopwords only stay lowercase
+  // mid-name (live-verified: IS_EMAIL_OPT_IN → "Is Email Opt In", DAYS_TO_SHIP →
+  // "Days to Ship"; cross-element refs are case-SENSITIVE so a wrong-case trailing
+  // stopword compiles to type "error").
+  const words = normalized.toLowerCase().split(/[_\s]+/).filter(Boolean);
+  return words.map((w, i) =>
+    (i === 0 || i === words.length - 1 || !SIGMA_LOWERCASE_WORDS.has(w))
+      ? w.charAt(0).toUpperCase() + w.slice(1)
+      : w
+  ).join(' ');
+}
+
+/** Column formula: [TABLE_NAME/Display Name] */
+export function sigmaColFormula(tableName: string, identifier: string): string {
+  return `[${tableName}/${sigmaDisplayName(identifier)}]`;
+}
+
+/** Metric formula: aggregation referencing column by display name (no table prefix) */
+export function sigmaAggFormula(agg: string, identifier: string): string {
+  const dn = sigmaDisplayName(identifier);
+  const map: Record<string, string> = {
+    sum:            `Sum([${dn}])`,
+    avg:            `Avg([${dn}])`,
+    average:        `Avg([${dn}])`,
+    min:            `Min([${dn}])`,
+    max:            `Max([${dn}])`,
+    count:          `CountIf(IsNotNull([${dn}]))`,
+    count_distinct: `CountDistinct([${dn}])`,
+    count_distict:  `CountDistinct([${dn}])`,
+    median:         `Median([${dn}])`,
+    percentile:     `Percentile([${dn}], 0.5)`,
+    sum_boolean:    `CountIf([${dn}])`,
+  };
+  return map[agg?.toLowerCase()] || `Sum([${dn}])`;
+}
+
+/**
+ * Infer a Sigma format object from a formula string and display name.
+ * Returns null when no rule matches (omit format from output).
+ *
+ * Priority:
+ *  1. Formula is already ×100 percent scale (e.g. `* 100`) → plain number + % suffix
+ *  2. Ratio pattern (Agg() / Agg())                         → ,.2%
+ *  3. Name keywords for %                                    → ,.2%
+ *  4. Name keywords for currency                             → $,.2f
+ *  5. Count/CountDistinct formula                            → ,.0f integer
+ */
+/**
+ * Map a source-tool numeric format mask (Excel/.NET style, e.g. "$#,0.00",
+ * "0.0%", "#,##0") to a Sigma format object. The PRIMARY format signal when the
+ * source carries one — far more reliable than guessing from the formula/name
+ * (beads-sigma-4q7k). Returns null for masks we don't recognize (e.g. dates,
+ * "General Date") so the heuristic fallback still runs.
+ */
+export function formatFromMask(mask?: string): Record<string, any> | null {
+  if (!mask || typeof mask !== 'string') return null;
+  const s = mask.trim();
+  if (!s || /general|date|time|@|yy|dd/i.test(s)) return null;
+  // decimals = run of 0/# after a decimal point in the mask
+  const decM = s.match(/\.([0#]+)/);
+  const decimals = decM ? decM[1].length : 0;
+  const isPercent = /%/.test(s);
+  const isCurrency = /[$£€¥]/.test(s);
+  if (isPercent) return { kind: 'number', formatString: `,.${decimals}%` };
+  if (isCurrency) return { kind: 'number', formatString: `$,.${decimals}f`, currencySymbol: '$' };
+  if (/[0#]/.test(s)) return { kind: 'number', formatString: `,.${decimals}f` };
+  return null;
+}
+
+export function inferSigmaFormat(formula: string, displayName?: string, sourceMask?: string): Record<string, any> | null {
+  // Honor the source format mask first when present — most reliable signal.
+  const fromMask = formatFromMask(sourceMask);
+  if (fromMask) return fromMask;
+  if (!formula) return null;
+  const f = formula.trim();
+  const n = (displayName || '').toLowerCase();
+
+  const alreadyPctScale = /\*\s*100\b/.test(f);
+  if (alreadyPctScale && /\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n)) {
+    return { kind: 'number', formatString: ',.2f', suffix: '%' };
+  }
+  const currencyWord = /\b(revenue|sales|profit|cost|spend|amount|discounts?|price|value|aov|arpu)\b/;
+  // A ratio of two aggregates is a PERCENTAGE only when both operands are the same unit
+  // (e.g. count/count, revenue/revenue) — NOT when it's a per-unit measure like
+  // Sum(Revenue)/CountDistinct(Order) (a dollar amount) or Sum(Revenue)/Count(*) (AOV).
+  const ratio = f.match(/^([A-Za-z]+)\s*\(([^)]*)\)\s*\/\s*([A-Za-z]+)\s*\(([^)]*)\)$/);
+  if (ratio) {
+    const [, numFn, numArg, denFn, denArg] = ratio;
+    const isCount = (fn: string) => /^Count/i.test(fn);
+    const numIsCurrency = currencyWord.test(numArg.toLowerCase());
+    const nameSaysPct = /\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n);
+    if (nameSaysPct || (isCount(numFn) && isCount(denFn))) {
+      return { kind: 'number', formatString: ',.2%' };
+    }
+    // Currency numerator over a non-currency denominator (count / quantity) → $ per-unit.
+    if (numIsCurrency) {
+      return { kind: 'number', formatString: '$,.2f', currencySymbol: '$' };
+    }
+    // Otherwise a plain decimal ratio.
+    return { kind: 'number', formatString: ',.2f' };
+  }
+  if (/\b(rate|margin|pct|percent|ratio|share|mix)\b|%/.test(n)) {
+    return { kind: 'number', formatString: ',.2%' };
+  }
+  if (currencyWord.test(n)) {
+    return { kind: 'number', formatString: '$,.2f', currencySymbol: '$' };
+  }
+  if (/^Count(?:Distinct|If|DistinctIf)?\s*\(/.test(f)) {
+    return { kind: 'number', formatString: ',.0f' };
+  }
+  return null;
+}
+
+/** Sigma Data Model JSON Schema reference (for prompts/docs) */
+export const DATA_MODEL_SCHEMA_SUMMARY = `
+Sigma Data Model JSON top-level structure:
+{
+  "name": "Model Name",
+  "pages": [{ "id": "pageId", "name": "Page 1", "elements": [...] }]
+}
+
+Element types: warehouse-table, custom-sql (kind:"sql"), join, union, control.
+Columns: { "id": "inode-xxx/COL", "formula": "[TABLE/Display Name]" }
+Calculated columns: { "id": "shortId", "formula": "[Price] - [Cost]", "name": "Profit" }
+Metrics: { "id": "shortId", "formula": "Sum([Revenue])", "name": "Total Revenue" }
+Relationships: { "id": "shortId", "targetElementId": "...", "keys": [{ "sourceColumnId": "...", "targetColumnId": "..." }] }
+
+Cross-element Reference (accessing related dimension columns via relationships):
+  [SOURCE_TABLE/REL_NAME/Column Display Name]
+  REL_NAME is the relationship's "name" field (= target table name uppercase by convention).
+  Example: DateDiff("day", [ORDER_FACT/PROMO_DIM/Start Date], [ORDER_FACT/PROMO_DIM/End Date])
+  ⚠ The dash-link form [SRC/FK_COL - link/Field] does NOT work via the API — use REL_NAME.
+
+Conditional Aggregate Syntax:
+  CountIf(condition) — condition only, NO field argument
+  SumIf(field, condition) — FIELD FIRST, condition second
+  AvgIf/MaxIf/MinIf/CountDistinctIf — all FIELD FIRST
+  For booleans: always use [Column] = True, never bare [Column]
+
+Groupings (for LOD / different aggregation levels):
+  "groupings": [{ "id": "gId", "groupBy": ["colId1"], "calculations": ["calcId1"] }]
+  Array order = nesting hierarchy. Use child elements for LOD patterns.
+`.trim();
+
+/** Common column/element interfaces */
+export interface SigmaColumn {
+  id: string;
+  formula: string;
+  name?: string;
+  description?: string;
+  hidden?: boolean;
+}
+
+export interface SigmaMetric {
+  id: string;
+  formula: string;
+  name: string;
+  description?: string;
+}
+
+export interface SigmaRelationshipKey {
+  sourceColumnId: string;
+  targetColumnId: string;
+}
+
+export interface SigmaRelationship {
+  id: string;
+  targetElementId: string;
+  keys: SigmaRelationshipKey[];
+  name: string;
+  relationshipType?: string;
+}
+
+export interface SigmaElement {
+  id: string;
+  kind: string;
+  source: Record<string, any>;
+  columns: SigmaColumn[];
+  metrics?: SigmaMetric[];
+  relationships?: SigmaRelationship[];
+  order: string[];
+  [key: string]: any;
+}
+
+export interface SigmaPage {
+  id: string;
+  name: string;
+  elements: SigmaElement[];
+}
+
+export interface SigmaDataModel {
+  name: string;
+  schemaVersion?: number;
+  pages: SigmaPage[];
+}
+
+export interface ConversionResult {
+  model: SigmaDataModel;
+  warnings: string[];
+  stats: Record<string, number>;
+  /**
+   * Detected source-tool security rules (RLS/CLS). The converter only DETECTS
+   * and reports — it never injects security into the model spec (a stateless
+   * converter can't provision Sigma user attributes, so an injected
+   * CurrentUserAttributeText filter would fail-closed to 0 rows). The skill's
+   * apply_sigma_rls.py provisions + applies these after the model is posted.
+   */
+  security?: Array<Record<string, any>>;
+}
+
+export interface ElementResult {
+  element: SigmaElement;
+  elementId: string;
+  colIdMap: Record<string, string>;
+}
+
+/**
+ * Build a derived "join view" element for each source element that has outgoing
+ * relationships. The derived element exposes own columns plus dim columns via
+ * [SRC/REL_NAME/Col] cross-element formulas. Used by Qlik, OAC, Alteryx, Atlan.
+ */
+export function buildDerivedElements(elements: SigmaElement[]): SigmaElement[] {
+  const derived: SigmaElement[] = [];
+  for (const srcEl of elements) {
+    if (!srcEl.relationships?.length) continue;
+    if (srcEl.source?.kind !== 'warehouse-table') continue;
+
+    const srcPath: string[] = srcEl.source.path || [];
+    const srcTableName: string = srcPath[srcPath.length - 1] || '';
+    // The base prefix in formulas must match what Sigma resolves the base element as:
+    //   - if the element has an explicit `name` field, that is its identifier
+    //   - otherwise Sigma falls back to the warehouse-table path-tail uppercase
+    const baseName: string = srcEl.name || srcTableName;
+    // Derived element NAME must differ from the base so [<base>/Field] is unambiguous.
+    const derivedName = `${srcEl.name || sigmaDisplayName(srcTableName)} View`;
+    const viewCols: Array<{ id: string; formula: string }> = [];
+    const viewOrder: string[] = [];
+
+    for (const col of (srcEl.columns || [])) {
+      if (!col.formula || col.formula.startsWith('/*')) continue;
+      const fm = col.formula.match(/^\[([^\/\]]+)\/([^\]]+)\]$/);
+      if (!fm) continue; // skip calc cols
+      const dispName = fm[2];
+      // A "/" in the display name breaks Sigma's slash-delimited bracket ref — skip.
+      if (dispName.includes('/')) continue;
+      const cId = sigmaShortId();
+      viewCols.push({ id: cId, formula: `[${baseName}/${dispName}]` });
+      viewOrder.push(cId);
+    }
+
+    for (const rel of srcEl.relationships) {
+      if (!rel.name) continue;
+      const tgtEl = elements.find(e => e.id === rel.targetElementId);
+      if (!tgtEl || tgtEl.source?.kind !== 'warehouse-table') continue;
+      // Skip the relationship's OWN key column(s): a cross-element passthrough of a join key compiles to type "error" in Sigma.
+      const relKeyIds = new Set((rel.keys || []).map(k => k.targetColumnId));
+      for (const col of (tgtEl.columns || [])) {
+        if (relKeyIds.has(col.id)) continue;
+        if (!col.formula || col.formula.startsWith('/*')) continue;
+        const fm = col.formula.match(/^\[([^\]]+)\]$/);
+        if (!fm) continue;
+        const inner = fm[1];
+        // The display name is everything after the FIRST slash (the table/element
+        // prefix). Use indexOf, not lastIndexOf — a display name may itself contain a
+        // slash (e.g. Tableau caption "Product Key/Name").
+        const s = inner.indexOf('/');
+        const dispName = s >= 0 ? inner.slice(s + 1) : inner;
+        // A display name containing a "/" cannot be referenced via Sigma's
+        // slash-delimited bracket syntax ([Base/Rel/Field] would over-segment). Such a
+        // column stays accessible on its own dimension element; just don't surface it as
+        // a denormalized cross-element passthrough (it would compile to type "error").
+        if (dispName.includes('/')) continue;
+        const cId = sigmaShortId();
+        viewCols.push({ id: cId, formula: `[${baseName}/${rel.name}/${dispName}]` });
+        viewOrder.push(cId);
+      }
+    }
+
+    if (viewCols.length > 0) {
+      derived.push({
+        id: sigmaShortId(),
+        kind: 'table',
+        name: derivedName,
+        source: { kind: 'table', elementId: srcEl.id },
+        columns: viewCols,
+        order: viewOrder,
+      });
+    }
+  }
+  return derived;
+}

--- a/metabase-migration-skills/metabase-to-sigma/converter/test.ts
+++ b/metabase-migration-skills/metabase-to-sigma/converter/test.ts
@@ -1,0 +1,468 @@
+// Smoke + contract tests on the bundled fixtures: node --import tsx/esm test.ts
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { convertMetabaseToSigma, recognizeSimpleNativeSql, buildFieldIndex } from './metabase.js';
+import { convertMetabaseDashboardToSigma } from './metabase-dashboard.js';
+
+const FIX = join(dirname(fileURLToPath(import.meta.url)), '..', 'fixtures');
+const read = (f: string) => JSON.parse(readFileSync(join(FIX, f), 'utf8'));
+let fail = 0;
+const check = (group: string, label: string, ok: boolean) => {
+  if (ok) console.log(`✓ ${group}: ${label}`);
+  else { fail++; console.log(`✗ ${group}: ${label}`); }
+};
+
+const metadata = read('metadata.json');
+const ordersModel = read('orders-model.card.json');
+const revenueTrend = read('revenue-trend.card.json');
+const nativeCard = read('top-customers-native.card.json');
+
+// ── cards → data model ────────────────────────────────────────────────────────
+{
+  const r = convertMetabaseToSigma(
+    { metadata, cards: [ordersModel, revenueTrend, nativeCard] },
+    { connectionId: 'conn1', database: 'CSA', schema: 'TJ' },
+  );
+  const els = r.model.pages[0].elements as any[];
+  const byName = (n: string) => els.find((e) => e.name === n);
+  const orderFact = byName('Order Fact');
+  const customerDim = byName('Customer Dim');
+  const joinEl = byName('Orders Model');
+  const sqlEl = els.find((e) => e.source?.kind === 'sql');
+  const derived = byName('Order Fact View');
+  const col = (el: any, n: string) => el?.columns?.find((c: any) => c.name === n);
+
+  check('dm', 'schemaVersion is 1', (r.model as any).schemaVersion === 1);
+  check('dm', 'warehouse-table elements for both referenced tables (path CSA/TJ/TABLE)',
+    JSON.stringify(orderFact?.source?.path) === JSON.stringify(['CSA', 'TJ', 'ORDER_FACT'])
+    && JSON.stringify(customerDim?.source?.path) === JSON.stringify(['CSA', 'TJ', 'CUSTOMER_DIM']));
+  check('dm', 'field-id resolution: plain column = inode id + [TABLE/Display] formula',
+    orderFact?.columns?.some((c: any) => /^inode-.{22}\/SALES_AMOUNT$/.test(c.id) && c.formula === '[ORDER_FACT/Sales Amount]'));
+  check('dm', 'join element: live contract — columns key, left-outer, named sides, [Display] refs',
+    joinEl?.source?.kind === 'join'
+    && typeof joinEl?.source?.name === 'string'
+    && joinEl?.source?.joins?.[0]?.joinType === 'left-outer'
+    && typeof joinEl?.source?.joins?.[0]?.name === 'string'
+    && joinEl?.source?.joins?.[0]?.left?.connectionId !== undefined
+    && joinEl?.source?.joins?.[0]?.columns?.[0]?.left === '[Customer Key]'
+    && joinEl?.source?.joins?.[0]?.columns?.[0]?.right === '[Customer Key]');
+  check('dm', 'arithmetic expression: Net Amount = ([Sales Amount] - [Discount Amount])',
+    col(joinEl, 'Net Amount')?.formula === '([Sales Amount] - [Discount Amount])');
+  check('dm', 'case → If, multi-value = → infix or chain (no IsIn, no Or() function — live-verified)',
+    col(joinEl, 'Tier Bucket')?.formula === 'If(([Loyalty Tier] = "GOLD" or [Loyalty Tier] = "PLATINUM"), "Premium", "Standard")');
+  check('dm', 'datetime-diff → DateDiff',
+    col(orderFact, 'Days Since Order')?.formula === 'DateDiff("day", [Order Date], Now())');
+  check('dm', 'breakout temporal-unit → DateTrunc calc column',
+    col(orderFact, 'Order Date (Month)')?.formula === 'DateTrunc("month", [Order Date])');
+  check('dm', 'named aggregation keeps its display-name (Total Revenue)',
+    joinEl?.metrics?.some((m: any) => m.name === 'Total Revenue' && m.formula === 'Sum([Sales Amount])'));
+  check('dm', 'unnamed aggregation derives a name (Sum of Sales Amount)',
+    orderFact?.metrics?.some((m: any) => m.name === 'Sum of Sales Amount' && m.formula === 'Sum([Sales Amount])'));
+  check('dm', 'card filter NOT applied to the shared element (warned instead)',
+    !orderFact?.filters && r.warnings.some((w) => /NOT applied to the shared/.test(w) && /DateAdd\("day", -365, Today\(\)\)/.test(w)));
+  check('dm', 'native SQL card → sql-source element with NO element-level name',
+    !!sqlEl && sqlEl.name === undefined && /SELECT/.test(sqlEl.source.statement));
+  check('dm', 'native sql columns are [Custom SQL/RAW_ALIAS] refs with names (bare refs error live)',
+    sqlEl?.columns?.some((c: any) => /^\[Custom SQL\//.test(c.formula) && typeof c.name === 'string'));
+  check('dm', 'plain text {{tag}} warns with the control to create',
+    r.warnings.some((w) => /\{\{region\}\}/.test(w) && /control/.test(w) && /"region"/.test(w)));
+  check('dm', 'dimension {{tag}} (field filter) is flagged',
+    r.warnings.some((w) => /\{\{order_date\}\}/.test(w) && /FIELD FILTER/.test(w)));
+  check('dm', 'FK metadata → relationship CUSTOMER_DIM on the fact element',
+    orderFact?.relationships?.length === 1
+    && orderFact.relationships[0].name === 'CUSTOMER_DIM'
+    && orderFact.relationships[0].targetElementId === customerDim?.id
+    && orderFact.relationships[0].keys?.[0]?.sourceColumnId && orderFact.relationships[0].keys?.[0]?.targetColumnId);
+  check('dm', 'STORE_DIM FK skipped (table not referenced — both tables must be present)',
+    !els.some((e) => e.name === 'Store Dim') && orderFact?.relationships?.length === 1);
+  check('dm', 'derived join view exists and exposes dim columns',
+    !!derived && derived.columns.some((c: any) => c.formula === '[Order Fact/CUSTOMER_DIM/Region]'));
+  check('dm', 'derived view SKIPS the relationship key column (no Customer Key passthrough)',
+    !!derived && !derived.columns.some((c: any) => c.formula === '[Order Fact/CUSTOMER_DIM/Customer Key]'));
+}
+
+// ── nested questions (source-table "card__N") ────────────────────────────────
+{
+  const nested = {
+    id: 300, name: 'Premium Orders', type: 'question', display: 'table', database_id: 2,
+    dataset_query: { type: 'query', database: 2, query: { 'source-table': 'card__100' } },
+    result_metadata: [],
+  };
+  const r = convertMetabaseToSigma({ metadata, cards: [ordersModel, nested] }, { connectionId: 'c', database: 'CSA', schema: 'TJ' });
+  const els = r.model.pages[0].elements as any[];
+  const parent = els.find((e) => e.name === 'Orders Model');
+  const child = els.find((e) => e.name === 'Premium Orders');
+  check('nested', 'in-input nested card → element sourced from card 100\'s element',
+    !!child && child.source?.kind === 'table' && child.source?.elementId === parent?.id);
+
+  const r2 = convertMetabaseToSigma({ metadata, cards: [nested] }, { connectionId: 'c', database: 'CSA' });
+  check('nested', 'missing source card → warning + skip',
+    !(r2.model.pages[0].elements as any[]).some((e: any) => e.name === 'Premium Orders')
+    && r2.warnings.some((w) => /card 100/.test(w) && /NOT in the input set/.test(w)));
+}
+
+// ── learned rules hook (applied before built-in translation) ─────────────────
+{
+  const r = convertMetabaseToSigma(
+    { metadata, cards: [revenueTrend] },
+    { connectionId: 'c', database: 'CSA', learnedRules: [{ pattern: '\\["datetime-diff",.*"day"\\]', template: 'DaysBetween()' }] },
+  );
+  const of = (r.model.pages[0].elements as any[]).find((e) => e.name === 'Order Fact');
+  check('rules', 'learned rule overrides the built-in translation',
+    of?.columns?.some((c: any) => c.name === 'Days Since Order' && c.formula === 'DaysBetween()'));
+}
+
+// ── sandboxing detection (detect-only) ───────────────────────────────────────
+{
+  const r = convertMetabaseToSigma({
+    metadata, cards: [revenueTrend],
+    sandboxes: [{ table_id: 45, group_id: 7, attribute_remappings: { region: ['dimension', ['field', 85, null]] } }],
+  }, { connectionId: 'c', database: 'CSA' });
+  check('security', 'sandbox → security entry (row-filter, group, readable expression)',
+    (r as any).security?.length === 1
+    && (r as any).security[0].type === 'row-filter'
+    && (r as any).security[0].groups?.[0] === 7
+    && /\[Region\] = user attribute "region"/.test((r as any).security[0].expression));
+  check('security', 'security is detect-only — no filters injected into the model',
+    !(r.model.pages[0].elements as any[]).some((e: any) => e.filters?.length)
+    && r.warnings.some((w) => /SECURITY/.test(w) && /NOT ported/.test(w)));
+}
+
+// ── dashboard → workbook ─────────────────────────────────────────────────────
+{
+  const r = convertMetabaseDashboardToSigma(read('exec-overview.dashboard.json'),
+    { metadata, cardNameById: { 100: 'Orders Model' } });
+  const wb = r.workbook;
+  const els = wb.pages.flatMap((p) => p.elements) as any[];
+  const byName = (n: string) => els.find((e) => e.name === n);
+
+  check('wb', 'schemaVersion is 1', wb.schemaVersion === 1);
+  check('wb', 'one page per dashboard tab (Overview, Detail) + trailing Data page for base tables',
+    wb.pages.length === 3 && wb.pages[0].name === 'Overview' && wb.pages[1].name === 'Detail'
+    && wb.pages[2].name === 'Data' && wb.pages[2].id.startsWith('data'));
+  check('wb', 'text dashcard → text element with the markdown in body (live contract)',
+    els.some((e) => e.kind === 'text' && /## Executive Overview/.test((e as any).body)));
+  const kpi = byName('Total Revenue');
+  check('wb', 'scalar → kpi-chart with value {columnId} (NOT {id})',
+    kpi?.kind === 'kpi-chart' && !!kpi.value?.columnId && kpi.value?.id === undefined);
+  check('wb', 'column_settings currency/decimals → Sigma format on the KPI column',
+    kpi?.columns?.some((c: any) => c.format?.formatString === '$,.0f'));
+  const line = byName('Revenue Trend');
+  check('wb', 'line → line-chart with x dim + y metric matched through result_metadata',
+    line?.kind === 'line-chart' && !!line.xAxis?.columnId && line.yAxis?.columnIds?.length === 1);
+  const lineBase = byName('Revenue Trend Base');
+  check('wb', 'range-mapped chart re-rooted through a base TABLE on the Data page (control targets need a table)',
+    lineBase?.kind === 'table' && lineBase?.source?.kind === 'data-model' && lineBase?.source?.elementId === 'Order Fact'
+    && wb.pages[2].elements.some((e: any) => e.id === lineBase.id)
+    && line?.source?.kind === 'table' && line?.source?.elementId === lineBase.id);
+  check('wb', 'line x column is the DateTrunc breakout rewritten through the base table',
+    line?.columns?.some((c: any) => c.formula === 'DateTrunc("month", [Revenue Trend Base/Order Date])')
+    && lineBase?.columns?.some((c: any) => c.name === 'Order Date' && c.formula === '[Order Fact/Order Date]'));
+  const bar = byName('Customers by Region');
+  check('wb', 'bar → bar-chart with orientation key OMITTED (vertical)',
+    bar?.kind === 'bar-chart' && !('orientation' in bar));
+  const row = byName('Customers by Loyalty Tier');
+  check('wb', 'row → bar-chart with orientation "horizontal" (the only valid value)',
+    row?.kind === 'bar-chart' && row.orientation === 'horizontal');
+  const pie = byName('Stores by State');
+  check('wb', 'pie → pie-chart with slice + value', pie?.kind === 'pie-chart' && !!pie.color?.id && !!pie.value?.id);
+  const pivot = byName('Revenue by Region and Tier');
+  check('wb', 'pivot → rowsBy/columnsBy as [{id}] OBJECTS + values as bare id strings',
+    pivot?.kind === 'pivot-table'
+    && pivot.rowsBy?.length === 1 && typeof pivot.rowsBy[0] === 'object' && !!pivot.rowsBy[0].id
+    && pivot.columnsBy?.length === 1 && !!pivot.columnsBy[0].id
+    && pivot.values?.length === 1 && typeof pivot.values[0] === 'string');
+  check('wb', 'explicit-join card sources its own card-named join element (exact columns, no dedup suffixes)',
+    pivot?.source?.elementId === 'Revenue by Region and Tier');
+  const funnel = byName('Tier Funnel (was funnel)');
+  check('wb', 'funnel → table element + LOUD warning (never fake a viz)',
+    funnel?.kind === 'table' && r.warnings.some((w) => /funnel/.test(w) && /TABLE/.test(w)));
+  check('wb', 'nested-question dashcard → source placeholder is the model name',
+    byName('Premium Orders')?.source?.elementId === 'Orders Model');
+  check('wb', 'nested card MBQL filter → hidden bool column + element filter [true]',
+    byName('Premium Orders')?.columns?.some((c: any) => c.hidden && c.formula === '[Orders Model/Tier Bucket] = "Premium"')
+    && byName('Premium Orders')?.filters?.some((f: any) => f.kind === 'list' && f.mode === 'include' && f.values[0] === true));
+  const dateCtl = (wb.controls || []).find((c) => c.controlId === 'date_range');
+  check('wb', 'parameters → controls wired by slug (date/range → date-range mode "between", string/= → list)',
+    dateCtl?.controlType === 'date-range' && (dateCtl as any)?.mode === 'between'
+    && (wb.controls || []).some((c) => c.controlId === 'region' && c.controlType === 'list'));
+  check('wb', 'relative range default dropped with a warning (no verified Sigma spec shape)',
+    dateCtl?.value === undefined && r.warnings.some((w) => /range default "past30days"/.test(w)));
+  const barBase = byName('Customers by Region Base');
+  const regionCtl = (wb.controls || []).find((c) => c.controlId === 'region') as any;
+  check('wb', 'list parameter_mapping → control `filters` target on the chart\'s base table (NO boolean match column — list-control formula refs error live)',
+    regionCtl?.filters?.length === 1
+    && regionCtl.filters[0].source?.kind === 'table'
+    && regionCtl.filters[0].source?.elementId === barBase?.id
+    && regionCtl.filters[0].columnId === barBase?.columns?.find((c: any) => c.name === 'Region')?.id
+    && !bar?.columns?.some((c: any) => /= \[region\]/.test(String(c.formula))));
+  check('wb', 'range parameter_mapping → control `filters` target on the base table column (not boolean equality)',
+    (dateCtl as any)?.filters?.length === 1
+    && (dateCtl as any).filters[0].source?.kind === 'table'
+    && (dateCtl as any).filters[0].source?.elementId === lineBase?.id
+    && (dateCtl as any).filters[0].columnId === lineBase?.columns?.find((c: any) => c.name === 'Order Date')?.id
+    && !line?.columns?.some((c: any) => /= \[date_range\]/.test(String(c.formula))));
+  check('wb', 'element source placeholders are DM element NAMES on data-model sources (remap rewrites); mapped charts re-root through their base',
+    row?.source?.kind === 'data-model' && row?.source?.elementId === 'Customer Dim'
+    && bar?.source?.kind === 'table' && bar?.source?.elementId === barBase?.id);
+  check('wb', 'controls placed AFTER the elements they target in spec order (POST rejects forward targets)',
+    (() => { const kinds = wb.pages[0].elements.map((e: any) => e.kind); return kinds.lastIndexOf('control') === kinds.length - 1 && kinds.indexOf('control') > kinds.findIndex((k: string) => k !== 'control'); })());
+  check('wb', 'control-scope sidecar: signals = mapped params; scope/mustReach = declared targets',
+    r.controlScope.sourceFilterSignals === 2
+    && r.controlScope.controls.length === 2
+    && JSON.stringify(r.controlScope.controls.find((c) => c.controlId === 'date_range')?.scope) === '["Revenue Trend"]'
+    && JSON.stringify(r.controlScope.controls.find((c) => c.controlId === 'region')?.mustReach) === '["Customers by Region"]');
+  check('wb', 'layout hints preserve the 1:1 24-col grid',
+    r.layout.grid === 24
+    && r.layout.pages[0].elements.some((h) => h.name === 'Revenue Trend' && h.col === 5 && h.sizeX === 10 && h.sizeY === 6));
+  check('wb', 'click_behavior flagged', r.warnings.some((w) => /click_behavior/.test(w)));
+}
+
+// ── legacy ordered_cards (sizeX/sizeY) ───────────────────────────────────────
+{
+  const r = convertMetabaseDashboardToSigma(read('legacy-grid.dashboard.json'), { metadata });
+  const els = r.workbook.pages.flatMap((p) => p.elements) as any[];
+  check('legacy', 'ordered_cards accepted — both dashcards converted on one page',
+    r.workbook.pages.length === 1 && els.filter((e) => e.kind !== 'control').length === 2);
+  check('legacy', 'sizeX/sizeY geometry flows into the layout hints',
+    r.layout.pages[0].elements.some((h) => h.sizeX === 12 && h.sizeY === 6));
+  check('legacy', 'kpi value {columnId} on the legacy scalar too',
+    els.some((e) => e.kind === 'kpi-chart' && !!e.value?.columnId));
+}
+
+// ── pMBQL (modern "lib/" MBQL — 100% of a 7k-card production estate) ─────────
+{
+  const cards = ['pmbql-native', 'pmbql-native-tags', 'pmbql-structured', 'pmbql-joins', 'pmbql-expressions', 'pmbql-multistage']
+    .map((f) => read(`${f}.card.json`));
+  const r = convertMetabaseToSigma({ metadata, cards }, { connectionId: 'c', database: 'CSA', schema: 'TJ' });
+  const els = r.model.pages[0].elements as any[];
+  const sqlEls = els.filter((e) => e.source?.kind === 'sql');
+  const ctrl = (id: string) => els.find((e) => e.kind === 'control' && e.controlId === id);
+  // pmbql-native is a SIMPLE single-SELECT → auto-remodeled to a native model (no
+  // sql element); pmbql-native-tags has variable tags → stays a custom-SQL element.
+  check('pmbql', 'simple native stage → native model; tagged native stage stays sql (1 sql element)',
+    sqlEls.length === 1
+    && r.warnings.some((w) => /Daily Revenue \(pMBQL Native\).*auto-remodeled to a NATIVE Sigma data model/.test(w)));
+  const tagged = sqlEls.find((e) => /JOIN CSA.TJ.CUSTOMER_DIM/.test(e.source.statement));
+  check('pmbql', 'plain {{region}} kept verbatim (Sigma uses the same syntax) + text control emitted',
+    /\{\{region\}\}/.test(tagged?.source.statement || '')
+    && ctrl('region')?.controlType === 'text' && ctrl('region')?.value === 'West');
+  check('pmbql', 'number tag → number control with default',
+    ctrl('min_qty')?.controlType === 'number' && ctrl('min_qty')?.value === 1);
+  check('pmbql', 'field-filter tag neutralized to 1=1 + brace-free comment (Sigma parses {{}} in comments)',
+    /1=1 \/\* Metabase field filter 'order_date' → filter \[Order Date\]/.test(tagged?.source.statement || '')
+    && !/\{\{order_date\}\}/.test(tagged?.source.statement || ''));
+  check('pmbql', 'optional [[…]] block without a default DROPPED + warned',
+    !/\{\{tier\}\}/.test(tagged?.source.statement || '') && r.warnings.some((w) => /\[\[…\]\] block DROPPED/.test(w) && /tier/.test(w)));
+  check('pmbql', 'card tag {{#400…}} inlined as a sub-select from the referenced native card',
+    /\(\nSELECT ORDER_DATE, SUM\(SALES_AMOUNT\)/.test(tagged?.source.statement || ''));
+  const of = els.find((e) => e.name === 'Order Fact');
+  check('pmbql', 'named pMBQL aggregation (display-name in opts) → Total Revenue metric',
+    of?.metrics?.some((m: any) => m.name === 'Total Revenue' && m.formula === 'Sum([Sales Amount])')
+    && of?.metrics?.some((m: any) => m.name === 'Count' && m.formula === 'Count()'));
+  check('pmbql', 'opts-second temporal-unit breakout → DateTrunc week calc',
+    of?.columns?.some((c: any) => c.name === 'Order Date (Week)' && c.formula === 'DateTrunc("week", [Order Date])'));
+  check('pmbql', 'filters array AND-merged; pMBQL "in" → Or chain (warned on the shared element)',
+    r.warnings.some((w) => /\(\[Order Number\] = 100 or \[Order Number\] = 200\)/.test(w))
+    && r.warnings.some((w) => /\[Order Date\] >= DateAdd\("month", -6, Today\(\)\)/.test(w)));
+  const joinEl = els.find((e) => e.name === 'Orders with Customers (pMBQL Join)');
+  check('pmbql', 'pMBQL join {stages, conditions} → join source on Customer Key (live shape)',
+    joinEl?.source?.kind === 'join' && joinEl?.source?.joins?.[0]?.joinType === 'left-outer'
+    && joinEl?.source?.joins?.[0]?.columns?.[0]?.left === '[Customer Key]');
+  check('pmbql', 'expression list (lib/expression-name) → calc columns: case→If, date()→DateTrunc day',
+    of?.columns?.some((c: any) => c.name === 'Size Bucket' && c.formula === 'If([Sales Amount] > 1000, "Large", "Small")')
+    && of?.columns?.some((c: any) => c.name === 'Days to Now' && c.formula === 'DateDiff("day", [Order Date], Now())')
+    && of?.columns?.some((c: any) => c.name === 'Order Day' && c.formula === 'DateTrunc("day", [Order Date])'));
+  check('pmbql', 'multi-stage card flagged + skipped (never silently mistranslated)',
+    r.warnings.some((w) => /MULTI-STAGE/.test(w) && /Average Weekly Revenue/.test(w))
+    && !els.some((e) => e.name === 'Average Weekly Revenue (pMBQL Multi-Stage)'));
+}
+
+// ── legacy_query preference (server's own down-conversion wins when present) ──
+{
+  const { normalizeCard } = await import('./pmbql-normalize.mjs');
+  const card = {
+    id: 1, name: 'lq', dataset_query: { 'lib/type': 'mbql/query', database: 2, stages: [{ 'lib/type': 'mbql.stage/native', native: 'SELECT 2' }] },
+    legacy_query: JSON.stringify({ type: 'native', database: 2, native: { query: 'SELECT 1', 'template-tags': {} } }),
+  };
+  const n = normalizeCard(card);
+  check('pmbql', 'legacy_query JSON string preferred over re-normalizing',
+    n.dataset_query.type === 'native' && n.dataset_query.native.query === 'SELECT 1');
+  const n2 = normalizeCard({ ...card, legacy_query: 'not json {' });
+  check('pmbql', 'unparseable legacy_query falls back to the normalizer',
+    n2.dataset_query.type === 'native' && n2.dataset_query.native.query === 'SELECT 2');
+}
+
+// ── pMBQL dashboard: tag wiring, conditional formats, series settings, object ─
+{
+  const r = convertMetabaseDashboardToSigma(read('pmbql-params.dashboard.json'), { metadata });
+  const els = r.workbook.pages.flatMap((p) => p.elements) as any[];
+  const table = els.find((e) => e.name === 'Filtered Revenue (pMBQL Native + Tags)');
+  const bar = els.find((e) => e.name === 'Weekly Orders by Region (pMBQL)');
+  check('pmbql-wb', 'date/range dimension parameter → live date-range control (real filter target)',
+    (r.workbook.controls || []).some((c) => c.controlId === 'order_window' && c.controlType === 'date-range'));
+  check('pmbql-wb', 'variable + field-filter template-tag targets recorded in parameterWiring',
+    (r.parameterWiring || []).some((w) => w.slug === 'region_param' && w.tag === 'region' && w.kind === 'variable')
+    && (r.parameterWiring || []).some((w) => w.slug === 'order_date_param' && w.tag === 'order_date' && w.kind === 'field-filter'));
+  check('pmbql-wb', 'tag wiring warnings AGGREGATED (one per parameter, not per mapping)',
+    r.warnings.filter((w) => /drives native template tag/.test(w)).length === 2);
+  const barBase = els.find((e) => e.name === 'Weekly Orders by Region (pMBQL) Base');
+  const owCtl = (r.workbook.controls || []).find((c) => c.controlId === 'order_window') as any;
+  check('pmbql-wb', 'pMBQL dimension target (opts-second field) on a date/range param → base-table control filter target',
+    barBase?.kind === 'table'
+    && bar?.source?.elementId === barBase?.id
+    && owCtl?.filters?.[0]?.source?.elementId === barBase?.id
+    && !bar?.columns?.some((c: any) => /= \[order_window\]$/.test(String(c.formula))));
+  check('pmbql-wb', 'unwirable field-filter control NOT emitted (column missing from every mapped result set)',
+    !(r.workbook.controls || []).some((c) => c.controlId === 'order_date_param')
+    && r.warnings.some((w) => /order_date_param.*NOT emitted|control "Order Date".*NOT emitted/i.test(w)));
+  check('pmbql-wb', 'variable-tag-only control NOT emitted (DM-SQL {{tag}} binding is inert, live-disproven) and listed in unreproducibleFilters',
+    !(r.workbook.controls || []).some((c) => c.controlId === 'region_param')
+    && (r.unreproducibleFilters || []).some((u) => u.controlId === 'region_param' && /inert|pre-aggregation/.test(u.reason)));
+  check('pmbql-wb', 'table.column_formatting single rule → conditionalFormats; range rule flagged',
+    table?.conditionalFormats?.length === 1
+    && table.conditionalFormats[0].condition === '>'
+    && table.conditionalFormats[0].style?.backgroundColor === '#22c55e'
+    && r.warnings.some((w) => /gradient\/range/.test(w)));
+  check('pmbql-wb', 'series_settings title renames the series column',
+    bar?.columns?.some((c: any) => c.name === 'Revenue ($)')
+    && r.warnings.some((w) => /per-series color/.test(w)));
+  check('pmbql-wb', 'object display → flagged detail-view table',
+    els.some((e) => e.kind === 'table' && e.name === 'Order Record (object detail)')
+    && r.warnings.some((w) => /object DETAIL view/.test(w)));
+  check('pmbql-wb', 'virtual text card still passes markdown through (body field)',
+    els.some((e) => e.kind === 'text' && /## Ops Notes/.test((e as any).body)));
+}
+
+// ── control-targeting: unmapped parameters are furniture in Metabase too ─────
+{
+  const d = read('exec-overview.dashboard.json');
+  d.parameters = [...(d.parameters || []), { id: 'pX', name: 'Orphan Filter', slug: 'orphan', type: 'string/=' }];
+  const r = convertMetabaseDashboardToSigma(d, { metadata, cardNameById: { 100: 'Orders Model' } });
+  check('scope', 'parameter with zero parameter_mappings → NO control + loud warning',
+    !(r.workbook.controls || []).some((c) => c.controlId === 'orphan')
+    && r.warnings.some((w) => /"Orphan Filter".*NO parameter_mappings/.test(w)));
+  check('scope', 'unmapped parameter not counted in sourceFilterSignals',
+    r.controlScope.sourceFilterSignals === 2);
+}
+
+// ── BigQuery estate: paths/casing/dialect (Sigma side LIVE-verified 2026-06-11
+// against conn bc534032 "BigQuery- Wells"; Metabase side fixture-shaped) ────────
+{
+  const bq = read('bq-estate.card.json');
+  // NO --database flag: project must come from metadata.details['project-id'].
+  const r = convertMetabaseToSigma(bq, { connectionId: 'connBQ' });
+  const els = r.model.pages[0].elements as any[];
+  const orders = els.find((e) => e.name === 'Data Order');
+  const customers = els.find((e) => e.name === 'Dim Customer');
+  const joinEl = els.find((e) => e.name === 'Revenue by Region (BQ join)');
+  const sqlEl = els.find((e) => e.source?.kind === 'sql');
+
+  check('bq', 'project auto-derived from details.project-id, case-preserved lowercase table tail',
+    JSON.stringify(orders?.source?.path) === JSON.stringify(['acme-data-lake', 'dbt_prod', 'data_order']));
+  check('bq', 'per-table dataset wins (estate spans datasets — no global --schema)',
+    JSON.stringify(customers?.source?.path) === JSON.stringify(['acme-data-lake', 'dbt_core', 'dim_customer']));
+  check('bq', 'warehouse column prefix matches the lowercase path tail',
+    orders?.columns?.some((c: any) => c.formula === '[data_order/Order Id]'));
+  check('bq', 'BQ-dialect native SQL verbatim (backticks + trailing comma preserved)',
+    /`acme-data-lake\.dbt_prod\.data_order`/.test(sqlEl?.source?.statement || '')
+    && /as n_orders,\s*from/.test(sqlEl?.source?.statement || ''));
+  check('bq', 'join source/relationship names case-preserved + prettified condition refs',
+    joinEl?.source?.name === 'data_order'
+    && joinEl?.source?.joins?.[0]?.name === 'dim_customer'
+    && joinEl?.source?.joins?.[0]?.columns?.[0]?.left === '[Customer Id]'
+    && orders?.relationships?.some((x: any) => x.name === 'dim_customer'));
+}
+
+// ── the two pmbql-normalize.mjs copies must stay byte-identical ──────────────
+{
+  const here = dirname(fileURLToPath(import.meta.url));
+  const a = readFileSync(join(here, 'pmbql-normalize.mjs'), 'utf8');
+  const b = readFileSync(join(here, '..', '..', 'metabase-assessment', 'scripts', 'pmbql-normalize.mjs'), 'utf8');
+  check('sync', 'converter + assessment pmbql-normalize.mjs copies are byte-identical', a === b);
+}
+
+// ── native-SQL → NATIVE-MODEL recognizer (auto-remodel + safety bails) ───────
+{
+  const meta = { tables: [
+    { id: 1, name: 'ORDER_FACT', schema: 'TJ', fields: [
+      { id: 101, name: 'CUSTOMER_KEY', base_type: 'type/Integer' },
+      { id: 102, name: 'NET_REVENUE', base_type: 'type/Float' }] },
+    { id: 2, name: 'CUSTOMER_DIM', schema: 'TJ', fields: [
+      { id: 201, name: 'CUSTOMER_KEY', base_type: 'type/Integer' },
+      { id: 202, name: 'REGION', base_type: 'type/Text' },
+      { id: 203, name: 'LAST_NAME', base_type: 'type/Text' }] }] };
+  const fidx = buildFieldIndex(meta);
+  const ff = (name: string, fid: number) => ({ [name]: { id: 't', name, 'display-name': name, type: 'dimension', dimension: ['field', fid, null], 'widget-type': 'string/=' } });
+  const card = (q: string, tags?: any) => ({ id: 9, name: 'Native', display: 'bar',
+    dataset_query: { type: 'native', database: 2, native: { query: q, 'template-tags': tags || {} } },
+    result_metadata: [{ name: 'REGION', display_name: 'Region' }, { name: 'NET_REVENUE', display_name: 'Net Revenue' }],
+    visualization_settings: { 'graph.dimensions': ['REGION'], 'graph.metrics': ['NET_REVENUE'] } });
+  const JOIN = 'from CSA.TJ.ORDER_FACT f join CSA.TJ.CUSTOMER_DIM c on f.CUSTOMER_KEY = c.CUSTOMER_KEY';
+
+  const simple = card(`select c.REGION as REGION, sum(f.NET_REVENUE) as NET_REVENUE ${JOIN} where {{last_name}} group by c.REGION`, ff('last_name', 203));
+  const rm = recognizeSimpleNativeSql(simple, fidx);
+  check('remodel', 'simple SELECT+JOIN+GROUP BY → structured native model + surfaces field-filter dim',
+    !!rm && rm.query['source-table'] === 1 && rm.query.joins?.length === 1 && rm.query.aggregation?.length === 1
+    && rm.resultMetadata.some((r: any) => r.name === 'LAST_NAME' && r.field_ref[1] === 203));
+  const dmR = convertMetabaseToSigma({ metadata: meta, cards: [simple] }, { connectionId: 'c', database: 'CSA' });
+  check('remodel', 'remodeled card emits a NATIVE element (join source), NO sql element',
+    !dmR.model.pages[0].elements.some((e: any) => e.source?.kind === 'sql')
+    && dmR.model.pages[0].elements.some((e: any) => e.source?.kind === 'join'));
+  // the field filter wires to a LIVE control with a real element-filter target
+  const dash = { name: 'D', parameters: [{ id: 'p', name: 'Last Name', slug: 'last_name', type: 'string/=', sectionId: 'string' }],
+    dashcards: [{ id: 1, card_id: 9, row: 0, col: 0, size_x: 12, size_y: 8, card: simple,
+      parameter_mappings: [{ parameter_id: 'p', card_id: 9, target: ['dimension', ['template-tag', 'last_name']] }] }] };
+  const wbR = convertMetabaseDashboardToSigma(dash, { metadata: meta });
+  const lnCtrl = (wbR.workbook.controls || []).find((c) => c.controlId === 'last_name') as any;
+  check('remodel', 'field-filter param → LIVE control with a real element-filter target (not dead furniture)',
+    !!lnCtrl && (lnCtrl.filters || []).length > 0 && !(wbR.unreproducibleFilters || []).some((u) => u.controlId === 'last_name'));
+
+  // SAFETY BAILS — never silently mistranslate
+  check('remodel', 'real WHERE predicate → bail to custom SQL (no silent filter drop)',
+    recognizeSimpleNativeSql(card(`select c.REGION as REGION, sum(f.NET_REVENUE) as NET_REVENUE ${JOIN} where f.NET_REVENUE > 100 and {{last_name}} group by c.REGION`, ff('last_name', 203)), fidx) === null);
+  check('remodel', 'LIMIT → bail', recognizeSimpleNativeSql(card('select c.REGION as REGION from CSA.TJ.CUSTOMER_DIM c group by c.REGION limit 10'), fidx) === null);
+  check('remodel', 'CASE / CTE / subquery / window → bail',
+    recognizeSimpleNativeSql(card('select case when 1=1 then 2 end as x from CSA.TJ.ORDER_FACT f'), fidx) === null
+    && recognizeSimpleNativeSql(card('with t as (select 1) select * from t'), fidx) === null
+    && recognizeSimpleNativeSql(card('select count(*) n from CSA.TJ.ORDER_FACT f where id in (select id from CSA.TJ.CUSTOMER_DIM c)'), fidx) === null);
+  check('remodel', 'variable (non-field-filter) tag → bail (needs custom-SQL substitution)',
+    recognizeSimpleNativeSql(card(`select c.REGION as REGION ${JOIN} where c.REGION = {{region}} group by c.REGION`, { region: { id: 't', name: 'region', type: 'text' } }), fidx) === null);
+  check('remodel', 'unknown table/column → bail', recognizeSimpleNativeSql(card('select x from NOPE.NOPE.NOPE n'), fidx) === null);
+  check('remodel', 'no metadata → bail (safe)', recognizeSimpleNativeSql(simple, undefined) === null);
+
+  // trailing semicolon must be stripped from custom-SQL fallback (Sigma wraps the
+  // statement as a subquery → trailing `;` is a POST syntax error). CTE → not remodeled.
+  const semi = { id: 7, name: 'Semi', display: 'table',
+    dataset_query: { type: 'native', database: 2, native: {
+      query: 'with t as (select region from CSA.TJ.CUSTOMER_DIM) select * from t order by region;', 'template-tags': {} } },
+    result_metadata: [{ name: 'region', display_name: 'Region' }] };
+  const semiR = convertMetabaseToSigma({ metadata: meta, cards: [semi] }, { connectionId: 'c', database: 'CSA' });
+  const semiEl = semiR.model.pages[0].elements.find((e: any) => e.source?.kind === 'sql');
+  check('remodel', 'custom-SQL fallback strips trailing semicolon (no subquery-wrap break)',
+    !!semiEl && !/;\s*$/.test(semiEl.source.statement) && /order by region$/i.test(semiEl.source.statement.trim()));
+}
+
+// ── every fixture converts without throwing ──────────────────────────────────
+for (const f of readdirSync(FIX).sort()) {
+  try {
+    if (f.endsWith('.card.json')) {
+      const j = read(f);
+      // self-contained bundles ({metadata, cards}) carry their own engine metadata
+      const r = j.cards
+        ? convertMetabaseToSigma(j, { connectionId: 'c' })
+        : convertMetabaseToSigma({ metadata, cards: [j] }, { connectionId: 'c', database: 'CSA', schema: 'TJ' });
+      // a lone flagged card (e.g. multi-stage) may legitimately produce 0 elements — but never silently
+      if (!r.model.pages[0].elements.length && !r.warnings.length) throw new Error('no elements and no warnings');
+      console.log(`✓ ${f.padEnd(36)} cards → ${r.stats.elements} elems · ${r.stats.columns} cols · ${r.stats.metrics} metrics · ${r.stats.relationships} rels (${r.warnings.length} warnings)`);
+    } else if (f.endsWith('.dashboard.json')) {
+      const r = convertMetabaseDashboardToSigma(read(f), { metadata });
+      if (!r.workbook.pages.length) throw new Error('no pages');
+      console.log(`✓ ${f.padEnd(36)} dashboard → ${r.stats.pages} pages · ${r.stats.kpis} kpis · ${r.stats.charts} charts · ${r.stats.pivots} pivots · ${r.stats.tables} tables · ${r.stats.texts} texts · ${r.stats.controls} controls · ${r.stats.filters} filters (${r.warnings.length} warnings)`);
+    }
+  } catch (e: any) { fail++; console.log(`✗ ${f} — ${e.message}`); }
+}
+
+console.log(fail ? `\n${fail} FAILED` : '\nall checks green ✓');
+process.exit(fail ? 1 : 0);

--- a/metabase-migration-skills/metabase-to-sigma/converter/tsconfig.json
+++ b/metabase-migration-skills/metabase-to-sigma/converter/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["*.ts"]
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/bq-estate.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/bq-estate.card.json
@@ -1,0 +1,69 @@
+{
+  "metadata": {
+    "engine": "bigquery-cloud-sdk",
+    "name": "Acme BigQuery",
+    "details": { "project-id": "acme-data-lake" },
+    "tables": [
+      {
+        "id": 1,
+        "name": "data_order",
+        "schema": "dbt_prod",
+        "fields": [
+          { "id": 11, "name": "order_id", "base_type": "type/Text" },
+          { "id": 12, "name": "customer_id", "base_type": "type/Integer", "fk_target_field_id": 21 },
+          { "id": 13, "name": "order_total", "base_type": "type/Float" },
+          { "id": 14, "name": "brand", "base_type": "type/Text" }
+        ]
+      },
+      {
+        "id": 2,
+        "name": "dim_customer",
+        "schema": "dbt_core",
+        "fields": [
+          { "id": 21, "name": "customer_id", "base_type": "type/Integer" },
+          { "id": 22, "name": "customer_region", "base_type": "type/Text" }
+        ]
+      }
+    ]
+  },
+  "cards": [
+    {
+      "id": 901,
+      "name": "Orders by Brand (BQ native)",
+      "display": "bar",
+      "dataset_query": {
+        "type": "native",
+        "database": 7,
+        "native": {
+          "query": "select brand, count(*) as n_orders, from `acme-data-lake.dbt_prod.data_order` group by brand order by n_orders desc"
+        }
+      },
+      "result_metadata": [
+        { "name": "brand", "display_name": "brand" },
+        { "name": "n_orders", "display_name": "n_orders" }
+      ]
+    },
+    {
+      "id": 902,
+      "name": "Revenue by Region (BQ join)",
+      "display": "bar",
+      "dataset_query": {
+        "type": "query",
+        "database": 7,
+        "query": {
+          "source-table": 1,
+          "joins": [
+            {
+              "source-table": 2,
+              "alias": "c",
+              "strategy": "left-join",
+              "condition": ["=", ["field", 12, null], ["field", 21, { "join-alias": "c" }]]
+            }
+          ],
+          "aggregation": [["sum", ["field", 13, null]]],
+          "breakout": [["field", 22, { "join-alias": "c" }]]
+        }
+      }
+    }
+  ]
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/exec-overview.dashboard.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/exec-overview.dashboard.json
@@ -1,0 +1,189 @@
+{
+  "id": 9,
+  "name": "Exec Overview",
+  "description": "Executive orders dashboard — tabs, parameters, mixed viz.",
+  "parameters": [
+    { "id": "p1", "name": "Date",   "slug": "date_range", "type": "date/range", "default": "past30days" },
+    { "id": "p2", "name": "Region", "slug": "region",     "type": "string/=",   "default": null }
+  ],
+  "tabs": [
+    { "id": 11, "name": "Overview" },
+    { "id": 12, "name": "Detail" }
+  ],
+  "dashcards": [
+    {
+      "id": 1, "card_id": null, "dashboard_tab_id": 11,
+      "row": 0, "col": 0, "size_x": 24, "size_y": 2,
+      "visualization_settings": {
+        "virtual_card": { "display": "text" },
+        "text": "## Executive Overview\nKey order metrics for CSA. Filters apply across the page."
+      }
+    },
+    {
+      "id": 2, "card_id": 201, "dashboard_tab_id": 11,
+      "row": 2, "col": 0, "size_x": 5, "size_y": 4,
+      "parameter_mappings": [],
+      "card": {
+        "id": 201, "name": "Total Revenue", "type": "question", "display": "scalar", "database_id": 2, "table_id": 45,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 45,
+          "aggregation": [["sum", ["field", 72, null]]]
+        }},
+        "result_metadata": [
+          { "name": "sum", "display_name": "Sum of Sales Amount", "base_type": "type/Float", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {
+          "column_settings": { "[\"name\",\"sum\"]": { "number_style": "currency", "decimals": 0 } }
+        }
+      }
+    },
+    {
+      "id": 3, "card_id": 101, "dashboard_tab_id": 11,
+      "row": 2, "col": 5, "size_x": 10, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p1", "card_id": 101, "target": ["dimension", ["field", 71, null]] }
+      ],
+      "card": {
+        "id": 101, "name": "Revenue Trend", "type": "question", "display": "line", "database_id": 2, "table_id": 45,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 45,
+          "aggregation": [["sum", ["field", 72, null]]],
+          "breakout": [["field", 71, { "temporal-unit": "month" }]]
+        }},
+        "result_metadata": [
+          { "name": "ORDER_DATE", "display_name": "Order Date",          "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "month" }] },
+          { "name": "sum",        "display_name": "Sum of Sales Amount", "base_type": "type/Float",    "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": { "graph.dimensions": ["ORDER_DATE"], "graph.metrics": ["sum"] }
+      }
+    },
+    {
+      "id": 4, "card_id": 203, "dashboard_tab_id": 11,
+      "row": 2, "col": 15, "size_x": 9, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p2", "card_id": 203, "target": ["dimension", ["field", 85, null]] }
+      ],
+      "card": {
+        "id": 203, "name": "Customers by Region", "type": "question", "display": "bar", "database_id": 2, "table_id": 46,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 46,
+          "aggregation": [["count"]],
+          "breakout": [["field", 85, null]]
+        }},
+        "result_metadata": [
+          { "name": "REGION", "display_name": "Region", "base_type": "type/Text",    "field_ref": ["field", 85, null] },
+          { "name": "count",  "display_name": "Count",  "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {
+          "graph.dimensions": ["REGION"], "graph.metrics": ["count"],
+          "click_behavior": { "type": "crossfilter" }
+        }
+      }
+    },
+    {
+      "id": 5, "card_id": 204, "dashboard_tab_id": 11,
+      "row": 8, "col": 0, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [],
+      "card": {
+        "id": 204, "name": "Customers by Loyalty Tier", "type": "question", "display": "row", "database_id": 2, "table_id": 46,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 46,
+          "aggregation": [["count"]],
+          "breakout": [["field", 84, null]]
+        }},
+        "result_metadata": [
+          { "name": "LOYALTY_TIER", "display_name": "Loyalty Tier", "base_type": "type/Text",    "field_ref": ["field", 84, null] },
+          { "name": "count",        "display_name": "Count",        "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": { "graph.dimensions": ["LOYALTY_TIER"], "graph.metrics": ["count"] }
+      }
+    },
+    {
+      "id": 6, "card_id": 205, "dashboard_tab_id": 11,
+      "row": 8, "col": 12, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [],
+      "card": {
+        "id": 205, "name": "Stores by State", "type": "question", "display": "pie", "database_id": 2, "table_id": 47,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 47,
+          "aggregation": [["count"]],
+          "breakout": [["field", 94, null]]
+        }},
+        "result_metadata": [
+          { "name": "STATE", "display_name": "State", "base_type": "type/Text",    "field_ref": ["field", 94, null] },
+          { "name": "count", "display_name": "Count", "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": { "pie.dimension": "STATE", "pie.metric": "count" }
+      }
+    },
+    {
+      "id": 7, "card_id": 206, "dashboard_tab_id": 12,
+      "row": 0, "col": 0, "size_x": 14, "size_y": 8,
+      "parameter_mappings": [],
+      "card": {
+        "id": 206, "name": "Revenue by Region and Tier", "type": "question", "display": "pivot", "database_id": 2, "table_id": 45,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 45,
+          "joins": [
+            { "source-table": 46, "alias": "Customer", "strategy": "left-join",
+              "condition": ["=", ["field", 75, null], ["field", 81, { "join-alias": "Customer" }]], "fields": "all" }
+          ],
+          "aggregation": [["sum", ["field", 72, null]]],
+          "breakout": [
+            ["field", 85, { "join-alias": "Customer" }],
+            ["field", 84, { "join-alias": "Customer" }]
+          ]
+        }},
+        "result_metadata": [
+          { "name": "REGION",       "display_name": "Region",              "base_type": "type/Text",  "field_ref": ["field", 85, { "join-alias": "Customer" }] },
+          { "name": "LOYALTY_TIER", "display_name": "Loyalty Tier",        "base_type": "type/Text",  "field_ref": ["field", 84, { "join-alias": "Customer" }] },
+          { "name": "sum",          "display_name": "Sum of Sales Amount", "base_type": "type/Float", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {
+          "pivot_table.column_split": {
+            "rows":    [["field", 85, { "join-alias": "Customer" }]],
+            "columns": [["field", 84, { "join-alias": "Customer" }]],
+            "values":  [["aggregation", 0]]
+          }
+        }
+      }
+    },
+    {
+      "id": 8, "card_id": 207, "dashboard_tab_id": 12,
+      "row": 0, "col": 14, "size_x": 10, "size_y": 8,
+      "parameter_mappings": [],
+      "card": {
+        "id": 207, "name": "Tier Funnel", "type": "question", "display": "funnel", "database_id": 2, "table_id": 46,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 46,
+          "aggregation": [["count"]],
+          "breakout": [["field", 84, null]]
+        }},
+        "result_metadata": [
+          { "name": "LOYALTY_TIER", "display_name": "Loyalty Tier", "base_type": "type/Text",    "field_ref": ["field", 84, null] },
+          { "name": "count",        "display_name": "Count",        "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9, "card_id": 210, "dashboard_tab_id": 12,
+      "row": 8, "col": 0, "size_x": 24, "size_y": 8,
+      "parameter_mappings": [],
+      "card": {
+        "id": 210, "name": "Premium Orders", "type": "question", "display": "table", "database_id": 2,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": "card__100",
+          "filter": ["=", ["field", "Tier Bucket", { "base-type": "type/Text" }], "Premium"]
+        }},
+        "result_metadata": [
+          { "name": "ORDER_NUMBER", "display_name": "Order Number", "base_type": "type/Integer", "field_ref": ["field", "ORDER_NUMBER", { "base-type": "type/Integer" }] },
+          { "name": "SALES_AMOUNT", "display_name": "Sales Amount", "base_type": "type/Float",   "field_ref": ["field", "SALES_AMOUNT", { "base-type": "type/Float" }] },
+          { "name": "Net Amount",   "display_name": "Net Amount",   "base_type": "type/Float",   "field_ref": ["field", "Net Amount",   { "base-type": "type/Float" }] },
+          { "name": "Tier Bucket",  "display_name": "Tier Bucket",  "base_type": "type/Text",    "field_ref": ["field", "Tier Bucket",  { "base-type": "type/Text" }] }
+        ],
+        "visualization_settings": {}
+      }
+    }
+  ]
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/legacy-grid.dashboard.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/legacy-grid.dashboard.json
@@ -1,0 +1,42 @@
+{
+  "id": 5,
+  "name": "Legacy Grid",
+  "description": "Old-shape dashboard (pre-v48): ordered_cards with sizeX/sizeY.",
+  "parameters": [],
+  "ordered_cards": [
+    {
+      "id": 1, "card_id": 201,
+      "row": 0, "col": 0, "sizeX": 6, "sizeY": 4,
+      "parameter_mappings": [],
+      "card": {
+        "id": 201, "name": "Total Revenue", "display": "scalar", "database_id": 2, "table_id": 45,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 45,
+          "aggregation": [["sum", ["field", 72, null]]]
+        }},
+        "result_metadata": [
+          { "name": "sum", "display_name": "Sum of Sales Amount", "base_type": "type/Float", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 2, "card_id": 203,
+      "row": 0, "col": 6, "sizeX": 12, "sizeY": 6,
+      "parameter_mappings": [],
+      "card": {
+        "id": 203, "name": "Customers by Region", "display": "bar", "database_id": 2, "table_id": 46,
+        "dataset_query": { "type": "query", "database": 2, "query": {
+          "source-table": 46,
+          "aggregation": [["count"]],
+          "breakout": [["field", 85, null]]
+        }},
+        "result_metadata": [
+          { "name": "REGION", "display_name": "Region", "base_type": "type/Text",    "field_ref": ["field", 85, null] },
+          { "name": "count",  "display_name": "Count",  "base_type": "type/Integer", "field_ref": ["aggregation", 0] }
+        ],
+        "visualization_settings": { "graph.dimensions": ["REGION"], "graph.metrics": ["count"] }
+      }
+    }
+  ]
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/metadata.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/metadata.json
@@ -1,0 +1,38 @@
+{
+  "id": 2,
+  "name": "CSA Snowflake",
+  "engine": "snowflake",
+  "tables": [
+    {
+      "id": 45, "name": "ORDER_FACT", "schema": "TJ", "db_id": 2, "display_name": "Order Fact",
+      "fields": [
+        { "id": 70, "name": "ORDER_NUMBER",   "display_name": "Order Number",   "base_type": "type/Integer",  "semantic_type": "type/PK", "table_id": 45, "fk_target_field_id": null },
+        { "id": 71, "name": "ORDER_DATE",     "display_name": "Order Date",     "base_type": "type/DateTime", "semantic_type": null,       "table_id": 45, "fk_target_field_id": null },
+        { "id": 72, "name": "SALES_AMOUNT",   "display_name": "Sales Amount",   "base_type": "type/Float",    "semantic_type": null,       "table_id": 45, "fk_target_field_id": null },
+        { "id": 73, "name": "QUANTITY",       "display_name": "Quantity",       "base_type": "type/Integer",  "semantic_type": null,       "table_id": 45, "fk_target_field_id": null },
+        { "id": 74, "name": "DISCOUNT_AMOUNT","display_name": "Discount Amount","base_type": "type/Float",    "semantic_type": null,       "table_id": 45, "fk_target_field_id": null },
+        { "id": 75, "name": "CUSTOMER_KEY",   "display_name": "Customer Key",   "base_type": "type/Integer",  "semantic_type": "type/FK",  "table_id": 45, "fk_target_field_id": 81 },
+        { "id": 76, "name": "ORDER_STORE_KEY","display_name": "Order Store Key","base_type": "type/Integer",  "semantic_type": "type/FK",  "table_id": 45, "fk_target_field_id": 91 }
+      ]
+    },
+    {
+      "id": 46, "name": "CUSTOMER_DIM", "schema": "TJ", "db_id": 2, "display_name": "Customer Dim",
+      "fields": [
+        { "id": 81, "name": "CUSTOMER_KEY", "display_name": "Customer Key", "base_type": "type/Integer", "semantic_type": "type/PK", "table_id": 46, "fk_target_field_id": null },
+        { "id": 82, "name": "FIRST_NAME",   "display_name": "First Name",   "base_type": "type/Text",    "semantic_type": null,      "table_id": 46, "fk_target_field_id": null },
+        { "id": 83, "name": "LAST_NAME",    "display_name": "Last Name",    "base_type": "type/Text",    "semantic_type": null,      "table_id": 46, "fk_target_field_id": null },
+        { "id": 84, "name": "LOYALTY_TIER", "display_name": "Loyalty Tier", "base_type": "type/Text",    "semantic_type": "type/Category", "table_id": 46, "fk_target_field_id": null },
+        { "id": 85, "name": "REGION",       "display_name": "Region",       "base_type": "type/Text",    "semantic_type": "type/Category", "table_id": 46, "fk_target_field_id": null }
+      ]
+    },
+    {
+      "id": 47, "name": "STORE_DIM", "schema": "TJ", "db_id": 2, "display_name": "Store Dim",
+      "fields": [
+        { "id": 91, "name": "STORE_KEY",  "display_name": "Store Key",  "base_type": "type/Integer", "semantic_type": "type/PK", "table_id": 47, "fk_target_field_id": null },
+        { "id": 92, "name": "STORE_NAME", "display_name": "Store Name", "base_type": "type/Text",    "semantic_type": null,      "table_id": 47, "fk_target_field_id": null },
+        { "id": 93, "name": "CITY",       "display_name": "City",       "base_type": "type/Text",    "semantic_type": null,      "table_id": 47, "fk_target_field_id": null },
+        { "id": 94, "name": "STATE",      "display_name": "State",      "base_type": "type/Text",    "semantic_type": "type/State", "table_id": 47, "fk_target_field_id": null }
+      ]
+    }
+  ]
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/orders-model.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/orders-model.card.json
@@ -1,0 +1,45 @@
+{
+  "id": 100,
+  "name": "Orders Model",
+  "description": "Curated orders dataset joined to customers — the Metabase model.",
+  "type": "model",
+  "display": "table",
+  "database_id": 2,
+  "table_id": 45,
+  "collection_id": 5,
+  "dataset_query": {
+    "type": "query",
+    "database": 2,
+    "query": {
+      "source-table": 45,
+      "joins": [
+        {
+          "source-table": 46,
+          "alias": "Customer",
+          "strategy": "left-join",
+          "condition": ["=", ["field", 75, null], ["field", 81, { "join-alias": "Customer" }]],
+          "fields": "all"
+        }
+      ],
+      "expressions": {
+        "Net Amount": ["-", ["field", 72, null], ["field", 74, null]],
+        "Tier Bucket": ["case",
+          [[["=", ["field", 84, { "join-alias": "Customer" }], "GOLD", "PLATINUM"], "Premium"]],
+          { "default": "Standard" }
+        ]
+      },
+      "aggregation": [
+        ["aggregation-options", ["sum", ["field", 72, null]], { "name": "total_revenue", "display-name": "Total Revenue" }]
+      ]
+    }
+  },
+  "result_metadata": [
+    { "name": "ORDER_NUMBER", "display_name": "Order Number", "base_type": "type/Integer",  "field_ref": ["field", 70, null] },
+    { "name": "ORDER_DATE",   "display_name": "Order Date",   "base_type": "type/DateTime", "field_ref": ["field", 71, null] },
+    { "name": "SALES_AMOUNT", "display_name": "Sales Amount", "base_type": "type/Float",    "field_ref": ["field", 72, null] },
+    { "name": "REGION",       "display_name": "Region",       "base_type": "type/Text",     "field_ref": ["field", 85, { "join-alias": "Customer" }] },
+    { "name": "Net Amount",   "display_name": "Net Amount",   "base_type": "type/Float",    "field_ref": ["expression", "Net Amount"] },
+    { "name": "Tier Bucket",  "display_name": "Tier Bucket",  "base_type": "type/Text",     "field_ref": ["expression", "Tier Bucket"] }
+  ],
+  "visualization_settings": {}
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-expressions.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-expressions.card.json
@@ -1,0 +1,36 @@
+{
+  "id": 404,
+  "name": "Order Enrichment (pMBQL Expressions)",
+  "description": "Modern-format structured card with expressions as a pMBQL clause LIST (lib/expression-name in opts): case, datetime-diff, a date() cast, and lower(). Synthetic.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 45,
+        "expressions": [
+          ["case", { "lib/uuid": "00000000-0000-4000-8000-00000000e001", "lib/expression-name": "Size Bucket" },
+            [
+              [[">", { "lib/uuid": "00000000-0000-4000-8000-00000000e002" },
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000e003", "base-type": "type/Float", "effective-type": "type/Float" }, 72], 1000],
+               "Large"]
+            ],
+            "Small"],
+          ["datetime-diff", { "lib/uuid": "00000000-0000-4000-8000-00000000e004", "lib/expression-name": "Days to Now" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000e005", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71],
+            ["now", { "lib/uuid": "00000000-0000-4000-8000-00000000e006" }],
+            "day"],
+          ["date", { "lib/uuid": "00000000-0000-4000-8000-00000000e007", "lib/expression-name": "Order Day" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000e008", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71]]
+        ]
+      }
+    ]
+  },
+  "result_metadata": [],
+  "visualization_settings": {}
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-joins.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-joins.card.json
@@ -1,0 +1,35 @@
+{
+  "id": 403,
+  "name": "Orders with Customers (pMBQL Join)",
+  "description": "Modern-format structured card with a pMBQL join: {stages:[{source-table}], conditions:[…], alias, strategy}. Synthetic.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 45,
+        "joins": [
+          {
+            "lib/type": "mbql/join",
+            "alias": "Customer Dim - Customer",
+            "strategy": "left-join",
+            "fields": "all",
+            "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 46 }],
+            "conditions": [
+              ["=", { "lib/uuid": "00000000-0000-4000-8000-00000000j001" },
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000j002", "base-type": "type/Integer", "effective-type": "type/Integer" }, 75],
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000j003", "base-type": "type/Integer", "effective-type": "type/Integer", "join-alias": "Customer Dim - Customer" }, 81]]
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "result_metadata": [],
+  "visualization_settings": {}
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-multistage.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-multistage.card.json
@@ -1,0 +1,35 @@
+{
+  "id": 405,
+  "name": "Average Weekly Revenue (pMBQL Multi-Stage)",
+  "description": "Modern-format TWO-stage query (aggregate over an aggregation) — normalizes to legacy source-query nesting; the converter flags it (rare but real: 14 of 7,023 cards on a production estate). Synthetic.",
+  "type": "question",
+  "display": "scalar",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 45,
+        "aggregation": [
+          ["sum", { "lib/uuid": "00000000-0000-4000-8000-00000000m001" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000m002", "base-type": "type/Float", "effective-type": "type/Float" }, 72]]
+        ],
+        "breakout": [
+          ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000m003", "base-type": "type/DateTime", "effective-type": "type/DateTime", "temporal-unit": "week" }, 71]
+        ]
+      },
+      {
+        "lib/type": "mbql.stage/mbql",
+        "aggregation": [
+          ["avg", { "lib/uuid": "00000000-0000-4000-8000-00000000m004" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000m005", "base-type": "type/Float", "effective-type": "type/Float" }, "sum"]]
+        ]
+      }
+    ]
+  },
+  "result_metadata": [],
+  "visualization_settings": {}
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-native-tags.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-native-tags.card.json
@@ -1,0 +1,43 @@
+{
+  "id": 401,
+  "name": "Filtered Revenue (pMBQL Native + Tags)",
+  "description": "Modern-format native card with every template-tag kind: text + number variables, a dimension field filter (pMBQL field clause), a card ref, and an optional [[…]] block. Synthetic.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/native",
+        "native": "SELECT c.REGION, SUM(o.SALES_AMOUNT) AS REVENUE\nFROM CSA.TJ.ORDER_FACT o\nJOIN CSA.TJ.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY\nWHERE c.REGION = {{region}} AND {{order_date}} AND o.QUANTITY >= {{min_qty}} [[AND c.LOYALTY_TIER = {{tier}}]]\n  AND o.ORDER_NUMBER IN (SELECT ORDER_NUMBER FROM {{#400-daily-revenue}})\nGROUP BY 1",
+        "template-tags": {
+          "region": {
+            "id": "tt1", "name": "region", "display-name": "Region", "type": "text", "default": "West"
+          },
+          "min_qty": {
+            "id": "tt2", "name": "min_qty", "display-name": "Min Quantity", "type": "number", "default": 1
+          },
+          "order_date": {
+            "id": "tt3", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+            "widget-type": "date/range", "required": false,
+            "dimension": ["field", { "lib/uuid": "00000000-0000-4000-8000-000000000071", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71]
+          },
+          "tier": {
+            "id": "tt4", "name": "tier", "display-name": "Loyalty Tier", "type": "text"
+          },
+          "#400-daily-revenue": {
+            "id": "tt5", "name": "#400-daily-revenue", "display-name": "#400 Daily Revenue", "type": "card", "card-id": 400
+          }
+        }
+      }
+    ]
+  },
+  "result_metadata": [
+    { "name": "REGION", "display_name": "Region", "base_type": "type/Text" },
+    { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+  ],
+  "visualization_settings": {}
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-native.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-native.card.json
@@ -1,0 +1,24 @@
+{
+  "id": 400,
+  "name": "Daily Revenue (pMBQL Native)",
+  "description": "Modern-format (lib/type) native card — single stage, no tags. Synthetic.",
+  "type": "question",
+  "display": "line",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/native",
+        "native": "SELECT ORDER_DATE, SUM(SALES_AMOUNT) AS REVENUE\nFROM CSA.TJ.ORDER_FACT\nGROUP BY 1"
+      }
+    ]
+  },
+  "result_metadata": [
+    { "name": "ORDER_DATE", "display_name": "Order Date", "base_type": "type/DateTime" },
+    { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+  ],
+  "visualization_settings": { "graph.dimensions": ["ORDER_DATE"], "graph.metrics": ["REVENUE"] }
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-params.dashboard.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-params.dashboard.json
@@ -1,0 +1,131 @@
+{
+  "id": 500,
+  "name": "Regional Ops (pMBQL)",
+  "description": "Modern-format dashboard: parameters targeting native template tags (variable + field-filter), a pMBQL dimension target, conditional formatting, series_settings renames, and an object-detail card. Synthetic.",
+  "collection_id": 5,
+  "parameters": [
+    { "id": "p1", "name": "Region", "slug": "region_param", "type": "string/=", "default": "West" },
+    { "id": "p2", "name": "Order Window", "slug": "order_window", "type": "date/range" },
+    { "id": "p3", "name": "Order Date", "slug": "order_date_param", "type": "date/all-options" }
+  ],
+  "tabs": [],
+  "dashcards": [
+    {
+      "id": 9001,
+      "card_id": 401,
+      "row": 0, "col": 0, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p1", "card_id": 401, "target": ["variable", ["template-tag", "region"]] },
+        { "parameter_id": "p3", "card_id": 401, "target": ["dimension", ["template-tag", "order_date"], { "stage-number": 0 }] }
+      ],
+      "visualization_settings": {
+        "table.column_formatting": [
+          { "columns": ["REVENUE"], "type": "single", "operator": ">", "value": 10000, "color": "#22c55e", "highlight_row": false },
+          { "columns": ["REVENUE"], "type": "range", "colors": ["#ffffff", "#509ee3"], "min_type": null, "max_type": null }
+        ]
+      },
+      "card": {
+        "id": 401,
+        "name": "Filtered Revenue (pMBQL Native + Tags)",
+        "display": "table",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [
+            {
+              "lib/type": "mbql.stage/native",
+              "native": "SELECT c.REGION, SUM(o.SALES_AMOUNT) AS REVENUE FROM CSA.TJ.ORDER_FACT o JOIN CSA.TJ.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY WHERE c.REGION = {{region}} AND {{order_date}} GROUP BY 1",
+              "template-tags": {
+                "region": { "id": "tt1", "name": "region", "display-name": "Region", "type": "text", "default": "West" },
+                "order_date": {
+                  "id": "tt3", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+                  "widget-type": "date/range",
+                  "dimension": ["field", { "lib/uuid": "00000000-0000-4000-8000-000000000071", "base-type": "type/DateTime" }, 71]
+                }
+              }
+            }
+          ]
+        },
+        "result_metadata": [
+          { "name": "REGION", "display_name": "Region", "base_type": "type/Text" },
+          { "name": "REVENUE", "display_name": "Revenue", "base_type": "type/Float" }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9002,
+      "card_id": 402,
+      "row": 0, "col": 12, "size_x": 12, "size_y": 6,
+      "parameter_mappings": [
+        { "parameter_id": "p2", "card_id": 402, "target": ["dimension", ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000d001", "base-type": "type/DateTime", "temporal-unit": "week" }, 71], { "stage-number": 0 }] }
+      ],
+      "visualization_settings": {
+        "series_settings": { "total_revenue": { "title": "Revenue ($)", "color": "#88BF4D" } }
+      },
+      "card": {
+        "id": 402,
+        "name": "Weekly Orders by Region (pMBQL)",
+        "display": "bar",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [
+            {
+              "lib/type": "mbql.stage/mbql",
+              "source-table": 45,
+              "aggregation": [
+                ["count", { "lib/uuid": "00000000-0000-4000-8000-00000000a001" }],
+                ["sum", { "lib/uuid": "00000000-0000-4000-8000-00000000a002", "name": "total_revenue", "display-name": "Total Revenue" },
+                  ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000a003", "base-type": "type/Float" }, 72]]
+              ],
+              "breakout": [
+                ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000b001", "base-type": "type/DateTime", "temporal-unit": "week" }, 71]
+              ]
+            }
+          ]
+        },
+        "result_metadata": [
+          { "name": "ORDER_DATE", "display_name": "Order Date: Week", "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "week" }] },
+          { "name": "count", "display_name": "Count", "base_type": "type/Integer", "field_ref": ["aggregation", 0] },
+          { "name": "total_revenue", "display_name": "Total Revenue", "base_type": "type/Float", "field_ref": ["aggregation", 1] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9003,
+      "card_id": 406,
+      "row": 6, "col": 0, "size_x": 8, "size_y": 4,
+      "parameter_mappings": [],
+      "visualization_settings": {},
+      "card": {
+        "id": 406,
+        "name": "Order Record",
+        "display": "object",
+        "database_id": 2,
+        "dataset_query": {
+          "lib/type": "mbql/query",
+          "database": 2,
+          "stages": [{ "lib/type": "mbql.stage/mbql", "source-table": 45 }]
+        },
+        "result_metadata": [
+          { "name": "ORDER_NUMBER", "display_name": "Order Number", "base_type": "type/Integer", "field_ref": ["field", 70, null] }
+        ],
+        "visualization_settings": {}
+      }
+    },
+    {
+      "id": 9004,
+      "card_id": null,
+      "row": 6, "col": 8, "size_x": 8, "size_y": 4,
+      "parameter_mappings": [],
+      "visualization_settings": {
+        "virtual_card": { "display": "text" },
+        "text": "## Ops Notes\nSynthetic markdown block."
+      }
+    }
+  ]
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-structured.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/pmbql-structured.card.json
@@ -1,0 +1,41 @@
+{
+  "id": 402,
+  "name": "Weekly Orders by Region (pMBQL)",
+  "description": "Modern-format structured card: named + unnamed aggregations, temporal-unit breakout, filters incl. the pMBQL-only `in` op and time-interval with opts-second clause order. Synthetic.",
+  "type": "question",
+  "display": "bar",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "lib/type": "mbql/query",
+    "database": 2,
+    "stages": [
+      {
+        "lib/type": "mbql.stage/mbql",
+        "source-table": 45,
+        "aggregation": [
+          ["count", { "lib/uuid": "00000000-0000-4000-8000-00000000a001" }],
+          ["sum", { "lib/uuid": "00000000-0000-4000-8000-00000000a002", "name": "total_revenue", "display-name": "Total Revenue" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000a003", "base-type": "type/Float", "effective-type": "type/Float" }, 72]]
+        ],
+        "breakout": [
+          ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000b001", "base-type": "type/DateTime", "effective-type": "type/DateTime", "temporal-unit": "week" }, 71]
+        ],
+        "filters": [
+          ["=", { "lib/uuid": "00000000-0000-4000-8000-00000000f001" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000f002", "base-type": "type/Integer", "effective-type": "type/Integer" }, 73], 1, 2, 3],
+          ["in", { "lib/uuid": "00000000-0000-4000-8000-00000000f003", "effective-type": "type/Boolean" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000f004", "base-type": "type/Integer", "effective-type": "type/Integer" }, 70], 100, 200],
+          ["time-interval", { "lib/uuid": "00000000-0000-4000-8000-00000000f005", "include-current": true, "effective-type": "type/Boolean" },
+            ["field", { "lib/uuid": "00000000-0000-4000-8000-00000000f006", "base-type": "type/DateTime", "effective-type": "type/DateTime" }, 71], -6, "month"]
+        ]
+      }
+    ]
+  },
+  "result_metadata": [
+    { "name": "ORDER_DATE", "display_name": "Order Date: Week", "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "week" }] },
+    { "name": "count", "display_name": "Count", "base_type": "type/Integer", "field_ref": ["aggregation", 0] },
+    { "name": "total_revenue", "display_name": "Total Revenue", "base_type": "type/Float", "field_ref": ["aggregation", 1] }
+  ],
+  "visualization_settings": { "graph.dimensions": ["ORDER_DATE"], "graph.metrics": ["count", "total_revenue"] }
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/revenue-trend.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/revenue-trend.card.json
@@ -1,0 +1,31 @@
+{
+  "id": 101,
+  "name": "Revenue Trend",
+  "description": "Monthly revenue, trailing 12 months.",
+  "type": "question",
+  "display": "line",
+  "database_id": 2,
+  "table_id": 45,
+  "collection_id": 5,
+  "dataset_query": {
+    "type": "query",
+    "database": 2,
+    "query": {
+      "source-table": 45,
+      "expressions": {
+        "Days Since Order": ["datetime-diff", ["field", 71, null], ["now"], "day"]
+      },
+      "aggregation": [["sum", ["field", 72, null]]],
+      "breakout": [["field", 71, { "temporal-unit": "month" }]],
+      "filter": ["time-interval", ["field", 71, null], -365, "day"]
+    }
+  },
+  "result_metadata": [
+    { "name": "ORDER_DATE", "display_name": "Order Date",          "base_type": "type/DateTime", "field_ref": ["field", 71, { "temporal-unit": "month" }] },
+    { "name": "sum",        "display_name": "Sum of Sales Amount", "base_type": "type/Float",    "field_ref": ["aggregation", 0] }
+  ],
+  "visualization_settings": {
+    "graph.dimensions": ["ORDER_DATE"],
+    "graph.metrics": ["sum"]
+  }
+}

--- a/metabase-migration-skills/metabase-to-sigma/fixtures/top-customers-native.card.json
+++ b/metabase-migration-skills/metabase-to-sigma/fixtures/top-customers-native.card.json
@@ -1,0 +1,30 @@
+{
+  "id": 102,
+  "name": "Top Customers (Native)",
+  "description": "Hand-written SQL with a text variable and a field filter.",
+  "type": "question",
+  "display": "table",
+  "database_id": 2,
+  "collection_id": 5,
+  "dataset_query": {
+    "type": "native",
+    "database": 2,
+    "native": {
+      "query": "SELECT c.FIRST_NAME || ' ' || c.LAST_NAME AS CUSTOMER, SUM(o.SALES_AMOUNT) AS REVENUE\nFROM CSA.TJ.ORDER_FACT o\nJOIN CSA.TJ.CUSTOMER_DIM c ON c.CUSTOMER_KEY = o.CUSTOMER_KEY\nWHERE c.REGION = {{region}} AND {{order_date}}\nGROUP BY 1\nORDER BY 2 DESC\nLIMIT 10",
+      "template-tags": {
+        "region": {
+          "id": "t1", "name": "region", "display-name": "Region", "type": "text", "default": "West"
+        },
+        "order_date": {
+          "id": "t2", "name": "order_date", "display-name": "Order Date", "type": "dimension",
+          "widget-type": "date/range", "dimension": ["field", 71, null]
+        }
+      }
+    }
+  },
+  "result_metadata": [
+    { "name": "CUSTOMER", "display_name": "Customer", "base_type": "type/Text" },
+    { "name": "REVENUE",  "display_name": "Revenue",  "base_type": "type/Float" }
+  ],
+  "visualization_settings": {}
+}

--- a/metabase-migration-skills/metabase-to-sigma/refs/control-parity.md
+++ b/metabase-migration-skills/metabase-to-sigma/refs/control-parity.md
@@ -1,0 +1,99 @@
+# Control parity — lint, flip test, and the MCP/export answer
+
+SHARED ref, vendored byte-identical into every covered plugin's `refs/`
+(md5 discipline). Companion to `scripts/lib/control_lint.rb` (gate 7 /
+post-and-readback control lint) and `scripts/probe-controls.rb` (flip test).
+
+## Why this exists
+
+A migrated workbook can pass data parity, the column-type guard, and the
+layout lint and still ship **broken interactivity**. The 2026-06 estate audit
+of tj-wells-1989 found 86 controls across 36 kept workbooks: 8 DEAD (no
+filter target, no formula reference — pure furniture), 18 PARTIAL (same-page
+charts outside the control's reach; 8 of them bugs), and the Qlik class
+(source dashboards full of listboxes migrated with zero controls). None of
+the existing gates noticed, because every existing gate evaluates elements in
+their default state.
+
+## The three layers
+
+1. **Control lint** (`scripts/lib/control_lint.rb`) — static spec analysis:
+   dead controls, ghost filter targets, source-closure reach vs same-page
+   queryable elements, and source-signal coverage via the
+   `control-scope.json` sidecar. Runs automatically in
+   `post-and-readback.rb --type workbook` (exit 4) and as
+   `assert-phase6-ran.rb` **gate 7** (exit 9, `--skip-control-lint` escape).
+2. **control-scope.json contract** — emitted by the builder next to the
+   workbook spec. Carries (a) `sourceFilterSignals`: how many filter-like
+   signals the SOURCE artifact had (Tableau quick filters + actions, PBI
+   slicers, Qlik listboxes, QuickSight/Cognos parameters+prompts, Looker
+   dashboard filters, TS Liveboard filters) — `>0` with zero spec controls
+   FAILS the lint; (b) per-control intent: `scope: "page"` (default — the
+   control must reach every same-page queryable element) or
+   `scope: ["Element name or id", ...]` (the **single-chart-switcher
+   allowlist** for intentional narrow controls like grain/geo-level toggles)
+   plus optional `mustReach` hard assertions. Full schema in the
+   `control_lint.rb` header CONTRACT block. The in-spec `controlScope` key on
+   a control element means the same thing but does NOT survive Sigma
+   readback — the sidecar is the durable form.
+3. **Flip test** (`scripts/probe-controls.rb`) — OPTIONAL Phase-6 runtime
+   evidence, not the mandatory inner loop. Exports one in-closure element CSV
+   with and without `parameters:{<controlId>: <first non-default value>}` —
+   they must differ; with `--check-out-of-closure`, an out-of-closure element
+   must NOT differ. Use it after hand-wiring controls, after estate repairs,
+   or when the lint's static reach needs runtime confirmation.
+
+## The MCP question — definitive answer (verified 2026-06-12, tj-wells-1989)
+
+Tested by setting a saved default (`values: ["West"]`) on a live workbook's
+Region list control (PHASEE, `64e78398`), then querying/exporting the same
+in-closure bar chart every way available:
+
+| Path | Control defaults applied? | Can set a control value? |
+|---|---|---|
+| `mcp__sigma-mcp-v2__query` (type=workbook) | **YES** — returned only the West row | **NO** — schema is `{type, workbookId, sql}` only; no parameter mechanism exists in the MCP query path |
+| REST export, no `parameters` | **YES** — only the West row | n/a |
+| REST `POST /v2/workbooks/{id}/export` with `"parameters": {"<controlId>": "<value>"}` | starts from defaults | **YES** — and the parameter **REPLACES** the saved default (parameters `{"ctl-region":"South"}` over a West default returned only South — no intersection) |
+
+Consequences:
+
+- MCP is fine for **default-state parity** (Phase 6 uses exactly that), and
+  default-state MCP rows DO move if you change a control's saved default.
+- MCP can NOT exercise a non-default control value — flip testing MUST go
+  through the export API's `parameters` map. That is why probe-controls.rb is
+  built on export.
+- A parameter value that matches no data row returns an EMPTY (header-only)
+  CSV, not an error — pick flip values from the column's actual domain
+  (probe-controls.rb auto-picks from the control's value-source column).
+
+## Repair recipes (what the lint tells you to do)
+
+- **dead control, column exists on a master** → add
+  `filters: [{source: {kind: "table", elementId: "<master>"}, columnId: "<col>"}]`
+  (and point the control's own `source` at the same column for its value
+  list).
+- **dead control, column does NOT exist anywhere** → REMOVE the control.
+  Honest beats decorative; do not fake-wire to an unrelated column.
+- **partial reach, multi-master page** → add one filter target per master the
+  control should govern (the column must exist on each); elements sourcing
+  from those masters inherit via the closure.
+- **partial reach, chart bypasses the master** (sources the DM directly) →
+  either re-source the chart from the master or re-root it through a hidden
+  shared BASE TABLE (a `kind: table` element sourcing the same DM element,
+  carrying passthrough columns; the chart re-sourced through it) and target
+  the table. Control filter targets may only point at TABLE elements — a
+  chart/KPI target is rejected at POST/PUT with 400 "Dependency not found"
+  (live-verified 2026-06-12; the looker builder's listen-scope tables and
+  enhance-apply's `ensure_base_table!` are the two automated forms of this
+  pattern).
+- **intentional narrow control** (grain switcher driving one chart by
+  formula) → annotate `scope: [...]` in control-scope.json; don't fake-wire.
+
+After any repair: flip-test the workbook
+(`ruby scripts/probe-controls.rb --workbook-id <id> --check-out-of-closure`).
+
+## Gotcha: list-control targets on NUMERIC columns are silently stripped
+Same class as the datetime strip: a list control whose filter target column is
+numeric returns PUT 200 but reads back `filters: null`. Fix: add a hidden
+`Text()` cast column on the target element and point the control at the cast.
+(Found live by gate 7 on the MicroStrategy retrofit, 2026-06-12.)

--- a/metabase-migration-skills/metabase-to-sigma/refs/customization.md
+++ b/metabase-migration-skills/metabase-to-sigma/refs/customization.md
@@ -1,0 +1,81 @@
+# Customizing this skill — make it yours
+
+This skill is **agent-driven**: Claude reads these files and follows them. That means
+you can fine-tune the migration **by telling Claude what you want, in plain language**
+— no code required for most changes. Say it once, ask Claude to remember it, and every
+future run applies it.
+
+There are three tiers, from lightest to deepest:
+
+## Tier 1 — Preferences file (plain language, no code)
+
+`~/.metabase-to-sigma/preferences.md` — YOUR standing instructions, written in
+natural language. The agent reads it at the start of every migration run (Phase 0)
+and honors it throughout. It lives in your home directory, not the repo, so a
+`git pull` never overwrites it.
+
+How to create or extend it: just tell Claude. Examples of things customers have
+asked for — phrase them however you like:
+
+```markdown
+# My metabase-to-sigma preferences
+
+- Always alias bare aggregates in migrated SQL (count(*) AS n_orders) so chart
+  labels are readable — never leave a BigQuery f0_ column.
+- Use list controls (not segmented) even for small static value lists.
+- Our dashboards' "AU" tabs are deprecated — skip them, migrate UK pages only.
+- Name migrated workbooks "<Dashboard name> (migrated <date>)" and put
+  everything under the "Metabase Migration" folder.
+- Date controls should default to last 30 days when Metabase has no default.
+- After every workbook posts, export the PNG and show it to me before parity.
+```
+
+**The agent's side of the contract** (Claude: this is an instruction to you):
+- Read `~/.metabase-to-sigma/preferences.md` at the start of every run, restate the
+  active preferences in one line, and apply them.
+- Whenever the user corrects your output or expresses a preference mid-run
+  ("actually, make the controls list-type", "don't migrate archived cards"),
+  **offer to save it to the preferences file** so the next run gets it for free.
+- A preference can override any default in SKILL.md EXCEPT the verification gates
+  (post-and-readback, parity, visual check) — those are never skipped.
+
+## Tier 2 — Learned formula rules (per-org translation overrides)
+
+`~/.metabase-to-sigma/learned-rules.json` — regex → template rules applied BEFORE
+the built-in MBQL translator. This is for **formula translations** specific to your
+org (a custom function, a house SQL idiom, a wrapper the converter doesn't know).
+The gap-scout flow (SKILL.md "Gaps") proposes these automatically when a card hits
+an unmapped expression; you can also ask Claude to write one directly:
+
+> "Whenever you see our `fiscal_quarter(x)` function, translate it to
+> `DateTrunc(\"quarter\", DateAdd(\"month\", -1, x))` — save that as a learned rule."
+
+Rules are validated (the scout round-trips them against live Sigma before
+persisting) and survive skill updates.
+
+## Tier 3 — Converter changes (code, tests, shared back)
+
+For behavior that's structural — a new chart type, a different DM topology, an
+element-naming scheme — ask Claude to change the converter itself:
+
+> "Open converter/metabase-dashboard.ts and make funnel cards convert to a bar
+> chart sorted descending instead of a flagged table. Add a fixture test."
+
+Ground rules the agent follows:
+- Every converter change gets a fixture + test in `converter/test.ts` (run
+  `node --import tsx/esm test.ts` — must stay green).
+- Live-verify against your Sigma org with `post-and-readback` before trusting it.
+- If the change fixes something broken (not just org-specific taste), please
+  share it back — `scripts/escalate-gap.py` opens a GitHub issue on the skill
+  repo with the details pre-filled, or open a PR. Your fix becomes everyone's fix.
+
+## What goes where (quick router)
+
+| You want to change… | Tier |
+|---|---|
+| Naming, folders, which pages/cards to include, control widget choices, layout taste, run etiquette | 1 — preferences.md |
+| How a specific formula/function/SQL idiom translates | 2 — learned-rules.json |
+| Chart-type mappings, DM structure, new Metabase features, bug fixes | 3 — converter + tests |
+
+When in doubt, just describe what you want — Claude picks the tier and tells you
+where it saved it.

--- a/metabase-migration-skills/metabase-to-sigma/refs/design-notes.md
+++ b/metabase-migration-skills/metabase-to-sigma/refs/design-notes.md
@@ -1,0 +1,326 @@
+# Design notes — Metabase → Sigma
+
+## Status: LIVE-VALIDATED end to end (2026-06-11)
+
+Full pipeline proven against a local Metabase **v0.61.3** (jar, OpenJDK) connected
+to the same Snowflake warehouse as Sigma: 8 pilot cards + a 2-tab parameterized
+dashboard → discovery → converter → DM POST (readback clean) → workbook POST
+(readback clean) → **EXACT MCP-query parity** on every element (KPI total, 4
+regions, 3 channels, 30 months, 15 category×channel cells, pivot cells, filtered
+row counts). See §10 for the live-verified contracts that replaced the old
+"known unknowns" and the validation-loop recipe.
+
+## What maps to what
+
+| Metabase | Sigma | Carrier |
+|---|---|---|
+| Database / table | DM `warehouse-table` element | `GET /api/database/{id}/metadata` (schema + field ids) |
+| **Model** (curated dataset) | DM element (table / join / sql) | the model's own `dataset_query` |
+| Question (MBQL) used by dashboards | DM element + metrics, or workbook element sourced from the DM | `dataset_query.query` |
+| Question (native SQL) | DM **`sql` element** (Custom SQL) | `dataset_query.native.query`; `{{tags}}` → controls |
+| MBQL `joins` | DM `join` source (left/right/inner/full) | join condition field pairs |
+| FK metadata (`fk_target_field_id`) | DM **relationships** (+ derived view) | database metadata — Metabase's implicit-join graph |
+| `expressions` (custom columns) | calc columns | `translateMbqlExpr` |
+| `aggregation` (+ named wrappers) | element **metrics** | |
+| Dashboard | workbook page(s) — one page per dashboard **tab** | `dashcards` grid → 24-col Sigma layout, 1:1 |
+| Dashcard | chart/table/pivot/KPI/text element | `display` + `visualization_settings` |
+| Dashboard `parameters` | workbook **controls** + targets | `parameter_mappings` name the filtered column per card |
+| Collections | folder suggestion only (Sigma folder = POST `folderId`) | not auto-created |
+
+## Decisions (and why)
+
+1. **Field-id resolution is a hard prerequisite.** MBQL refs columns by integer
+   id. The converter REQUIRES `--metadata metadata.json`
+   (`GET /api/database/{id}/metadata`) and falls back to the card's
+   `result_metadata` names when an id is missing — with a warning, because
+   fallback names lose the table qualifier.
+2. **Models become the DM; ad-hoc questions become workbook elements.** A
+   Metabase model is the semantic-layer object — it maps to a DM element other
+   elements source. Questions that only a dashboard uses convert as workbook
+   elements wired to the DM element for their source table (keeps the DM small
+   instead of one element per question — mirrors how the tableau/qlik
+   converters treat sheet-level calcs).
+3. **Nested questions (`source-table: "card__N"`)** convert to an element
+   sourced from card N's element (`source: {kind:"table", elementId}`) when card
+   N is in the input set; otherwise flagged with the card id so discovery can
+   fetch it.
+4. **Joins: MBQL explicit joins → DM join sources; FK metadata → DM
+   relationships.** Two different Metabase features, two different Sigma
+   carriers. The derived "join view" (`buildDerivedElements`) skips the
+   relationship's own key column (cross-element passthrough of a join key
+   compiles to type `error` — learned on qlik/oac, baked into `sigma-ids.ts`).
+5. **Number formats**: `column_settings` (`number_style`, `decimals`, `suffix`)
+   are the primary signal → Sigma d3 `formatString`; name/formula heuristics
+   (`inferSigmaFormat`) only fill gaps. Mirrors the powerbi `format` lesson
+   (beads-sigma-4q7k).
+6. **Never faked**: cum-sum/offset/segment/metric refs, binning, click
+   behaviors, funnel/gauge/progress/waterfall viz → loud warnings + readable
+   placeholders (flagged table for unsupported viz), exactly like the cognos
+   converter's contract. See `expression-dsl.md` for the full table.
+7. **Charts**: `display` + `graph.dimensions`/`graph.metrics` (names matched
+   through `result_metadata`) drive the Sigma viz: bar/row→bar (row = horizontal
+   — Sigma's only `orientation` enum value), line→line, area→area,
+   combo→combo (`series_settings` per-series display → dual-axis string/object
+   yAxis form), scatter→scatter, pie→pie, scalar/smartscalar→kpi-chart,
+   pivot→pivot-table (`pivot_table.column_split` → rowsBy/columnsBy `{id}`
+   objects + bare-string values), map→region-map/point-map (`map.type`).
+8. **Sandboxing (RLS) is EE-only and detect-only here**: `GET /api/mt/gtap`
+   (sandboxes) + group memberships exist only on Pro/EE. When detected (or
+   provided manually), the shared `apply_sigma_rls.py` engine ports it to Sigma
+   user-attributes after the DM is posted — same opt-in/out gate as every
+   sibling skill (never silent, never slow).
+
+## Live-verified contracts (was "known unknowns" — resolved 2026-06-11, see §10)
+
+- **Native SQL column refs**: bare `[Display Name]` POSTs 200 but resolves to
+  type "error" at query time. The contract is `[Custom SQL/RAW_ALIAS]` (raw SQL
+  output alias from `result_metadata.name`) + an explicit column `name`. The
+  readback gate exists for exactly this failure class.
+- **Join-source spec shape** (the manager's `on:[…]` contract was WRONG): each
+  join is `{left, right, joinType, columns:[{left:'[Display Name]', right:…}],
+  name}` — `columns` not `on`; refs are Sigma-PRETTIFIED display names (physical
+  `[PRODUCT_KEY]` → 400 "Column reference not found"); `connectionId` is REQUIRED
+  on each side's nested source; enum is `inner|left-outer|right-outer|full-outer|
+  lookup` (bare `left` → 400). `source.name` + per-join `name` are the formula
+  prefixes (`[NAME/Col]`) for head/right columns.
+- **DM control elements**: each `controlType` variant has REQUIRED discriminant
+  fields (text/number/date need `mode`); omitting them fails the union match and
+  surfaces misleadingly as `Invalid kind: "control"`.
+- **Sigma parses `{{…}}` inside SQL comments** — a neutralized field-filter
+  comment must NOT contain the literal tag braces or the POST 400s on the
+  missing control.
+- **Text elements carry `body`**, not `text`.
+- **100% stacking**: enum is `none|stacked|normalized` — Metabase's `normalized`
+  passes through verbatim ('percent' is rejected).
+- **Cross-document DM references** are `source.kind:'data-model'` (kind 'table'
+  is same-workbook only → 400 "Dependency not found").
+- **Display-name casing is AP-style**: first AND last words always capitalize;
+  stopwords lowercase only mid-name (`IS_EMAIL_OPT_IN` → "Is Email Opt In",
+  `DAYS_TO_SHIP` → "Days to Ship"). Cross-element refs are case-SENSITIVE;
+  warehouse-table refs are case-insensitive — so a casing bug only breaks
+  derived views/relationship refs.
+- **Pivot result_metadata carries `field_ref: null`** (v0.61) — refs must be
+  reconstructed from the MBQL by name (agg cols are named sum/count/avg/…);
+  `pivot-grouping` is a Metabase-internal column to skip.
+- **Sigma does NOT honor sql-element names** (all read back "Custom SQL") —
+  remap-wb-to-dm-ids.mjs matches native-card placeholders by column-set
+  fingerprint (smallest unique superset) and REPAIRS every workbook formula ref
+  against the live DM columns ([Element Name/Actual Column Name]).
+
+## Still open
+
+- Exact `dashcards` field names on older self-hosted versions (`size_x` verified on v0.61).
+- Sigma funnel support: if/when a native funnel element verifies end-to-end,
+  upgrade `funnel` from flagged→converted.
+- **Layout application**: the workbook converter emits a 1:1 24-col `layout`
+  HINT block; `scripts/apply-layout.mjs` currently computes its own per-kind
+  heights — add an exact-grid mode that consumes the hints.
+- Conditional formatting: `single` rules pass through; `range` (gradient) rules
+  are still flagged (Sigma backgroundScale shape not yet live-verified).
+
+## 9. First production contact (2026-06, Metabase Cloud v1.61.4 — 7,023 cards / 1,548 dashboards)
+
+Empirical findings folded back into the converter + assessment:
+
+- **pMBQL is the wire format.** 100% of the estate's `dataset_query`s were
+  `{"lib/type":"mbql/query","stages":[…]}`. `pmbql-normalize.mjs` (intake, both
+  skills) converts to the legacy shape; `legacy_query` (server's own
+  down-conversion, a JSON string, present on ~70% of cards) is preferred when
+  parseable. Sniff `lib/type` per card — a list response may mix formats.
+- **Template tags are the dominant feature** (45% of cards): text 5,629 ·
+  date 2,364 · dimension 1,914 · number 1,002 · card 384 · boolean 47; 1,705
+  cards use optional `[[…]]` blocks. See `template-tags.md` for the mapping.
+- **Dashboard parameters target tags, not columns**: 13,474 of 14,600
+  `parameter_mappings` targets were `["variable",["template-tag",…]]`; 1,057
+  `dimension`; 69 `text-tag` (flagged). 53% of dashboards carry parameters;
+  17% use tabs; 6,189 virtual (text/heading) dashcards.
+- **Display histogram** (cards): table 2999 · bar 1604 · line 1176 · combo 449 ·
+  scalar 259 · pie 135 · row 130 · funnel 83 · area 67 · pivot 39 · object 37 ·
+  waterfall 15 · sankey 13 · gauge 11 · scatter 3 · progress 3.
+- **Engines**: BigQuery was the warehouse — `project.dataset.table` refs and
+  trailing-comma SELECTs pass straight through, because the converter emits
+  native SQL **verbatim** into Sigma custom SQL (same-warehouse migrations are
+  near-verbatim; cross-warehouse needs a transpile pass first).
+- **Auth**: API keys send `x-api-key` (NOT a Bearer header). Scoped keys can
+  403 on `/api/database/{id}/metadata`; `GET /api/field/{id}` still worked for
+  restricted DBs — hence the field-resolution fallback chain.
+- **Discovery at scale**: the per-item walk took >1hr; bulk `GET /api/card`
+  (110MB, streamed + split locally) + parallel dashboard GETs ≈ 1 minute.
+
+**Unvalidated remainder (honesty ledger):** Sigma POST shapes for DM `control`
+elements emitted from template tags (`text`/`number`/`date`/`switch`
+controlTypes) and `conditionalFormats` built from `table.column_formatting`
+are doc-derived — verify on the first live Sigma POST; no end-to-end
+Metabase→Sigma parity migration has been run yet.
+
+## 10. First live Sigma validation (2026-06-11, local Metabase v0.61.3 → tj-wells-1989)
+
+The repeatable validation loop, no Docker required:
+
+1. `brew install openjdk` + the Metabase jar (match the customer's major version;
+   Java 24+ needs `--sun-misc-unsafe-memory-access=allow --add-opens=java.base/java.nio=ALL-UNNAMED`
+   or the Snowflake JDBC driver's Arrow reader throws `ExceptionInInitializerError`).
+2. Headless setup: `GET /api/session/properties` → `setup-token` → `POST /api/setup`.
+3. Snowflake connection via key-pair: details `{use-password:false,
+   private-key-options:'local', private-key-path:…}` — same warehouse Sigma reads,
+   so native SQL migrates verbatim and parity is apples-to-apples.
+4. Author pilot cards via `POST /api/card` mirroring the estate's dominant
+   patterns (native SQL, template tags incl. field filters + `[[optional]]`,
+   MBQL agg/breakout, explicit join, implicit FK breakout, scalar/pie/stacked-bar/
+   pivot/cond-format displays), one 2-tab dashboard with `parameter_mappings`.
+5. Execute every card (`POST /api/card/{id}/query`) and SAVE the rows — this is
+   the parity baseline AND proves the card-results extraction path customers'
+   scoped keys may lack (Eucalyptus's key 403'd ALL THREE execution surfaces:
+   card query, `/query/json` export, ad-hoc `/api/dataset` — plan engagements
+   accordingly: parity needs either query perms or warehouse access).
+6. Skill loop: discover → convert → post-and-readback (DM) → convert dashboard
+   → remap (now also repairs refs) → post-and-readback (workbook) → MCP query
+   each element vs the step-5 baseline.
+
+Result: EXACT parity on all 8 cards (total 110,788.35; 633 filtered rows; all
+dimension splits). OSS v0.61 serves pMBQL with `legacy_query: null` — the
+pmbql-normalize path is mandatory, not a Cloud quirk.
+
+Found-and-fixed during the gauntlet (each was a live 400 or an error-typed
+column): join-source shape ×4, control `mode`, `{{tag}}`-in-comment, sql-element
+`[Custom SQL/…]` refs, text `body`, `stacking:normalized`, `data-model` source
+kind, AP-style last-word casing, pivot `field_ref:null`, implicit-FK dim-table
+ensure, explicit-join cards sourcing their card-named element. Plus two script
+bugs any first run would hit: six scripts committed without exec bits, and
+`metabase-discover.sh` f-string escapes that crash python ≤3.11.
+
+### §10b Gold round (same day): model + nested question + combo — EXACT parity
+
+Second pilot wave on the local harness: a curated **model** (`type:"model"`,
+ORDER_FACT ⟕ CUSTOMER_DIM + expression), a **nested question** (`card__N` on the
+model, agg by joined-dim breakout — nested field refs are STRING form
+`["field","NAME",{base-type}]`), and a **combo** chart (2 aggs, per-series
+`series_settings` bar/line + right axis). All three POST clean and match
+Metabase exactly (tiers 22,212.23/32,057.13/21,624.46/31,663.30; channels
+62,316.78/842 · 31,964.18/411 · 16,507.39/228). Combo dual-axis persists via the
+bare-string vs `{columnId, type:'line'}` yAxis form.
+
+Two converter fixes from this round:
+- **Nested-card DM elements need parent passthrough columns** — a table-sourced
+  element starts EMPTY (zero queryable columns live-verified), so the element now
+  copies `[Parent Name/Col]` passthroughs for every parent column.
+- **`card__N` dashcards whose parent is NOT on the dashboard** now source the
+  card's OWN DM element by card name (a `card__N` placeholder 400s at POST);
+  passing `cardNameById` still routes to the parent model instead.
+
+### §10c BigQuery readiness (Sigma side LIVE-verified; Metabase side fixture-shaped)
+
+Same-warehouse BQ migrations need no new machinery — the differences are all
+encoded and tested (`fixtures/bq-estate.card.json` + the `bq:` test block):
+
+- **Paths are `[project, dataset, table]`**, case-preserved (BQ is case-sensitive,
+  typically lowercase). The converter no longer uppercases table names anywhere —
+  a no-op for Snowflake (whose metadata is already uppercase), required for BQ.
+- **Project auto-derives** from `metadata.details['project-id']` when `--database`
+  is omitted (Snowflake: `details.db`). **Per-table `schema` from metadata wins**
+  over `--schema` — real estates span datasets.
+- **Live-verified against a real BQ connection** (no Metabase-on-BQ needed — the
+  Sigma side is what the converter POSTs): warehouse-table element with lowercase
+  path + `[table_tail/Prettified Col]` refs, a join with lowercase source/join
+  names + prettified `[Display Name]` condition refs, and a **verbatim BQ-dialect
+  sql element (backticks + trailing comma)** all POST clean, read back 0 errors,
+  and return correct rows. Cross-project tables (`bigquery-public-data.*`) appear
+  in Sigma's catalog the same way.
+- **First live Metabase-on-BQ run, verify only**: that `/api/database/{id}/metadata`
+  `details` exposes `project-id` on the customer's auth flavor, and dataset-level
+  `schema` population. Everything Sigma-side is already proven.
+- **Cross-warehouse** (Metabase-on-BQ → Sigma-on-Snowflake) remains the one real
+  gap: the 91%-native-SQL estate would need a transpile pass before passthrough —
+  flag, don't fake.
+
+### §10d Customer-feedback round (Eucalyptus wave 0 — Margaret, 2026-06-12)
+
+Four reported issues, each reproduced on the customer's real dashboard (defs
+from the estate cache) and fixed:
+
+1. **Grain switchers** (`{{date_aggregation}}` driven by a static-list param) —
+   parameters with `values_source_type: "static-list"` now become a Sigma
+   **segmented control** (≤6 values; larger lists stay `list`) with a manual
+   value source and the Metabase default carried over. The {{tag}} in SQL stays
+   verbatim. Number defaults are coerced from Metabase's strings.
+2. **Raw aliases as chart labels** (`x_axis_type`, `count(*)`) — column display
+   names are now ALWAYS prettified (sigmaDisplayName is idempotent); formulas
+   keep the raw alias ([Custom SQL/x_axis_type]). BQ's anonymous `f0_` becomes
+   "F 0" — alias aggregates in SQL for a better label.
+3. **Controls not driving anything** — remap gains `--dm-spec`: workbook
+   controls whose controlId matches a DM {{tag}} control get
+   `parameters: [{kind:'data-model', dataModelId, controlId}]` (the OpenAPI
+   shape on BOTH spec paths). NOTE: live POST currently rejects the binding
+   ("Invalid parameter on control") even type-matched and id-vs-controlId —
+   likely the DM control must be UI-exposed as a parameter first.
+   post-and-readback now strips the bindings and retries ONCE with a loud
+   warning; sync each control in the UI (control → Sync with data source
+   parameter). Re-probe occasionally — if the platform starts accepting it,
+   the wiring is already emitted.
+4. **Stacked layout** — `cli.ts --layout-out hints.json` exports the 1:1
+   Metabase grid geometry; `apply-layout.mjs --hints hints.json` reproduces it
+   exactly (24-col, ROWSCALE=2, controls in a top band, unhinted leftovers
+   stacked below; element ids preserved on workbook CREATE so hints match).
+   Without --hints the generic per-kind layout still applies.
+
+Run order per dashboard: convert (--layout-out) → remap (--dm-spec) →
+post-and-readback → apply-layout (--hints) → assert-parity.
+
+## 11. Control-targeting standard + shared gate stack (2026-06-12 retrofit)
+
+Brought to the cross-plugin contract uniform across sigma-migration-skills' 8
+plugins. Vendored BYTE-IDENTICAL (md5 discipline): `scripts/lib/control_lint.rb`,
+`scripts/lib/layout_lint.rb`, `scripts/probe-controls.rb`,
+`scripts/assert-phase6-ran.rb`, `refs/control-parity.md`.
+
+**What the audit found** (gate 7 run against the §10 live Pilot Ops workbook):
+3 of 3 controls DEAD — Status (variable-tag: binding rejected by the org and
+stripped → decorative), Region (field-filter tag whose column isn't in the
+card's result set → never wired), Date Grain (parameter has zero
+parameter_mappings → filters nothing in Metabase either). Layout lint: clean
+(the §10d exact-grid round already passes; layouts unchanged by this retrofit).
+
+**What changed (reconciled with the §10d customer round, not clobbering it):**
+- Converter emits the `control-scope.json` sidecar (`--control-scope-out`):
+  `sourceFilterSignals` = MAPPED parameters; per-control `scope`/`mustReach`
+  from the declared `parameter_mappings` targets (Metabase targets are
+  explicit, like MSTR selectors — unmapped same-page cards are by-design).
+- ALL wirable mappings now wire as REAL control `filters` targets, replacing
+  the boolean match column `[Col] = [slug]` entirely: a list-control reference
+  inside a formula reads back as an error-typed column (live-caught by the
+  new gates on the first fixture build), and range semantics never fit an
+  equality anyway. Table dashcards are targeted directly; charts/KPIs/pivots
+  re-root through a hidden base TABLE on a trailing `Data` page (id prefixed
+  `data` — the layout-gate exemption convention), because control targets may
+  only point at table elements. Date params become date-range controls (flat
+  `mode:"between"` — datetime targets need it); list/segmented targets on
+  numeric/datetime columns bind through a hidden `Text()` cast column (the
+  silent-strip gotcha). remap-wb-to-dm-ids skips intra-workbook (base-table)
+  sources AND leaves `[controlId]` tokens unrepaired (rewriting `[region]` to
+  `[Customer Dim/Region]` made a filter always-true — also live-caught).
+- Controls are placed AFTER the elements they target in spec order.
+- Unmapped parameters and unwirable field-filters get NO control + a loud
+  warning (flag, never furniture — they do nothing in Metabase either /
+  cannot be honestly wired).
+- Variable-tag controls keep the §10d behavior (emit + `--dm-spec` binding);
+  NEW default when the org rejects the binding: post-and-readback DROPS those
+  controls (and patches the sidecar) instead of shipping decorative ones —
+  the customer's original complaint WAS "controls not driving anything".
+  `--keep-rejected-bindings` restores the strip-and-keep behavior (gate 7
+  will flag those dead until each is UI-synced to its DM parameter).
+- Sentinels: post-and-readback writes `wb-ids.json` + `posted-workbooks.jsonl`;
+  `assert-parity --check` writes `parity-final.json` (+ optional tile census);
+  post-and-readback and apply-layout run the shared lints inline;
+  `assert-phase6-ran.rb` (gates 1–7) is the GREEN gate.
+
+**Known limitation (deferred, needs an upstream standard change):** when an org
+ACCEPTS `control.parameters` DM bindings, the bound control is functional but
+spec-invisible to control_lint (the binding lives on the control element, which
+the lint doesn't treat as wiring) — gate 7 would false-positive it as dead.
+tj-wells-1989 currently rejects the binding, so this path is unexercised.
+
+**Bonus live finding (same retrofit, blocked the first fixture DM POST):**
+Sigma has NO `Or()`/`And()` FUNCTIONS — `Or(a, b)` is "Invalid formula" at
+POST; `and`/`or` are infix operators only. The MBQL translator now emits
+parenthesized infix chains (multi-value `=`, and/or/not nodes, is-empty/
+not-empty, inside). `Not()`, `Between()`, `IsNull()` are functions and fine.

--- a/metabase-migration-skills/metabase-to-sigma/refs/expression-dsl.md
+++ b/metabase-migration-skills/metabase-to-sigma/refs/expression-dsl.md
@@ -1,0 +1,82 @@
+# Metabase expressions → Sigma formulas
+
+Unlike every other source tool in this family, Metabase expressions arrive
+**already parsed**: MBQL is nested JSON arrays (`["+", ["field", 72, null], 5]`),
+so `converter/metabase.ts` (`translateMbqlExpr`) walks a tree — no regex DSL
+parsing. The custom-expression *text* a user typed (`[Price] - [Cost]`) is never
+stored; only the MBQL tree is.
+
+Modern instances emit **pMBQL** clauses (`[op, {opts}, …args]` — opts second);
+`pmbql-normalize.mjs` rewrites them to the legacy shapes below at intake, so
+every row in this table is expressed in legacy clause order. See
+`mbql-shapes.md` § pMBQL.
+
+## Translated (automatic)
+
+| MBQL op | Sigma | Notes |
+|---|---|---|
+| `["field", id, opts]` | `[Display Name]` / `[TABLE/Display Name]` | id → name via `fieldIndex`; `join-alias` → the joined element prefix; `temporal-unit` wraps in `DateTrunc("month", x)` |
+| `["expression", "Name"]` | `[Name]` | sibling custom-column ref |
+| `+ - * /` | `+ - * /` | n-ary in MBQL → left-fold binary |
+| `["case", [[c1,v1],[c2,v2]], {"default": d}]` | `If(c1, v1, If(c2, v2, d))` | |
+| `["coalesce", a, b, …]` | `Coalesce(a, b, …)` | |
+| `["concat", a, b, …]` | `Concat(a, b, …)` | |
+| `["substring", s, start, len]` | `Mid(s, start, len)` | both 1-indexed |
+| `["trim"/"ltrim"/"rtrim", s]` | `Trim/LTrim/RTrim(s)` | |
+| `["upper"/"lower", s]` | `Upper/Lower(s)` | |
+| `["length", s]` | `Len(s)` | |
+| `["replace", s, find, repl]` | `Replace(s, find, repl)` | literal find (not regex) |
+| `["regex-match-first", s, pat]` | `RegexpExtract(s, pat)` | |
+| `["split-part", s, delim, n]` | `SplitPart(s, delim, n)` | |
+| `["round"/"floor"/"ceil"/"abs"/"sqrt"/"exp", x]` | `Round/Floor/Ceiling/Abs/Sqrt/Exp(x)` | |
+| `["text", x]` / `["float", x]` / `["integer", x]` | `Text(x)` / `Number(x)` / `Int(x)` | v50+ casts |
+| `["date", x]` | `DateTrunc("day", x)` | date(x) = day-truncated datetime |
+| `["in"/"not-in", f, a, b, …]` | `(f = a or f = b or …)` / `(f != a and …)` | pMBQL multi-value ops (also appear in server `legacy_query`) |
+| `["power", x, y]` | `Power(x, y)` | |
+| `["log", x]` | `Log(x, 10)` | Metabase `log` is base-10 |
+| `["datetime-add", d, n, "unit"]` | `DateAdd("unit", n, d)` | unit string passes through |
+| `["datetime-subtract", d, n, "unit"]` | `DateAdd("unit", -n, d)` | |
+| `["datetime-diff", a, b, "unit"]` | `DateDiff("unit", a, b)` | |
+| `["get-year"/"get-month"/"get-day"/"get-hour"/"get-quarter", d]` | `DatePart("year"/…, d)` | `get-day-of-week` → `DatePart("dayofweek", d)` |
+| `["now"]` | `Now()` | |
+| `["relative-datetime", -30, "day"]` | `DateAdd("day", -30, Today())` | inside filters |
+| `= != < <= > >=` | `= != < <= > >=` | `["=", f, v1, v2]` (multi-value) → `(f = v1 or f = v2)` — Sigma has **no `IsIn`** (and **no `Or()`/`And()` functions** — infix only, live-verified) |
+| `["between", x, lo, hi]` | `Between(x, lo, hi)` | |
+| `["and"/"or"/"not", …]` | infix `(… and …)` / `(… or …)` / `Not(…)` | |
+| `["is-null"/"not-null", x]` | `IsNull(x)` / `IsNotNull(x)` | `is-empty`/`not-empty` add `Or x = ""` for text |
+| `["starts-with"/"ends-with"/"contains", s, sub]` | `StartsWith/EndsWith/Contains(s, sub)` | `does-not-contain` → `Not(Contains(…))`; default case-insensitive in Metabase — wrapped in `Lower()` unless `{"case-sensitive": true}` |
+| `["time-interval", f, -30, "day"]` | `f >= DateAdd("day", -30, Today())` | "previous 30 days" filter idiom; `"current"` → `DateTrunc(unit, f) = DateTrunc(unit, Today())` |
+| `["inside", lat, lon, …]` | lat/lon `Between` pair | map box filter |
+
+## Aggregations
+
+| MBQL | Sigma | Notes |
+|---|---|---|
+| `["count"]` | `Count()` | row count |
+| `["sum"/"avg"/"min"/"max"/"median", f]` | `Sum/Avg/Min/Max/Median(f)` | |
+| `["distinct", f]` | `CountDistinct(f)` | |
+| `["stddev", f]` | `StdDev(f)` | sample |
+| `["var", f]` | `Variance(f)` | |
+| `["percentile", f, 0.95]` | `Percentile(f, 0.95)` | |
+| `["count-where", cond]` | `CountIf(cond)` | condition only — no field arg |
+| `["sum-where", f, cond]` | `SumIf(f, cond)` | **field first** in both |
+| `["share", cond]` | `CountIf(cond) / Count()` | ratio of matching rows; format `,.2%` |
+| `["aggregation-options", inner, {name…}]` | inner | wrapper supplies the metric's name |
+
+## Flagged — never faked (warning + readable placeholder)
+
+| MBQL | Why | What to do |
+|---|---|---|
+| `["cum-sum"/"cum-count", f]` | running totals need a window scope Sigma defines on the *consuming element* | rebuild with `CumulativeSum` in the date-grouped workbook element (proven pattern — see powerbi DateLookback note) |
+| `["offset", expr, -1]` (v50+) | lag/lead window fn | rebuild with `Lag`/window calc in the consuming element |
+| `["segment", id]` | saved-segment ref — definition lives in another object | inline the segment's own MBQL (discovery fetches `/api/segment/{id}`; auto-inline is a roadmap item) |
+| `["metric", id]` (legacy) | saved-metric ref | same — inline from `/api/legacy-metric/{id}` |
+| `binning` opts on a breakout | numeric histogram buckets | recreate with `BinFixed`/`BinCount` in the workbook element |
+| `["day-name"/"month-name"/"quarter-name", x]` | localized name lookup — no confirmed Sigma fn | rebuild with a `case`/If chain or a Sigma Text format (observed 10× on a 7k-card estate) |
+| multi-stage query (pMBQL `stages` > 1 / legacy `source-query`) | a sub-query, not an expression | rebuild as chained Sigma elements; converter flags + skips (14 of 7,023 observed) |
+| native `{{tag}}` of type `dimension` ("field filter") | expands to a whole WHERE clause at runtime | becomes a Sigma control on the target column + element filter; plain `text`/`number`/`date` tags → `=`-parameter controls (converted) |
+| `click_behavior` | cross-filter / drill links | Sigma actions — manual follow-up |
+| `smartscalar`/`trend` comparison | auto previous-period delta | KPI value converts; add a Sigma comparison manually |
+
+> MBQL `["value", v, …]` literal wrappers unwrap transparently. Unknown ops emit
+> `/* unmapped: <op> */` placeholders + a loud warning — never silent, never guessed.

--- a/metabase-migration-skills/metabase-to-sigma/refs/mbql-shapes.md
+++ b/metabase-migration-skills/metabase-to-sigma/refs/mbql-shapes.md
@@ -1,0 +1,179 @@
+# Metabase source-format shapes (card + dashboard JSON, MBQL)
+
+What the converter parses. Written from the public MBQL reference and API docs,
+then **verified against a live production estate (Metabase Cloud v1.61.4,
+7,023 cards / 1,548 dashboards)**; shapes marked ⚠ have version variants. The
+biggest production finding: modern instances return **pMBQL** ("lib/" MBQL) —
+see the section at the bottom; everything below it is the LEGACY shape the
+converter operates on after `pmbql-normalize.mjs` runs at intake.
+
+## Card JSON (`GET /api/card/{id}`)
+
+```jsonc
+{
+  "id": 123, "name": "Revenue by Month", "description": null,
+  "collection_id": 5, "database_id": 2, "table_id": 45,
+  "type": "question",            // "question" | "model" | "metric"  (⚠ v46–49: models use "dataset": true)
+  "display": "line",             // table|bar|row|line|area|combo|scatter|pie|scalar|smartscalar|gauge|progress|funnel|waterfall|map|pivot|trend
+  "dataset_query": {
+    "type": "query",             // "query" = MBQL | "native" = SQL
+    "database": 2,
+    "query": { ... MBQL, below ... },
+    "native": {                  // only when type = "native"
+      "query": "SELECT ... WHERE category = {{cat}} AND {{date_range}}",
+      "template-tags": {
+        "cat":        { "name": "cat", "display-name": "Category", "type": "text", "default": "Widget" },
+        "date_range": { "name": "date_range", "type": "dimension", "widget-type": "date/range",
+                        "dimension": ["field", 80, null] }   // "field filter" — expands to a WHERE clause
+      }
+    }
+  },
+  "result_metadata": [           // per-result column — the id→name fallback when db metadata is absent
+    { "name": "CREATED_AT", "display_name": "Created At", "base_type": "type/DateTime", "field_ref": ["field", 80, {"temporal-unit": "month"}] }
+  ],
+  "visualization_settings": { ... display config, below ... }
+}
+```
+
+## MBQL query (`dataset_query.query`)
+
+```jsonc
+{
+  "source-table": 45,                  // integer table id — OR "card__123" (a nested question/model)
+  "joins": [{
+    "source-table": 50,
+    "alias": "Products",               // join alias — field refs carry {"join-alias": "Products"}
+    "strategy": "left-join",           // left-join | right-join | inner-join | full-join (default left)
+    "condition": ["=", ["field", 90, null], ["field", 91, {"join-alias": "Products"}]],
+    "fields": "all"                    // "all" | "none" | explicit field refs
+  }],
+  "expressions": {                     // custom columns — see expression-dsl.md
+    "Profit": ["-", ["field", 72, null], ["field", 73, null]]
+  },
+  "aggregation": [
+    ["sum", ["field", 72, null]],
+    ["count"],
+    ["aggregation-options", ["sum-where", ["field",72,null], ["=", ["field",81,null], "Widget"]],
+      { "name": "widget_rev", "display-name": "Widget Revenue" }]   // named aggregation wrapper
+  ],
+  "breakout": [ ["field", 80, { "temporal-unit": "month" }] ],     // group-bys
+  "filter": ["and",
+    ["=", ["field", 81, null], "Widget", "Gadget"],                 // = with >1 value ⇒ IN
+    ["time-interval", ["field", 80, null], -30, "day"],
+    ["segment", 7]                                                  // saved segment ref (flag)
+  ],
+  "order-by": [ ["desc", ["aggregation", 0]] ],
+  "limit": 100,
+  "fields": [ ["field", 72, null], ... ]                            // explicit column list (no aggregation)
+}
+```
+
+**Field refs** — the core shape: `["field", <id-int | "name-string">, opts|null]`.
+Opts: `"temporal-unit"` (`day|week|month|quarter|year|hour|…` — bucketing),
+`"join-alias"`, `"base-type"` (set when the id is a literal name, e.g. columns of
+a nested card), `"binning"` (`{"strategy":"num-bins","num-bins":10}` — numeric
+histogram). Integer ids resolve via `GET /api/database/{id}/metadata`
+(`fieldIndex`); string names resolve directly. `["expression", "Profit"]` refs a
+custom column; `["aggregation", 0]` refs an aggregation by position (order-by only).
+
+**Aggregations**: `count`, `sum`, `avg`, `distinct`, `min`, `max`, `median`,
+`stddev`, `var`, `percentile` (`["percentile", field, 0.95]`), `share` (ratio of
+rows matching a condition), `count-where`, `sum-where`, `cum-sum`, `cum-count`,
+legacy `["metric", id]`. Named via the `aggregation-options` wrapper.
+
+## Dashboard JSON (`GET /api/dashboard/{id}`)
+
+```jsonc
+{
+  "id": 9, "name": "Exec Overview",
+  "parameters": [                          // dashboard-level filters → Sigma controls
+    { "id": "abc123", "name": "Date", "slug": "date", "type": "date/range", "default": "past30days" },
+    { "id": "def456", "name": "Category", "slug": "cat", "type": "string/=" }
+  ],
+  "tabs": [ { "id": 1, "name": "Overview" } ],   // ⚠ v49+; dashcards carry dashboard_tab_id
+  "dashcards": [                                 // ⚠ pre-v48: "ordered_cards" with sizeX/sizeY
+    {
+      "id": 1, "card_id": 123,
+      "row": 0, "col": 0, "size_x": 8, "size_y": 6,   // 24-col grid → maps 1:1 to Sigma's 24-col layout
+      "dashboard_tab_id": 1,
+      "card": { ...full card JSON embedded... },
+      "parameter_mappings": [
+        { "parameter_id": "abc123", "card_id": 123,
+          "target": ["dimension", ["field", 80, null]] }   // which column this control filters on this card
+      ],
+      "visualization_settings": {
+        "virtual_card": { "display": "text" }, "text": "## Section header"   // text/heading cards have card_id: null
+      }
+    }
+  ]
+}
+```
+
+## `visualization_settings` keys the converter reads
+
+| Key | Display | Meaning |
+|---|---|---|
+| `graph.dimensions` / `graph.metrics` | bar/line/area/combo/row/scatter/waterfall | x-axis column names / series column names (match `result_metadata.name`) |
+| `stackable.stack_type` | bar/area | `"stacked"` \| `"normalized"` (100%) |
+| `series_settings` | combo | per-series `{"display": "line"\|"bar"}` overrides |
+| `pie.dimension` / `pie.metric` | pie | slice dim + value |
+| `pivot_table.column_split` | pivot | `{"rows": [field refs], "columns": [...], "values": [...]}` → rowsBy/columnsBy/values |
+| `scalar.field` | scalar | which column is THE number |
+| `map.type` | map | `"region"` → region-map; `"pin"` → point-map |
+| `column_settings` | any | per-column `{"number_style": "currency", "decimals": 2, "suffix": …}` → Sigma format |
+| `table.columns` | table | column order + `enabled` (hidden cols) |
+
+## Things that look like data but aren't
+
+- **Text/heading dashcards** — `card_id: null` + `visualization_settings.virtual_card`
+  → Sigma `text` elements (markdown passes through).
+- **Click behavior** (`click_behavior` in viz settings — cross-filter / link) →
+  flagged, not converted (Sigma actions are a manual follow-up).
+- **`trend` / `smartscalar`** — the KPI value converts; the auto "vs previous
+  period" comparison line is flagged (rebuild with a Sigma KPI comparison).
+
+## pMBQL ("lib/" MBQL) — what modern instances ACTUALLY return
+
+**Production finding (2026-06, Metabase Cloud v1.61.4): 100% of a 7,023-card
+estate returned `dataset_query` in pMBQL form**, not the legacy shape above. A
+single card-list response may contain EITHER format depending on instance
+version — sniff the `lib/type` key, never the version string.
+
+```jsonc
+{
+  "lib/type": "mbql/query",
+  "database": 134,
+  "stages": [                                   // legacy nests source-query; pMBQL chains stages
+    {
+      "lib/type": "mbql.stage/mbql",            // or "mbql.stage/native"
+      "source-table": 8391,                     // or "source-card": N  (legacy: "card__N")
+      "aggregation": [["count", {"lib/uuid": "…"}]],
+      "breakout":    [["field", {"lib/uuid": "…", "base-type": "type/DateTime", "temporal-unit": "week"}, 124164]],
+      "filters": [                              // ARRAY (implicit AND) — legacy has a single "filter"
+        ["=", {"lib/uuid": "…"}, ["field", {…}, 124158], "AU"],
+        ["in", {"lib/uuid": "…"}, ["field", {…}, 124161], "A", "B"]   // pMBQL multi-value op
+      ],
+      "expressions": [                          // LIST of clauses — legacy is a {name: clause} map
+        ["datetime-diff", {"lib/uuid": "…", "lib/expression-name": "Cohort Age"}, …]
+      ],
+      "joins": [{ "lib/type": "mbql/join", "alias": "…", "strategy": "left-join",
+                  "stages": [{"source-table": 46}], "conditions": [ … ], "fields": "all" }]
+    }
+  ]
+}
+```
+
+Key invariant: **every pMBQL clause is `[op, {opts}, …args]` — the options map
+is ALWAYS the second element** (legacy puts it last, or third for `field`).
+Native stages carry the SQL directly: `{"lib/type": "mbql.stage/native",
+"native": "<sql>", "template-tags": {…}}` (template-tag `dimension` refs are
+pMBQL field clauses too).
+
+`converter/pmbql-normalize.mjs` (byte-identical copy in
+`metabase-assessment/scripts/`) converts all of this to the legacy shape at
+intake in BOTH skills. It prefers the card's **`legacy_query`** field when
+present — a JSON *string* containing the server's own down-conversion (~70% of
+cards on the reference estate carry it) — and falls back to the local
+normalizer. Multi-stage queries (stages > 1; 14 of 7,023 observed) normalize to
+legacy `source-query` nesting, which the converter FLAGS (rebuild as chained
+Sigma elements), never mistranslates.

--- a/metabase-migration-skills/metabase-to-sigma/refs/rest-api.md
+++ b/metabase-migration-skills/metabase-to-sigma/refs/rest-api.md
@@ -1,0 +1,57 @@
+# Metabase REST API — extraction surface
+
+Everything this skill needs is on Metabase's first-class REST API — open source and
+Pro/EE alike. No private endpoints. Written from the public API docs
+(`<host>/api/docs` on any instance ≥ v48) and **validated read-side against a live
+production estate (Metabase Cloud v1.61.4, 7,023 cards / 1,548 dashboards)**. The
+conversion BUILD path (POST to Sigma) is still fixture-validated only — see repo
+README status. Production note: modern instances return `dataset_query` in
+**pMBQL** form and often include a `legacy_query` JSON string — see
+`mbql-shapes.md` § pMBQL.
+
+## Auth (two options)
+
+| Method | How | Notes |
+|---|---|---|
+| **API key** (preferred, v49+) | Admin → Settings → **Authentication → API keys** → create key (group: Administrators for full read). Send header `x-api-key: <key>` | Durable; the right choice for an engagement |
+| **Session token** | `POST /api/session {"username": "...", "password": "..."}` → `{"id": "<token>"}`. Send header `X-Metabase-Session: <token>` | Sessions expire (default 14 days, sooner with SSO); on 401 re-login |
+
+`scripts/get-metabase-session.sh` captures either into `MB_BASE` / `MB_KEY` /
+`MB_SESSION` env vars. All requests below are plain `GET`s — read-only.
+
+## Endpoints used
+
+| Need | Endpoint | Notes |
+|---|---|---|
+| Probe / version | `GET /api/session/properties` | `version.tag` — no auth needed for basic properties |
+| Databases | `GET /api/database` | `data[]` of `{id, name, engine}` — find the warehouse conn (e.g. `snowflake`) |
+| **Schema metadata** | `GET /api/database/{id}/metadata` | tables + **fields with ids** — REQUIRED: MBQL refs fields by integer id; this is the id→column map. Each field: `{id, name, display_name, base_type, semantic_type, fk_target_field_id, table_id}`; each table: `{id, name, schema, fields[]}` |
+| Collections (folder tree) | `GET /api/collection` | flat list with `location` path (`/3/7/`); `personal_owner_id` ≠ null = personal space |
+| Collection items | `GET /api/collection/{id}/items?models=card&models=dashboard&models=dataset` | paginated (`limit`/`offset`, default 50ish); `data[]` of `{id, model, name}` |
+| **Card (question/model) def** | `GET /api/card/{id}` | the full definition incl `dataset_query` (MBQL or native), `display`, `visualization_settings`, `result_metadata` — see `refs/mbql-shapes.md` |
+| **All cards (bulk)** | `GET /api/card` | unpaginated — returns EVERY card **with its full definition** in one response (~110MB for 7k cards on the reference estate). Stream to disk, then split locally (`metabase-assessment/scripts/mb-bulk-split.py`). This beats the per-item walk by ~60× on big estates |
+| **Single field** | `GET /api/field/{id}` | field-id → `{name, display_name, table_id, base_type}`. The fallback when `/api/database/{id}/metadata` 403s on a scoped key — **worked even for restricted DBs on the reference estate**. Resolution chain: db metadata → card `result_metadata` → `GET /api/field/{id}` → names from the SQL when native |
+| **Dashboard def** | `GET /api/dashboard/{id}` | `dashcards[]` with grid geometry + embedded `card` + `parameter_mappings`; top-level `parameters[]`, `tabs[]` |
+| Search | `GET /api/search?q=...&models=card` | quick lookup by name |
+| Recent views | `GET /api/activity/recents` | thin usage signal (see assessment skill's `usage-telemetry.md`) |
+
+## Version-shape gotchas (handle both)
+
+- **`dashcards` vs `ordered_cards`** — renamed in ~v48. Old shape uses
+  `ordered_cards[].sizeX/sizeY`; new uses `dashcards[].size_x/size_y`. The
+  converter accepts both.
+- **Models**: v50+ marks them `type: "model"` on the card; v46–49 use
+  `dataset: true`. Older "metrics"/"segments" (`/api/legacy-metric`,
+  `["metric", id]` / `["segment", id]` MBQL refs) still appear in old cards;
+  v50+ adds first-class metric cards (`type: "metric"`).
+- **Dashboard grid** is **24 columns** wide on current versions (older ~v44-
+  exports used 18 — detect by max `col + size_x` if layout looks compressed).
+- **Serialization export** (YAML bundles via `/api/ee/serialization/export`) is
+  **Pro/EE-only** — do not depend on it; the REST walk above works on OSS.
+
+## Offline mode
+
+Every converter input is a plain JSON file (`card.json`, `dashboard.json`,
+`metadata.json`), so the whole pipeline runs against files on disk — a customer
+can mail you `GET` outputs without granting access. `scripts/metabase-discover.sh`
+writes exactly these files.

--- a/metabase-migration-skills/metabase-to-sigma/refs/template-tags.md
+++ b/metabase-migration-skills/metabase-to-sigma/refs/template-tags.md
@@ -1,0 +1,105 @@
+# Template tags → Sigma controls
+
+Native-SQL template tags are the single most common Metabase feature in the
+wild: **45% of cards** on the reference production estate (7,023 cards,
+Metabase Cloud v1.61) carry at least one tag. Tag-type distribution observed
+there: text 5,629 · date 2,364 · dimension (field filter) 1,914 · number 1,002 ·
+card 384 · boolean 47.
+
+> ## ⚠️ 2026-06-15 — PREFER native-model remodel; custom-SQL control binding is INERT
+>
+> **Live-disproven (tj-wells-1989):** a *workbook* control bound only to a DM
+> custom-SQL `{{param}}` does NOT filter — a text grain control is ignored and a
+> numeric one mis-substitutes and breaks the query (0 rows). So the
+> `{{tag}}`-kept-verbatim path below only works when the user manually wires the
+> control to the DM parameter in the Sigma UI. Two consequences in the converter:
+>
+> 1. **Simple native SQL is auto-remodeled to a NATIVE Sigma data model** — a
+>    card that is a single `SELECT` over warehouse table(s) (no CTE / subquery /
+>    CASE / window / set-op, only field-filter tags, real WHERE only on those
+>    tags) is re-expressed as a structured query and built as a table/join model
+>    (no custom SQL). Its columns are exposed, so field filters reproduce as REAL
+>    Sigma controls + element filters that actually filter — verified live (a
+>    `last_name` control flips a chart 5→1 rows). This is the path to working
+>    filters; **the mapping table below is the FALLBACK for SQL too complex to
+>    remodel.**
+> 2. **No dead furniture:** a control whose only wiring would be a DM-SQL
+>    `{{param}}` (or a field-filter column missing from the result set) is NOT
+>    emitted — it goes into the result's `unreproducibleFilters` report
+>    (controlId / name / reason / hint) so the migration surfaces exactly what
+>    still needs a manual remodel. See design-notes.md "native-model remodel".
+
+The fact behind the fallback path: **Sigma custom SQL uses the same
+`{{control-id}}` parameter syntax as Metabase**, so a plain variable tag's SQL
+needs NO rewrite — but per the warning above, that control must be wired to the
+DM parameter in the UI to actually filter.
+
+## Mapping table
+
+| Tag type | Converter behavior | Sigma artifact |
+|---|---|---|
+| `text` | `{{tag}}` kept **verbatim** in the SQL | `controlType: text` control, `controlId` = tag name, `value` = tag default |
+| `number` | verbatim | `controlType: number` control (verify on first live POST — `number-range` is the spec-verified shape; single-value number is doc-derived) |
+| `date` | verbatim | `controlType: date` control |
+| `boolean` | verbatim | `controlType: switch` control |
+| `dimension` (**field filter**) | `{{tag}}` replaced with `1=1 /* … */` + loud warning | control + element filter on the mapped column, recreated on the **consuming workbook element** |
+| `card` (`{{#N-…}}`) | inlined as `( <card N SQL> )` when card N is in the input set, native, and tag-free; otherwise flagged | — |
+| `snippet` | flagged — inline `GET /api/native-query-snippet` by hand | — |
+
+Controls are emitted as `kind: control` elements on the data-model page (the
+custom SQL lives in the DM, so the `{{tag}}` reference must resolve there).
+The tag's `display-name` becomes the control name; `default` becomes `value`.
+A `required: true` tag with no default is warned about — the element errors
+until the control has a value.
+
+## Field filters (`type: dimension`) — why `1=1`
+
+A Metabase field filter does **not** substitute a scalar: at runtime it expands
+to a **whole SQL predicate** on the mapped column (`WHERE {{order_date}}` →
+`WHERE ORDER_DATE BETWEEN … AND …`), driven by the widget type. There is no
+Sigma equivalent inside custom SQL, so the converter:
+
+1. Replaces `{{tag}}` with `1=1 /* Metabase field filter {{tag}} → filter [Col]
+   on the consuming Sigma element */` — semantically the "no value selected"
+   state, and always safe because a dimension tag can only legally appear in
+   boolean-predicate position.
+2. Resolves the tag's `dimension` field ref to the column (metadata →
+   result_metadata → `GET /api/field/{id}`) and tells you (warning + the
+   dashboard converter's `parameterWiring`) to recreate it as a Sigma control +
+   element filter on that column.
+3. If the mapped column is **not** in the card's SELECT output, the filter
+   cannot be recreated on the element — flagged as ambiguous; add the column to
+   the SQL first.
+
+## Optional `[[ … ]]` blocks
+
+Metabase includes an optional block only when its tag has a value (24% of the
+reference estate's cards use them). Sigma has no optional-clause syntax:
+
+- every tag in the block is a **field filter** → block kept active (they
+  neutralize to `1=1`, so always-on is harmless);
+- every variable tag in the block **has a default** → block kept active
+  (matches Metabase's default state) + warning;
+- otherwise → block **dropped** (matches Metabase's empty-value behavior) +
+  loud warning listing the dropped clause.
+
+## Dashboard parameters driving tags
+
+On production estates, dashboard `parameter_mappings` overwhelmingly target
+template tags, not columns (13,474 `["variable",["template-tag",…]]` +
+1,057 dimension targets of 14,600 mappings observed). The dashboard converter
+records these in the result's `parameterWiring` array and emits ONE aggregated
+warning per parameter. Consolidation is manual today: either keep the DM
+control as the single source of truth, or sync the workbook control to it.
+
+`["dimension",["template-tag",…]]` targets (a parameter driving a field-filter
+tag) are auto-wired to a hidden boolean + include-`[true]` element filter when
+the tag's column is in the card's result set.
+
+## SQL dialect passthrough
+
+The statement (after tag handling) is emitted **verbatim** into the Sigma
+custom-SQL element — the dialect passes straight through to the warehouse. A
+same-warehouse migration (e.g. BigQuery→BigQuery: `project.dataset.table` refs,
+trailing-comma SELECTs) is near-verbatim; cross-warehouse migrations need a SQL
+transpile pass first.

--- a/metabase-migration-skills/metabase-to-sigma/scripts/apply-layout.mjs
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/apply-layout.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// apply-layout.mjs — give a migrated Metabase workbook a CLEAN dashboard grid.
+//
+// Sigma auto-arrange stacks every element at the SAME height (KPIs as tall as tables,
+// charts squished) — so for any multi-element page we write an explicit 24-col layout:
+// controls in a top row, then content stacked full-width with per-kind heights. Layout
+// elementIds must match the POSTED (reassigned) ids, so this GETs the readback spec first.
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/apply-layout.mjs --workbook <workbookId> [--hints layout-hints.json]
+//
+// --hints (from `cli.ts … --layout-out hints.json`) reproduces the ORIGINAL
+// Metabase dashboard geometry 1:1 (24-col grid, row/col/sizeX/sizeY per element;
+// element ids are preserved on workbook CREATE so hints match the live spec).
+// Controls aren't Metabase dashcards, so they get a top band; hinted content is
+// placed below at exact coordinates; unhinted leftovers stack at the bottom.
+// Without --hints, falls back to the generic per-kind stacked layout.
+//
+// Idempotent. Run it as the last step of the build/verify phase.
+import { readFileSync } from 'node:fs';
+import { api, parseArgs } from './lib/sigma-rest.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+if (!a.workbook) { console.error('need --workbook <workbookId> [--hints hints.json]'); process.exit(2); }
+const hints = a.hints ? JSON.parse(readFileSync(a.hints, 'utf8')) : null;
+const ROWSCALE = 2; // Metabase row unit → Sigma grid rows (proportions, rows are "auto")
+
+// per-kind row-unit heights (24-col grid; rows are "auto" so spans set relative size)
+const H = (k) => k === 'control' ? 2
+  : k === 'kpi-chart' ? 6
+  : k.endsWith('-chart') ? 10
+  : (k.endsWith('-map') || k === 'pivot-table' || k === 'table') ? 12
+  : k === 'text' ? 3 : 10;
+
+// Exact mode: place each hinted element at its Metabase grid coordinates.
+function pageLayoutExact(page, hintEls) {
+  const els = (page.elements || []).filter((e) => e.id);
+  if (els.length < 2) return null;
+  const byId = new Map(els.map((e) => [e.id, e]));
+  // name fallback queues (texts share names — consume in order)
+  const byName = new Map();
+  for (const e of els) {
+    const k = String(e.name || e.kind || '').toLowerCase();
+    if (!byName.has(k)) byName.set(k, []);
+    byName.get(k).push(e);
+  }
+  const controls = els.filter((e) => e.kind === 'control');
+  const lines = [];
+  let row = 1;
+  controls.forEach((c, i) => {
+    const perRow = Math.min(controls.length, 4);
+    const span = Math.floor(24 / perRow);
+    const col0 = 1 + (i % perRow) * span;
+    const r = row + Math.floor(i / perRow) * H('control');
+    const col1 = (i % perRow === perRow - 1) ? 25 : col0 + span;
+    lines.push(`  <LayoutElement elementId="${c.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('control')}"/>`);
+  });
+  if (controls.length) row += Math.ceil(controls.length / 4) * H('control');
+
+  const placed = new Set(controls.map((c) => c.id));
+  let maxRow = row;
+  for (const h of hintEls || []) {
+    let el = byId.get(h.elementId);
+    if (!el || placed.has(el.id)) {
+      const q = byName.get(String(h.name || '').toLowerCase()) || [];
+      el = q.find((e) => !placed.has(e.id));
+    }
+    if (!el || placed.has(el.id) || el.kind === 'control') continue;
+    placed.add(el.id);
+    const c0 = Math.max(1, (h.col ?? 0) + 1);
+    const c1 = Math.min(25, c0 + Math.max(h.sizeX ?? 4, 1));
+    const r0 = row + (h.row ?? 0) * ROWSCALE;
+    const r1 = r0 + Math.max((h.sizeY ?? 4) * ROWSCALE, 2);
+    lines.push(`  <LayoutElement elementId="${el.id}" gridColumn="${c0} / ${c1}" gridRow="${r0} / ${r1}"/>`);
+    if (r1 > maxRow) maxRow = r1;
+  }
+  // anything unhinted stacks full-width below the hinted grid
+  for (const e of els) {
+    if (placed.has(e.id)) continue;
+    const h = H(e.kind);
+    lines.push(`  <LayoutElement elementId="${e.id}" gridColumn="1 / 25" gridRow="${maxRow} / ${maxRow + h}"/>`);
+    maxRow += h;
+  }
+  return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${page.id}">\n${lines.join('\n')}\n</Page>`;
+}
+
+function pageLayout(page) {
+  const els = (page.elements || []).filter((e) => e.id);
+  if (els.length < 2) return null; // single element → auto-arrange is fine
+  const controls = els.filter((e) => e.kind === 'control');
+  const content = els.filter((e) => e.kind !== 'control');
+  const lines = [];
+  let row = 1;
+  // controls: up to 4 across the top
+  controls.forEach((c, i) => {
+    const perRow = Math.min(controls.length, 4);
+    const span = Math.floor(24 / perRow);
+    const col0 = 1 + (i % perRow) * span;
+    const r = row + Math.floor(i / perRow) * H('control');
+    const col1 = (i % perRow === perRow - 1) ? 25 : col0 + span;
+    lines.push(`  <LayoutElement elementId="${c.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('control')}"/>`);
+  });
+  if (controls.length) row += Math.ceil(controls.length / 4) * H('control');
+  // content: stacked full-width, per-kind heights (clean, no overlap, right proportions).
+  // Exception: RUNS of consecutive kpi-charts lay out as rows of up to 3 TALL tiles
+  // (a KPI panel) — full-width singles waste a page and Sigma hides the KPI title
+  // below ~5 grid rows, so never shrink them either.
+  for (let i = 0; i < content.length; i++) {
+    const e = content[i];
+    if (e.kind === 'kpi-chart') {
+      let j = i; while (j < content.length && content[j].kind === 'kpi-chart') j++;
+      const run = content.slice(i, j);
+      const perRow = Math.min(run.length, 3);
+      const span = Math.floor(24 / perRow);
+      run.forEach((k, n) => {
+        const col0 = 1 + (n % perRow) * span;
+        const col1 = (n % perRow === perRow - 1) ? 25 : col0 + span;
+        const r = row + Math.floor(n / perRow) * H('kpi-chart');
+        lines.push(`  <LayoutElement elementId="${k.id}" gridColumn="${col0} / ${col1}" gridRow="${r} / ${r + H('kpi-chart')}"/>`);
+      });
+      row += Math.ceil(run.length / perRow) * H('kpi-chart');
+      i = j - 1;
+      continue;
+    }
+    const h = H(e.kind);
+    lines.push(`  <LayoutElement elementId="${e.id}" gridColumn="1 / 25" gridRow="${row} / ${row + h}"/>`);
+    row += h;
+  }
+  return `<Page type="grid" gridTemplateColumns="repeat(24, 1fr)" gridTemplateRows="auto" id="${page.id}">\n${lines.join('\n')}\n</Page>`;
+}
+
+const got = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
+if (!got.json) { console.error(`GET spec failed (HTTP ${got.status}): ${got.text.slice(0, 300)}`); process.exit(1); }
+const spec = got.json;
+// The layout is a SINGLE top-level `spec.layout` XML holding one <Page> block per page
+// (NOT pages[].layout — that's silently dropped). Strip read-only fields before the PUT.
+const hintPageByName = new Map((hints?.pages || []).map((p) => [String(p.name || '').toLowerCase(), p.elements || []]));
+const pageBlocks = [];
+let exactPages = 0;
+for (const p of spec.pages || []) {
+  delete p.layout;
+  const hintEls = hintPageByName.get(String(p.name || '').toLowerCase());
+  const xml = hintEls?.length ? (exactPages++, pageLayoutExact(p, hintEls)) : pageLayout(p);
+  if (xml) pageBlocks.push(xml);
+}
+if (hints) console.error(`exact-grid pages: ${exactPages}/${(spec.pages || []).length}`);
+if (!pageBlocks.length) { console.log('no multi-element pages — nothing to lay out'); process.exit(0); }
+spec.layout = `<?xml version="1.0" encoding="utf-8"?>\n${pageBlocks.join('\n')}`;
+for (const k of ['workbookId', 'url', 'ownerId', 'createdBy', 'updatedBy', 'createdAt', 'updatedAt', 'latestDocumentVersion', 'documentVersion']) delete spec[k];
+if (a.folder && !spec.folderId) spec.folderId = a.folder;
+
+const put = await api('PUT', `/v2/workbooks/${a.workbook}/spec`, spec);
+if (!put.ok) { console.error(`PUT failed (HTTP ${put.status}): ${put.text.slice(0, 400)}`); process.exit(1); }
+
+// verify the layout survived readback
+const rb = await api('GET', `/v2/workbooks/${a.workbook}/spec`);
+const ok = /<LayoutElement/.test(rb.json?.layout || '');
+console.log(JSON.stringify({ workbookId: a.workbook, pagesLaidOut: pageBlocks.length, layoutOnReadback: ok }, null, 2));
+if (!ok) { console.error('FAIL: layout did not survive readback (check elementId matches)'); process.exit(1); }
+console.error(`clean layout applied (${pageBlocks.length} page block(s))`);
+
+// shared layout lint on the laid-out readback spec (same lib gate 6 runs —
+// scripts/lib/layout_lint.rb, vendored byte-identical across plugins)
+{
+  const { writeFileSync } = await import('node:fs');
+  const { dirname, join } = await import('node:path');
+  const { fileURLToPath } = await import('node:url');
+  const { spawnSync } = await import('node:child_process');
+  const tmp = `/tmp/layout-lint-${a.workbook}.spec.json`;
+  writeFileSync(tmp, JSON.stringify(rb.json, null, 2));
+  const lint = spawnSync('ruby', [join(dirname(fileURLToPath(import.meta.url)), 'lib', 'layout_lint.rb'), tmp], { stdio: 'inherit' });
+  if (lint.status !== 0) { console.error('FAIL: layout lint violations on the applied layout (see above) — fix and re-run.'); process.exit(1); }
+}

--- a/metabase-migration-skills/metabase-to-sigma/scripts/apply_sigma_rls.py
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/apply_sigma_rls.py
@@ -1,0 +1,366 @@
+#!/usr/bin/env python3
+"""Phase 1.5 (RLS decision gate) — apply a Looker RLS finding to Sigma, scripted.
+
+Sigma user attributes are FULLY API-supported (confirmed live 2026-06-10):
+  - GET  /v2/user-attributes            list (reuse-first)
+  - POST /v2/user-attributes            create
+  - POST /v2/user-attributes/{id}/users assign a value to a member
+And the Sigma RLS row-filter is fully spec-expressible (NOT UI-only): a boolean
+calc column `CurrentUserAttributeText("<attr>") = [<Field>]` on the base element
+plus an element `filters` entry `{kind:list, mode:include, values:[true]}`.
+
+This script does the whole flow, REUSE-FIRST and SAFE-BY-DEFAULT:
+  1. attribute   GET /v2/user-attributes → print a match if one already exists
+                 (by name, case-insensitive) before creating anything.
+  2. provision   --create  → POST /v2/user-attributes when nothing reusable exists.
+                 --assign   → POST /v2/user-attributes/{id}/users (needs --member-id
+                 + --value) to assign the attribute value to a member.
+  3. apply       --field <DisplayName> (+ --element-id/--dm-id) → print the RLS
+                 calc-column + element-filter spec snippet; with --apply, PATCH it
+                 into the DM element's spec (GET/PUT /v2/dataModels/{id}/spec).
+
+By default this only READS and PRINTS a plan — it mutates ONLY when you pass an
+explicit --create / --assign / --apply flag. Mirrors post_dm.py: reads
+$SIGMA_BASE_URL / $SIGMA_API_TOKEN from env (eval "$(scripts/get-token.sh)").
+Dependency-free (stdlib only).
+
+Live-validated: this exact flow produced exact 3-way parity (Looker-restricted ==
+Sigma-restricted == warehouse: $38,906.82 / 220 rows, region=West).
+
+Usage:
+  eval "$(scripts/get-token.sh)"
+  # reuse-first lookup only (default, read-only):
+  python3 apply_sigma_rls.py --attr region
+  # create the attribute if missing:
+  python3 apply_sigma_rls.py --attr region --value West --create
+  # assign a value to the querying member:
+  python3 apply_sigma_rls.py --attr region --value West --member-id <id> --assign
+  # print the RLS spec snippet for a DM element (plan only):
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid>
+  # ...and PATCH it into the DM element spec:
+  python3 apply_sigma_rls.py --attr region --field Region --element-id <eid> \
+      --dm-id <dataModelId> --apply
+
+BATCH MODE (tool-agnostic) — ingest a converter's result.security[] (architecture B:
+the converter REPORTS RLS/CLS; this script provisions + applies). Handles RLS via
+user attribute / team (CurrentUserInTeam) / email, and CLS (columnSecurities):
+  # 1) convert + POST the model (converter injects NO RLS), capture dataModelId
+  # 2) write result.security to a JSON file, then:
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId>            # plan only
+  python3 apply_sigma_rls.py --from-security security.json --dm-id <dmId> --provision --apply
+Elements match by name (Sigma reassigns ids on POST); CLS columns match by normalized
+name. --provision creates missing attributes/teams (assign per-user values separately).
+Works for tableau/quicksight/powerbi/thoughtspot/qlik/lookml converter output alike.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+BASE = os.environ.get("SIGMA_BASE_URL")
+TOK = os.environ.get("SIGMA_API_TOKEN")
+
+
+def api(method, path, body=None):
+    if not BASE or not TOK:
+        sys.exit("SIGMA_BASE_URL / SIGMA_API_TOKEN unset — run: eval \"$(scripts/get-token.sh)\"")
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(
+        BASE + path, data=data, method=method,
+        headers={"Authorization": "Bearer " + TOK, "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req) as r:
+            raw = r.read().decode()
+    except urllib.error.HTTPError as e:
+        print("HTTP", e.code, method, path, "->", e.read().decode()[:1000], file=sys.stderr)
+        raise
+    try:
+        return json.loads(raw)
+    except Exception:
+        return raw  # spec endpoints return YAML
+
+
+def _short_id(prefix="rls"):
+    """A short, deterministic-enough id for a calc column / filter."""
+    import hashlib
+    return prefix + "-" + hashlib.md5(prefix.encode() + os.urandom(4)).hexdigest()[:8]
+
+
+# --- 1. reuse-first attribute lookup --------------------------------------
+def find_attribute(name):
+    """Return the existing user-attribute entry matching `name` (case-insensitive), else None."""
+    res = api("GET", "/v2/user-attributes?limit=200")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+
+def list_attributes():
+    res = api("GET", "/v2/user-attributes?limit=200")
+    return res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+
+
+# --- 3. RLS spec snippet --------------------------------------------------
+def rls_spec_snippet(attr, field, element_id):
+    """The verified row-filter shape: a boolean calc column + an element list filter showing only True."""
+    col_id = _short_id("rlscol")
+    filt_id = _short_id("rlsf")
+    calc = {
+        "id": col_id,
+        "name": f"RLS {attr}",
+        "formula": f'CurrentUserAttributeText("{attr}") = [{field}]',
+    }
+    filt = {
+        "id": filt_id,
+        "columnId": col_id,
+        "kind": "list",
+        "mode": "include",
+        "values": [True],
+    }
+    return {
+        "elementId": element_id,
+        "calcColumn": calc,
+        "filter": filt,
+        "_note": (
+            f'Add calcColumn to element "{element_id}" columns, and `filter` to that '
+            f"element's filters[]. CurrentUserAttributeText(\"{attr}\") = [{field}] is the "
+            "user-attribute mode; team mode = CurrentUserInTeam([...]); email mode = "
+            "[Email] = CurrentUserEmail()."
+        ),
+    }
+
+
+def apply_to_dm(dm_id, element_id, calc, filt):
+    """PATCH the calc column + filter into the DM element's spec (GET → mutate → PUT)."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        # spec endpoints can return YAML; we can't safely mutate that here.
+        sys.exit("DM spec came back non-JSON (YAML) — cannot auto-PATCH; apply the snippet by hand.")
+    # The spec shape nests elements under the model; search for the element by id.
+    found = _inject(spec, element_id, calc, filt)
+    if not found:
+        sys.exit(f"element id {element_id} not found in DM {dm_id} spec — check --element-id")
+    res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+    print("PUT /v2/dataModels/%s/spec ->" % dm_id,
+          json.dumps(res)[:300] if isinstance(res, dict) else str(res)[:300])
+
+
+def _inject(node, element_id, calc, filt):
+    """Recursively find an element dict whose id == element_id; add calc col + filter. Returns True if injected."""
+    if isinstance(node, dict):
+        if node.get("id") == element_id and ("columns" in node or "kind" in node or "source" in node):
+            cols = node.setdefault("columns", [])
+            if not any(c.get("id") == calc["id"] for c in cols if isinstance(c, dict)):
+                cols.append(calc)
+            filters = node.setdefault("filters", [])
+            filters.append(filt)
+            return True
+        for v in node.values():
+            if _inject(v, element_id, calc, filt):
+                return True
+    elif isinstance(node, list):
+        for v in node:
+            if _inject(v, element_id, calc, filt):
+                return True
+    return False
+
+
+
+# --- shared engine: teams, element/column resolution, CLS, batch from result.security ---
+def find_team(name):
+    res = api("GET", "/v2/teams?limit=500")
+    entries = res.get("entries", res.get("data", [])) if isinstance(res, dict) else []
+    for e in entries:
+        if (e.get("name") or "").lower() == name.lower():
+            return e
+    return None
+
+def ensure_team(name, do_create):
+    t = find_team(name)
+    if t:
+        print(f"  REUSE team '{name}' (id={t.get('teamId') or t.get('id')}).")
+        return t.get("teamId") or t.get("id")
+    if do_create:
+        res = api("POST", "/v2/teams", {"name": name})
+        tid = res.get("teamId") or res.get("id") if isinstance(res, dict) else None
+        print(f"  CREATED team '{name}' (id={tid}). NOTE: add members via POST /v2/teams/{tid}/members.")
+        return tid
+    print(f"  (plan: team '{name}' missing — pass --provision to create it, then add members.)")
+    return None
+
+def _walk_elements(node, out):
+    if isinstance(node, dict):
+        if node.get("id") and ("columns" in node or "kind" in node):
+            out.append(node)
+        for v in node.values():
+            _walk_elements(v, out)
+    elif isinstance(node, list):
+        for v in node:
+            _walk_elements(v, out)
+    return out
+
+def _resolve_element(spec, element_id, element_name):
+    els = _walk_elements(spec, [])
+    for e in els:
+        if element_id and e.get("id") == element_id:
+            return e
+    for e in els:                                  # Sigma reassigns ids on POST → match by name
+        if element_name and (e.get("name") == element_name):
+            return e
+    # last resort: a path-tail match (warehouse-table element named by table)
+    for e in els:
+        path = (e.get("source") or {}).get("path") or []
+        if element_name and path and str(path[-1]).upper() == str(element_name).upper():
+            return e
+    return None
+
+def _norm(x):
+    """Normalize a column name for matching across raw/display forms (NET_PROFIT == Net Profit)."""
+    return __import__("re").sub(r"[^a-z0-9]", "", (x or "").lower())
+
+def _resolve_col_ids(element, names):
+    """Map raw-or-display column names -> live column ids (formula tail or name, normalized)."""
+    out = []
+    re = __import__("re")
+    for nm in (names or []):
+        cid = None
+        for c in (element.get("columns") or []):
+            cand = c.get("name") or ""
+            f = c.get("formula") or ""
+            m = re.match(r"^\[(?:[^\]/]+/)?([^\]]+)\]$", f)
+            if m:
+                cand = cand or m.group(1)
+                if _norm(m.group(1)) == _norm(nm): cid = c.get("id"); break
+            if _norm(cand) == _norm(nm): cid = c.get("id"); break
+        if cid: out.append(cid)
+        else: print(f"  WARN: CLS column '{nm}' not found on element — skipped.")
+    return out
+
+def apply_from_security(dm_id, security, do_apply, do_provision):
+    """Provision attrs/teams + apply RLS calc/filter and CLS for each result.security entry."""
+    spec = api("GET", f"/v2/dataModels/{dm_id}/spec")
+    if not isinstance(spec, dict):
+        sys.exit("DM spec came back non-JSON — cannot auto-apply.")
+    applied = 0
+    def _elname(e): return e.get('name') or ((e.get('source') or {}).get('path') or ['?'])[-1]
+    for rule in security:
+        el = _resolve_element(spec, rule.get("elementId"), rule.get("elementName"))
+        if not el:
+            print(f"⚠ {rule.get('kind')} on element '{rule.get('elementName')}' — not found in DM {dm_id}; skipped."); continue
+        if rule.get("kind") == "rls" and rule.get("rls"):
+            r = rule["rls"]
+            print(f"RLS → element '{_elname(el)}': {r['formula'][:80]}")
+            for attr in (r.get("userAttributes") or []):
+                ex = find_attribute(attr)
+                if ex: print(f"  REUSE attribute '{attr}'.")
+                elif do_provision:
+                    api("POST", "/v2/user-attributes", {"name": attr, "defaultValue": {"val": "", "type": "string"}})
+                    print(f"  CREATED attribute '{attr}'. NOTE: assign per-user values via POST /v2/user-attributes/{{id}}/users.")
+                else: print(f"  (plan: attribute '{attr}' — pass --provision to create; then assign per-user values.)")
+            for team in (r.get("teams") or []):
+                ensure_team(team, do_provision)
+            calc = {"id": _short_id("rlscol"), "name": r.get("name") or "RLS", "formula": r["formula"]}
+            filt = {"id": _short_id("rlsf"), "columnId": calc["id"], "kind": "list", "mode": "include", "values": [True]}
+            if do_apply:
+                el.setdefault("columns", []).append(calc)
+                el.setdefault("filters", []).append(filt); applied += 1
+        elif rule.get("kind") == "cls" and rule.get("cls"):
+            c = rule["cls"]
+            ids = _resolve_col_ids(el, c.get("restrictedColumnNames"))
+            print(f"CLS → element '{_elname(el)}': hide {c.get('restrictedColumnNames')}")
+            if do_apply and ids:
+                el.setdefault("columnSecurities", []).append({"id": _short_id("cls"), "criteria": c.get("criteria") or {"kind": "no-one-can-view"}, "restrictedColumns": ids}); applied += 1
+    if do_apply and applied:
+        res = api("PUT", f"/v2/dataModels/{dm_id}/spec", spec)
+        print(f"PUT spec -> applied {applied} rule(s):", (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif not do_apply:
+        print("\n(plan only — pass --apply --dm-id <id> to PATCH these into the DM spec; --provision to create attributes/teams.)")
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Apply a Looker RLS finding to Sigma (safe-by-default).")
+    ap.add_argument("--attr", help="Sigma user-attribute name (e.g. region)")
+    ap.add_argument("--value", help="attribute value (for --create defaultValue / --assign)")
+    ap.add_argument("--description", help="description when creating the attribute")
+    ap.add_argument("--member-id", help="Sigma memberId to assign the value to (with --assign)")
+    ap.add_argument("--field", help="DM column display name to filter on (e.g. Region) — for the RLS snippet")
+    ap.add_argument("--element-id", help="DM element id the RLS calc col + filter attach to")
+    ap.add_argument("--dm-id", help="dataModelId (with --apply, to PATCH the element spec)")
+    ap.add_argument("--create", action="store_true", help="create the user attribute if no reusable match")
+    ap.add_argument("--assign", action="store_true", help="assign --value to --member-id")
+    ap.add_argument("--apply", action="store_true", help="PATCH the RLS calc col + filter into the DM element spec")
+    ap.add_argument("--from-security", help="path to a converter result.security[] JSON (batch RLS+CLS apply)")
+    ap.add_argument("--provision", action="store_true", help="create missing user attributes / teams (with --from-security)")
+    a = ap.parse_args()
+
+    # Batch mode: ingest a converter's result.security[] and provision + apply all rules.
+    if a.from_security:
+        if not a.dm_id:
+            sys.exit("--from-security requires --dm-id (the posted data model).")
+        raw = json.load(open(a.from_security))
+        security = raw.get("security", raw) if isinstance(raw, dict) else raw
+        return apply_from_security(a.dm_id, security, a.apply, a.provision)
+
+    if not a.attr:
+        sys.exit("Provide --attr (single-rule mode) or --from-security <json> (batch mode).")
+    # --- 1. reuse-first --------------------------------------------------
+    existing = find_attribute(a.attr)
+    attr_id = None
+    if existing:
+        attr_id = existing.get("userAttributeId") or existing.get("id")
+        print(f"REUSE: user attribute '{a.attr}' already exists "
+              f"(id={attr_id}, default={existing.get('defaultValue')}) — reusing, NOT creating.")
+    else:
+        print(f"No existing Sigma user attribute named '{a.attr}'.")
+        if a.create:
+            body = {"name": a.attr}
+            if a.description:
+                body["description"] = a.description
+            if a.value is not None:
+                body["defaultValue"] = {"val": a.value, "type": "string"}
+            res = api("POST", "/v2/user-attributes", body)
+            attr_id = res.get("userAttributeId") or res.get("id") if isinstance(res, dict) else None
+            print(f"CREATED user attribute '{a.attr}' (id={attr_id}).")
+        else:
+            print("  (plan only — pass --create to create it.)")
+
+    # --- 2. assign -------------------------------------------------------
+    if a.assign:
+        if not attr_id:
+            sys.exit("--assign needs an attribute id — create/reuse it first (no id resolved).")
+        if not a.member_id or a.value is None:
+            sys.exit("--assign requires --member-id and --value.")
+        body = {"assignments": [{"userId": a.member_id, "value": {"val": a.value, "type": "string"}}]}
+        res = api("POST", f"/v2/user-attributes/{attr_id}/users", body)
+        print(f"ASSIGNED '{a.attr}'={a.value} to member {a.member_id}: "
+              + (json.dumps(res)[:200] if isinstance(res, dict) else str(res)[:200]))
+    elif a.value is not None and a.member_id:
+        print(f"  (plan: would assign '{a.attr}'={a.value} to member {a.member_id} — pass --assign.)")
+
+    # --- 3. RLS spec snippet --------------------------------------------
+    if a.field:
+        if not a.element_id:
+            print("\nNOTE: --field given without --element-id; printing the formula only.")
+            print(f'  calc column formula: CurrentUserAttributeText("{a.attr}") = [{a.field}]')
+        else:
+            snip = rls_spec_snippet(a.attr, a.field, a.element_id)
+            print("\nRLS spec snippet (verified shape — boolean calc col + element list filter on True):")
+            print(json.dumps(snip, indent=2))
+            if a.apply:
+                if not a.dm_id:
+                    sys.exit("--apply requires --dm-id.")
+                apply_to_dm(a.dm_id, a.element_id, snip["calcColumn"], snip["filter"])
+            else:
+                print("  (plan only — pass --apply --dm-id <id> to PATCH it into the DM element spec.)")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/metabase-migration-skills/metabase-to-sigma/scripts/assert-parity.mjs
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/assert-parity.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+// assert-parity.mjs — the verification GATE. Two modes.
+//
+// PLAN: given a posted workbook (or data model) id, emit one mcp-v2 query per
+// element so the agent can pull Sigma's actuals and compare to the Metabase source.
+//   node scripts/assert-parity.mjs --plan --type workbook --id <workbookId>
+//   node scripts/assert-parity.mjs --plan --type datamodel --id <dataModelId>
+//
+// CHECK: given the agent's saved query results + an expected baseline (the numbers
+// from the Metabase report / source warehouse), confirm parity within tolerance.
+//   node scripts/assert-parity.mjs --check --actual actual.json --expected expected.json [--tol 0.01]
+//     [--workdir DIR]            # write the gate sentinels here (default: dirname of --actual):
+//                                #   parity-final.json  (gate 1 of assert-phase6-ran.rb)
+//   actual.json / expected.json: { "<label>": <number>, ... }  (per-dimension or totals)
+//     [--census '<json>']        # optional tile census {zones_total, charts_built,
+//                                #   zones_unmatched, unmatched_zone_names:[]} — gate 5;
+//                                #   derive from the converter stats (dashcards vs built)
+//
+// A migration is GREEN only when --check passes AND `ruby scripts/assert-phase6-ran.rb
+// --workdir <dir> --workbook-id <id>` exits 0 (all 7 gates). Do not declare success
+// on a 200 POST alone.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { api, parseArgs, elementsOf } from './lib/sigma-rest.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+
+if (a.plan) {
+  if (!a.id || !a.type) { console.error('need --type workbook|datamodel --id <id>'); process.exit(2); }
+  const scope = a.type === 'workbook' ? 'workbook' : 'datamodel';
+  const els = elementsOf((await api('GET', a.type === 'workbook' ? `/v2/workbooks/${a.id}/elements` : `/v2/dataModels/${a.id}/elements`)).json);
+  console.log(`# Parity plan for ${a.type} ${a.id} — run each query via mcp-v2, then compare to the Metabase source.\n`);
+  for (const e of els) {
+    console.log(`## ${e.name} (${e.kind || 'element'})  elementId=${e.id}`);
+    console.log(`mcp__sigma-mcp-v2__query  type=${scope}  ${a.type === 'workbook' ? 'workbookId' : 'dataModelId'}=${a.id}`);
+    console.log(`  sql: SELECT * FROM "${scope}"."${e.id}" LIMIT 50\n`);
+  }
+  console.log('Then save the per-element totals/dimension values to actual.json and run --check against the Metabase numbers.');
+  process.exit(0);
+}
+
+if (a.check) {
+  if (!a.actual || !a.expected) { console.error('need --actual <json> --expected <json>'); process.exit(2); }
+  const actual = JSON.parse(readFileSync(a.actual, 'utf8'));
+  const expected = JSON.parse(readFileSync(a.expected, 'utf8'));
+  const tol = Number(a.tol ?? 0.01);
+  const rows = []; let fail = 0;
+  for (const k of Object.keys(expected)) {
+    const e = Number(expected[k]), av = Number(actual[k]);
+    const ok = Number.isFinite(av) && (e === 0 ? av === 0 : Math.abs(av - e) / Math.abs(e) <= tol);
+    if (!ok) fail++;
+    rows.push(`${ok ? 'PASS' : 'FAIL'}  ${k}: expected ${e}, got ${Number.isFinite(av) ? av : '(missing)'}`);
+  }
+  console.log(rows.join('\n'));
+  console.log(fail ? `\n${fail}/${rows.length} FAILED — not parity-clean.` : `\nPARITY GREEN: ${rows.length}/${rows.length} within ±${tol * 100}%.`);
+
+  // Gate sentinel: parity-final.json (gate 1 of the shared assert-phase6-ran.rb;
+  // same contract every sigma-migration-skills plugin emits). mode='live' because
+  // SKILL.md Phase 4 REQUIRES live re-run Metabase expecteds, never a stale baseline.
+  const workdir = a.workdir || dirname(a.actual);
+  const failNames = rows.filter((r) => r.startsWith('FAIL')).map((r) => r.slice(6, r.indexOf(':')));
+  const final = {
+    status: fail ? 'FAIL' : 'PASS', mode: 'live',
+    charts_total: rows.length, charts_pass: rows.length - fail,
+    fail_names: failNames, tolerance: tol, at: new Date().toISOString(),
+  };
+  if (a.census) {
+    try { final.tile_census = JSON.parse(a.census); }
+    catch { console.error('WARN: --census is not valid JSON — tile_census omitted (gate 5 will SKIP).'); }
+  }
+  writeFileSync(join(workdir, 'parity-final.json'), JSON.stringify(final, null, 2));
+  console.error(`sentinel → ${join(workdir, 'parity-final.json')} (gate 1; now run: ruby scripts/assert-phase6-ran.rb --workdir ${workdir} --workbook-id <id>)`);
+  process.exit(fail ? 1 : 0);
+}
+
+console.error('specify --plan or --check (see header).');
+process.exit(2);

--- a/metabase-migration-skills/metabase-to-sigma/scripts/assert-phase6-ran.rb
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/assert-phase6-ran.rb
@@ -1,0 +1,546 @@
+#!/usr/bin/env ruby
+# Hard gate that proves a tableau-to-sigma conversion is actually complete.
+# The subagent MUST run this script before declaring GREEN. It checks seven
+# independent things — failing ANY of them blocks the GREEN declaration:
+#
+#   1. Phase 6 ran (parity-final.json exists, status=PASS, pass-rate met)
+#      → beads-sigma-4pm
+#   2. No orphan workbooks left in the customer's My Documents
+#      (posted-workbooks.jsonl has ≤1 entry OR cleanup-marker.json shows
+#      cleanup ran with no failed deletes)  → beads-sigma-38a
+#   3. The live workbook's /columns endpoint shows no column with
+#      type=error (catches circular refs / runtime errors introduced
+#      AFTER the initial POST's column-type guard ran)  → beads-sigma-38a
+#   4. The workbook has a non-empty layout XML applied (catches the
+#      "elements just listed in a single column" regression where the
+#      agent forgot to PUT a layout)  → beads-sigma-bw3
+#   5. Tile census — parity-final.json's `tile_census` field (emitted by the
+#      converter's phase6 finalize when a dashboard zone tree is available)
+#      shows no unexplained dashboard zones without a matching chart in the
+#      parity plan. Catches the "empty view CSV silently dropped a tile and
+#      the workbook shipped with N-1 charts" escape (bead gjhe). Skipped
+#      (with a note) when the converter doesn't emit a census.
+#   6. Layout lint (scripts/lib/layout_lint.rb, shared) — no raw-id element
+#      display names, no input controls outside the GridContainer bands on a
+#      banded page, no dead zones (>25% empty grid rows between a page's
+#      first and last element), no generic header-band title ("Page 1" /
+#      "Sheet 3" / "Dashboard 2" must never title a dashboard), and no
+#      under-filled band (<60% of the 24 grid columns covered; deliberate
+#      KPI bands of <=4 tiles exempt). Catches the "PHASEE PBI Employee
+#      Dashboard" visual-mess regression (and its PHASEE2 sequel: "Page 1"
+#      header + a lone small chart beside a 19-column hole) that every data
+#      gate waved through.
+#   7. Control lint (scripts/lib/control_lint.rb, shared) — no dead controls
+#      (a control with no resolving `filters` target AND no [controlId]
+#      formula reference is furniture: the "Orders Overview (from Looker)"
+#      estate shipped three of them), no ghost filter targets, and no control
+#      whose source-closure misses same-page queryable elements (the PHASEE
+#      "Action(Region) -> Monthly Revenue Trend" escape). Honors the
+#      control-scope sidecar (<workdir>/control-scope.json or
+#      --control-scope) for source-signal coverage (zero controls built from
+#      an interactive source = FAIL, the Qlik class) and per-control
+#      scope:[...] allowlists (intentional single-chart switchers like grain
+#      controls). See the lib header CONTRACT.
+#
+# Usage:
+#   ruby scripts/assert-phase6-ran.rb --tableau /tmp/<name> \
+#     [--workbook-id <id>]     # override; default = read from wb-ids.json
+#     [--min-pass-rate 1.0]    # default 1.0 (every chart must PASS)
+#     [--allow-extract]        # treat extract-mode as acceptable
+#     [--skip-column-check]    # skip the live /columns type=error scan
+#     [--skip-orphan-check]    # skip the orphan-workbook scan (for callers
+#                              # that genuinely want multiple workbooks)
+#     [--skip-layout-check]    # skip the layout-applied scan
+#     [--skip-layout-lint]     # skip gate 6 (layout-quality lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--skip-control-lint]    # skip gate 7 (control-wiring lint) — escape
+#                              # hatch for legacy workbooks; name the reason
+#                              # in your report
+#     [--control-scope PATH]   # control-scope.json sidecar for gate 7
+#                              # (default: <workdir>/control-scope.json)
+#     [--min-layout-elements N] default 2 — single-page bare-element layouts
+#                              # often have just the page wrapper; require this
+#                              # many <LayoutElement> tags
+#     [--allow-missing-tiles N] default 0 — tolerate up to N unmatched dashboard
+#                              # zones in the tile census (for legitimately
+#                              # unbuildable zones; name them in your report)
+#
+# Exit codes:
+#   0  every gate passes — conversion is allowed to declare GREEN
+#   1  parity-final.json missing (Phase 6 skipped — the regression case)
+#   2  parity-final.json exists but status=FAIL / pass-rate below min /
+#      extract-mode without --allow-extract / charts_total==0
+#   3  parity-final.json malformed
+#   4  orphan workbooks left uncleaned (beads-sigma-38a)
+#   5  live workbook has column(s) with type=error (beads-sigma-38a)
+#   6  live workbook has no layout applied — single-column fallback
+#      (beads-sigma-bw3)
+#   7  tile census shows unexplained unmatched dashboard zones beyond
+#      --allow-missing-tiles (bead gjhe)
+#   8  layout lint violations — raw-id display names / orphan controls /
+#      dead zones (gate 6; scripts/lib/layout_lint.rb)
+#   9  control lint violations — dead controls / ghost targets / partial
+#      reach / source filter signals with zero controls
+#      (gate 7; scripts/lib/control_lint.rb)
+#
+# Prints a per-gate summary to stdout regardless of exit code.
+
+require 'json'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+opts = { min_pass_rate: 1.0, allow_extract: false, min_layout_elements: 2,
+         allow_missing_tiles: 0 }
+OptionParser.new do |p|
+  p.on('--tableau DIR')              { |v| opts[:tab] = v }
+  p.on('--workdir DIR', 'alias of --tableau for non-Tableau converters') { |v| opts[:tab] = v }
+  p.on('--workbook-id ID')           { |v| opts[:wb] = v }
+  p.on('--min-pass-rate F', Float)   { |v| opts[:min_pass_rate] = v }
+  p.on('--allow-extract')            { opts[:allow_extract] = true }
+  p.on('--skip-column-check')        { opts[:skip_column] = true }
+  p.on('--skip-orphan-check')        { opts[:skip_orphan] = true }
+  p.on('--skip-layout-check')        { opts[:skip_layout] = true }
+  p.on('--skip-layout-lint')         { opts[:skip_lint] = true }
+  p.on('--skip-control-lint')        { opts[:skip_control_lint] = true }
+  p.on('--control-scope PATH')       { |v| opts[:control_scope] = v }
+  p.on('--min-layout-elements N', Integer) { |v| opts[:min_layout_elements] = v }
+  p.on('--allow-missing-tiles N', Integer, 'tolerate N unmatched dashboard zones in the tile census') { |v| opts[:allow_missing_tiles] = v }
+end.parse!
+abort('--workdir (or --tableau) required') unless opts[:tab]
+
+summary_path = File.join(opts[:tab], 'parity-final.json')
+
+unless File.exist?(summary_path)
+  warn "[FAIL] Phase 6 skipped — #{summary_path} does not exist."
+  warn "       Run: ruby scripts/phase6-parity.rb --tableau #{opts[:tab]} --workbook-id <id>"
+  warn "       then collect actuals via mcp__sigma-mcp-v2__query and re-run with --finalize."
+  warn "       See SKILL.md Phase 6. This is the hard gate (beads-sigma-4pm)."
+  exit 1
+end
+
+begin
+  summary = JSON.parse(File.read(summary_path))
+rescue JSON::ParserError => e
+  warn "[FAIL] #{summary_path} is malformed JSON: #{e.message}"
+  exit 3
+end
+
+total = summary['charts_total'].to_i
+passed = summary['charts_pass'].to_i
+status = summary['status'].to_s
+mode = summary['mode'].to_s
+
+if total <= 0
+  warn "[FAIL] parity-final.json reports charts_total=#{total} — no charts were verified."
+  warn "       This usually means auto-parity-plan.rb matched zero Tableau views."
+  warn "       Phase 6 must verify at least one chart to declare GREEN."
+  exit 2
+end
+
+if mode == 'extract' && !opts[:allow_extract]
+  warn "[FAIL] parity ran in extract-mode but --allow-extract was not passed."
+  warn "       Extract-mode permits up to ±#{((summary['extract_tol'] || 0.30) * 100).to_i}% drift —"
+  warn "       only acceptable when the source Tableau workbook has hasExtracts=true."
+  exit 2
+end
+
+pass_rate = passed.to_f / total
+# status=PASS requires 100% — when the caller explicitly accepts a lower
+# pass-rate (--min-pass-rate, for honest NAMED divergences like LOD
+# placeholders / cross-grain semantics), the rate is the gate, not the status.
+rate_gate_only = opts[:min_pass_rate] < 1.0
+if (rate_gate_only ? pass_rate < opts[:min_pass_rate] : (status != 'PASS' || pass_rate < opts[:min_pass_rate]))
+  warn "[FAIL] parity status=#{status} pass-rate=#{(pass_rate * 100).round(1)}% (#{passed}/#{total})"
+  warn "       Required: #{rate_gate_only ? '' : 'status=PASS and '}pass-rate >= #{(opts[:min_pass_rate] * 100).to_i}%"
+  if (fail_names = summary['fail_names']) && !fail_names.empty?
+    warn "       Failing charts: #{fail_names.join(', ')}"
+  end
+  exit 2
+end
+
+if rate_gate_only && status != 'PASS'
+  puts "[OK] gate 1/7: Phase 6 ran — #{passed}/#{total} charts PASS (>= #{(opts[:min_pass_rate] * 100).to_i}% accepted); " \
+       "DIVERGING (accepted, must be NAMED in the report): #{(summary['fail_names'] || []).join(', ')}"
+else
+  puts "[OK] gate 1/7: Phase 6 ran cleanly — #{passed}/#{total} charts PASS (mode=#{mode}, status=#{status})"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 2 — orphan workbooks (beads-sigma-38a)
+# ---------------------------------------------------------------------------
+unless opts[:skip_orphan]
+  log = File.join(opts[:tab], 'posted-workbooks.jsonl')
+  if File.exist?(log)
+    posted = File.readlines(log).map { |l| JSON.parse(l) rescue nil }.compact
+    unique_ids = posted.map { |e| e['id'] }.uniq
+    if unique_ids.length > 1
+      marker_path = File.join(opts[:tab], 'cleanup-marker.json')
+      unless File.exist?(marker_path)
+        warn "[FAIL] gate 2/7: #{unique_ids.length} workbooks created during this conversion (orphans not cleaned)."
+        warn "       posted-workbooks.jsonl entries:"
+        unique_ids.each { |id| warn "         - #{id}" }
+        warn "       Run: ruby scripts/cleanup-orphan-workbooks.rb --workdir #{opts[:tab]}"
+        warn "       See beads-sigma-38a."
+        exit 4
+      end
+      marker = JSON.parse(File.read(marker_path)) rescue {}
+      if marker['failed'] && !marker['failed'].empty?
+        warn "[FAIL] gate 2/7: cleanup-marker.json reports #{marker['failed'].length} failed delete(s)."
+        warn "       Orphan workbooks are still in the customer's My Documents:"
+        marker['failed'].each { |f| warn "         - #{f['id']} (HTTP #{f['status']})" }
+        exit 4
+      end
+      if marker['dry_run']
+        warn "[FAIL] gate 2/7: cleanup-marker.json is from a --dry-run; orphans were not actually deleted."
+        warn "       Re-run cleanup-orphan-workbooks.rb without --dry-run."
+        exit 4
+      end
+      kept = marker['kept'] || '(unknown)'
+      deleted = (marker['deleted'] || []).length
+      puts "[OK] gate 2/7: orphan cleanup ran — kept #{kept}, deleted #{deleted}"
+    else
+      puts "[OK] gate 2/7: only one workbook POSTed (#{unique_ids.first}) — no orphan check needed"
+    end
+  else
+    puts "[OK] gate 2/7: posted-workbooks.jsonl missing — assuming no orphans (legacy or external POST flow)"
+  end
+else
+  puts "[SKIP] gate 2/7: --skip-orphan-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 3 — live /columns type=error scan (beads-sigma-38a)
+# Catches circular references and runtime errors that the initial post-and-
+# readback column-type guard missed because they were introduced by later
+# PUTs (layout updates, spec edits during error recovery).
+# ---------------------------------------------------------------------------
+unless opts[:skip_column]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 3/7: no workbook ID resolvable (pass --workbook-id or ensure wb-ids.json exists)"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 3/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch /columns"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/columns")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        cols = (JSON.parse(res.body)['entries'] rescue []) || []
+        error_cols = cols.select { |c| c.dig('type', 'type') == 'error' }
+        if error_cols.any?
+          warn "[FAIL] gate 3/7: live workbook #{wb_id} has #{error_cols.length} column(s) with type=error."
+          warn "       These render as visible errors in the Sigma UI (circular ref, unknown column,"
+          warn "       unsupported function, etc.). Fix the offending formulas and re-PUT before declaring GREEN."
+          error_cols.first(10).each do |c|
+            warn "         element=#{c['elementId']} col=#{c['columnId']} label=#{c['label'].inspect}"
+            warn "           formula: #{c['formula']}"
+          end
+          warn "       See beads-sigma-38a."
+          exit 5
+        end
+        puts "[OK] gate 3/7: #{cols.length} live columns clean (no type=error)"
+      else
+        warn "[SKIP] gate 3/7: GET /v2/workbooks/#{wb_id}/columns returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 3/7: --skip-column-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 4 — layout applied (beads-sigma-bw3)
+# Fetches the live workbook spec and confirms a non-empty top-level `layout`
+# XML is set, with at least --min-layout-elements <LayoutElement> tags.
+# Catches the "agent forgot to PUT a layout" regression where elements
+# render as a single-column stack instead of the dashboard grid.
+# ---------------------------------------------------------------------------
+unless opts[:skip_layout]
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+
+  if wb_id.nil? || wb_id.empty?
+    puts "[SKIP] gate 4/7: no workbook ID resolvable for layout check"
+  else
+    base = ENV['SIGMA_BASE_URL']
+    tok  = ENV['SIGMA_API_TOKEN']
+    if base.nil? || base.empty? || tok.nil? || tok.empty?
+      warn "[SKIP] gate 4/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+    else
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+
+      if res.is_a?(Net::HTTPSuccess)
+        body = res.body.to_s
+        spec =
+          begin
+            JSON.parse(body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(body, permitted_classes: [Date, Time]) || {}
+          end
+        layout_xml = spec['layout'].to_s
+        elem_count = layout_xml.scan(/<LayoutElement\b/).length
+
+        # Detect the Sigma "auto-generated single-column stack" layout that
+        # the server produces when a workbook is POSTed without a layout.
+        # Signature: every non-Data page has all its elements at the same
+        # gridColumn value (typically "1 / 13" — left half, vertically stacked).
+        # Note: per-page detection — a workbook with one element per content
+        # page is structurally fine (degenerate case, not a stack).
+        # Container-banded pages (<GridContainer> bands per layout-playbook.md)
+        # are exempt: full-width band containers (and single-chart rows inside
+        # them) legitimately share gridColumn="1 / 25" — that is deliberate
+        # banding, not the auto-stack regression.
+        non_data_stack_pages = []
+        # Walk one page at a time using the <Page id="..."> blocks
+        layout_xml.scan(/<Page\b[^>]*id="([^"]*)"[^>]*>(.*?)<\/Page>/m).each do |page_id, page_body|
+          next if page_id.to_s.downcase.include?('data')
+          next if page_body.include?('<GridContainer')
+          cols_on_page = page_body.scan(/gridColumn="([^"]+)"/).map(&:first).uniq
+          elems_on_page = page_body.scan(/<LayoutElement\b/).length
+          if elems_on_page >= 2 && cols_on_page.length == 1
+            non_data_stack_pages << [page_id, cols_on_page.first, elems_on_page]
+          end
+        end
+
+        if layout_xml.empty?
+          warn "[FAIL] gate 4/7: live workbook #{wb_id} has NO top-level layout XML."
+          warn "       Elements render as a single-column stack instead of the"
+          warn "       dashboard grid. Rebuild the layout with this skill's layout"
+          warn "       builder (see SKILL.md — layout phase) into #{opts[:tab]}/layout.xml,"
+          warn "       then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} \\"
+          warn "           --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        elsif elem_count < opts[:min_layout_elements]
+          warn "[FAIL] gate 4/7: layout XML has only #{elem_count} <LayoutElement> tag(s);"
+          warn "       at least #{opts[:min_layout_elements]} required (one master + ≥1 chart)."
+          warn "       The layout likely covers only the Data page — chart page is unstyled."
+          exit 6
+        elsif non_data_stack_pages.any?
+          warn "[FAIL] gate 4/7: live workbook #{wb_id} has Sigma's auto-generated"
+          warn "       single-column stack layout (multiple elements at the same gridColumn"
+          warn "       on a non-Data page). This is what Sigma defaults to when you POST"
+          warn "       a workbook without a layout — exactly the CoCo regression."
+          non_data_stack_pages.each do |pid, col, n|
+            warn "         page=#{pid.inspect}: #{n} elements all at gridColumn=#{col.inspect}"
+          end
+          warn "       Rebuild the layout with this skill's layout builder (see SKILL.md —"
+          warn "       layout phase) into #{opts[:tab]}/layout.xml, then PUT it:"
+          warn "         ruby scripts/put-layout.rb --workbook #{wb_id} --layout #{opts[:tab]}/layout.xml"
+          warn "       See beads-sigma-bw3."
+          exit 6
+        else
+          puts "[OK] gate 4/7: layout XML applied with #{elem_count} positioned element(s)"
+        end
+      else
+        warn "[SKIP] gate 4/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot verify"
+      end
+    end
+  end
+else
+  puts "[SKIP] gate 4/7: --skip-layout-check"
+end
+
+# ---------------------------------------------------------------------------
+# Gate 5 — tile census (bead gjhe)
+# parity-final.json's `tile_census` field compares the source dashboard's
+# chart-zone count against the charts that made it into the parity plan.
+# Catches the empty-view-CSV escape where the builder silently emits N-1
+# charts and parity still reports PASS (every chart it knows about passes —
+# it just doesn't know about the dropped one).
+# ---------------------------------------------------------------------------
+census = summary['tile_census']
+if census.nil?
+  puts "[SKIP] gate 5/7: no tile_census in parity-final.json (converter did not emit one — re-run phase6 finalize with the dashboard zone tree available to enable)"
+else
+  zones     = census['zones_total'].to_i
+  built     = census['charts_built'].to_i
+  unmatched = census['zones_unmatched'].to_i
+  names     = Array(census['unmatched_zone_names'])
+  if unmatched > opts[:allow_missing_tiles]
+    warn "[FAIL] gate 5/7: tile census — #{zones} dashboard zone(s), #{built} chart(s) built, #{unmatched} unmatched:"
+    names.each { |n| warn "         - #{n}" }
+    warn "       A zone that rendered in the source dashboard has NO matching chart in the"
+    warn "       parity plan. Common causes: empty/0-byte view CSV silently dropped the tile"
+    warn "       (re-fetch the view data and rebuild), or the tile was renamed without"
+    warn "       passing --rename to phase6-parity.rb / build-dashboard-layout.rb."
+    warn "       If #{unmatched} zone(s) are legitimately unbuildable, re-run with"
+    warn "       --allow-missing-tiles #{unmatched} and name them in your report. Bead gjhe."
+    exit 7
+  elsif unmatched > 0
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, #{unmatched} unmatched (within --allow-missing-tiles #{opts[:allow_missing_tiles]}): #{names.join(', ')}"
+  else
+    puts "[OK] gate 5/7: tile census — #{zones} zones, #{built} charts built, 0 unmatched"
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 6 — layout-quality lint (scripts/lib/layout_lint.rb, shared)
+# A workbook can pass every data gate above and still ship as a visual mess:
+# raw element ids as chart titles, controls dumped loose at the page foot,
+# dead zones between elements (the "PHASEE PBI Employee Dashboard" escape).
+# This gate mechanizes those checks on the LIVE spec.
+# ---------------------------------------------------------------------------
+if opts[:skip_lint]
+  puts "[SKIP] gate 6/7: --skip-layout-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 6/7: no workbook ID resolvable for layout lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 6/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/layout_lint'
+    rescue LoadError
+      warn "[SKIP] gate 6/7: scripts/lib/layout_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(LayoutLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        violations = LayoutLint.lint(spec)
+        if violations.any?
+          warn "[FAIL] gate 6/7: layout lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the spec/layout and re-PUT (raw-id names -> derive human titles;"
+          warn "       loose controls -> place into a band/container; dead zones -> re-band the page),"
+          warn "       then re-run this gate. Escape hatch (legacy workbooks only): --skip-layout-lint."
+          exit 8
+        end
+        puts '[OK] gate 6/7: layout lint clean (no raw-id names, no orphan controls, no dead zones, ' \
+             'no generic header title, no under-filled bands)'
+      else
+        warn "[SKIP] gate 6/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+# ---------------------------------------------------------------------------
+# Gate 7 — control-wiring lint (scripts/lib/control_lint.rb, shared)
+# A workbook can pass every gate above and still ship controls that do
+# NOTHING (dead controls: no resolving filter target, no [controlId] formula
+# reference — the "Orders Overview (from Looker)" estate escape) or controls
+# that silently skip same-page charts (the PHASEE "Action(Region) ->
+# Monthly Revenue Trend" escape). This gate mechanizes those checks on the
+# LIVE spec, plus source-signal coverage when a control-scope sidecar exists
+# (zero controls built from an interactive source = FAIL, the Qlik class).
+# ---------------------------------------------------------------------------
+if opts[:skip_control_lint]
+  puts "[SKIP] gate 7/7: --skip-control-lint (name the reason in your report)"
+else
+  wb_id = opts[:wb]
+  if wb_id.nil?
+    wb_ids_path = File.join(opts[:tab], 'wb-ids.json')
+    if File.exist?(wb_ids_path)
+      wb_ids = JSON.parse(File.read(wb_ids_path)) rescue {}
+      wb_id = wb_ids['workbookId']
+    end
+  end
+  base = ENV['SIGMA_BASE_URL']
+  tok  = ENV['SIGMA_API_TOKEN']
+  if wb_id.nil? || wb_id.to_s.empty?
+    puts "[SKIP] gate 7/7: no workbook ID resolvable for control lint"
+  elsif base.nil? || base.empty? || tok.nil? || tok.empty?
+    warn "[SKIP] gate 7/7: SIGMA_BASE_URL / SIGMA_API_TOKEN not set — cannot fetch spec"
+  else
+    begin
+      require_relative 'lib/control_lint'
+    rescue LoadError
+      warn "[SKIP] gate 7/7: scripts/lib/control_lint.rb not vendored in this plugin — re-vendor (md5 discipline)"
+    end
+    if defined?(ControlLint)
+      uri = URI("#{base}/v2/workbooks/#{wb_id}/spec")
+      req = Net::HTTP::Get.new(uri)
+      req['Authorization'] = "Bearer #{tok}"
+      req['Accept'] = 'application/json'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      if res.is_a?(Net::HTTPSuccess)
+        spec =
+          begin
+            JSON.parse(res.body)
+          rescue JSON::ParserError
+            require 'yaml'
+            require 'date'
+            YAML.safe_load(res.body, permitted_classes: [Date, Time]) || {}
+          end
+        scope_path = opts[:control_scope] || File.join(opts[:tab], 'control-scope.json')
+        scope = nil
+        if File.exist?(scope_path)
+          scope = JSON.parse(File.read(scope_path)) rescue nil
+          warn "[WARN] gate 7/7: #{scope_path} is not valid JSON — linting without source scope" if scope.nil?
+        end
+        violations = ControlLint.lint(spec, scope: scope)
+        if violations.any?
+          warn "[FAIL] gate 7/7: control lint — #{violations.length} violation(s) on live workbook #{wb_id}:"
+          violations.each { |v| warn "         - #{v}" }
+          warn "       Fix the control wiring and re-PUT (dead controls -> add filters targets"
+          warn "       ({source:{elementId}, columnId}) or remove the control; partial reach ->"
+          warn "       wire the uncovered elements or annotate controlScope in control-scope.json;"
+          warn "       see scripts/lib/control_lint.rb CONTRACT), then re-run this gate."
+          warn "       Flip-test the wiring live with: ruby scripts/probe-controls.rb --workbook-id #{wb_id}"
+          warn "       Escape hatch (legacy workbooks only): --skip-control-lint."
+          exit 9
+        end
+        n_controls = ControlLint.controls_report(spec).length
+        puts "[OK] gate 7/7: control lint clean (#{n_controls} control(s); no dead controls, no ghost " \
+             "targets, full same-page reach#{scope ? ', source scope honored' : ''})"
+      else
+        warn "[SKIP] gate 7/7: GET /v2/workbooks/#{wb_id}/spec returned HTTP #{res.code} — cannot lint"
+      end
+    end
+  end
+end
+
+puts "[OK] all gates pass — conversion may declare GREEN"
+exit 0

--- a/metabase-migration-skills/metabase-to-sigma/scripts/escalate-gap.py
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/escalate-gap.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""escalate-gap — opt-in GitHub-issue filer for gap-scout escalations.
+
+Shared across every migration skill (vendored identically into each plugin's
+scripts/). When the gap scout can't find a working Sigma translation for a
+source feature, the main agent offers the user the *option* to open a tracking
+issue in the appropriate repo. This script is what turns that "yes" into filed
+issues — with dedupe, repo routing, converter-repo mirroring, and a cross-linked
+bead.
+
+DESIGN: opt-in, never automatic.
+  - Default (no --yes): DRY RUN. Prints the drafted issue(s), the target repo(s),
+    and any existing open issues/beads that already cover this gap. Files NOTHING.
+    This is what the agent shows the user.
+  - With --yes: actually files. Skips any repo where dedupe already found a match
+    (unless --force).
+
+ROUTING (category -> repos):
+  converter / builder / skill -> twells89/metabase-to-sigma (standalone repo —
+                pre-graduation; see ROUTES comment for the post-graduation split)
+
+Usage (dry-run draft the agent shows the user):
+  python3 scout/escalate-gap.py \
+    --skill tableau-to-sigma --category converter \
+    --feature WINDOW_AVG --description 'moving average over SUM' \
+    --source-pattern 'WINDOW_AVG(SUM([...]))' \
+    --template-attempted 'MovingAvg(Sum([Master/\\1]), -10, 10)' \
+    --test-formula 'MovingAvg(Sum([Master/Sales]), -10, 10)' \
+    --sigma-response '<failing column type / error json>' \
+    --example-from 'Sales.twb line 412' \
+    --escalation-yaml ~/.tableau-to-sigma/escalations/window_avg.yaml
+
+Then, only if the user says yes, the agent re-runs the same command with --yes.
+
+Requires `gh` on PATH and authed for the target repos. `bd` (beads) optional.
+Exit codes: 0 = ok (drafted or filed), 3 = nothing fileable / gh missing on --yes.
+"""
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+# Pre-graduation routing: this plugin lives standalone, so every category files
+# against this repo. When the converter is vendored into the browser tool + MCP
+# and the plugin graduates into sigma-migration-skills, flip converter ->
+# [sigma-data-model-manager, sigma-data-model-mcp] and builder/skill ->
+# [sigma-migration-skills] like the sibling plugins.
+ROUTES = {
+    "converter": ["twells89/metabase-to-sigma"],
+    "builder":   ["twells89/metabase-to-sigma"],
+    "skill":     ["twells89/metabase-to-sigma"],
+}
+BEADS_DIR = os.path.expanduser("~/.beads-sigma")
+
+
+def have(cmd):
+    return shutil.which(cmd) is not None
+
+
+def run(args, **kw):
+    """Run a command, return (ok, stdout, stderr)."""
+    try:
+        p = subprocess.run(args, capture_output=True, text=True, **kw)
+        return p.returncode == 0, p.stdout.strip(), p.stderr.strip()
+    except Exception as e:  # noqa: BLE001
+        return False, "", str(e)
+
+
+def build_issue(a):
+    title = f"{a.skill} gap: {a.feature}" + (f" ({a.description})" if a.description else "")
+    body = []
+    body.append(f"**Skill:** `{a.skill}`")
+    body.append(f"**Gap category:** `{a.category}`")
+    body.append(f"**Feature:** `{a.feature}`")
+    if a.description:
+        body.append(f"**Description:** {a.description}")
+    if a.source_pattern:
+        body.append(f"**Source pattern:** `{a.source_pattern}`")
+    if a.template_attempted:
+        body.append(f"**Sigma template attempted:** `{a.template_attempted}`")
+    if a.test_formula:
+        body.append(f"**Test formula POSTed:** `{a.test_formula}`")
+    if a.sigma_response:
+        body.append(f"**Sigma response:**\n```\n{a.sigma_response}\n```")
+    body.append(f"**Example source:** {a.example_from or '(not provided)'}")
+    if a.escalation_yaml:
+        body.append(f"**Local escalation record:** `{a.escalation_yaml}`")
+    body.append("\n_Filed via the gap-scout opt-in escalation flow (`escalate-gap.py`)._")
+    return title, "\n\n".join(body)
+
+
+def labels_for(a):
+    return ["gap-scout-escalation", a.skill, f"category:{a.category}"]
+
+
+def ensure_labels(repo, labels):
+    """Best-effort: create labels so `gh issue create --label` won't fail."""
+    for lab in labels:
+        run(["gh", "label", "create", lab, "--repo", repo, "--force"])
+
+
+def find_dupes(repo, feature, skill):
+    """Return list of {number,title,url} open issues that look like this gap."""
+    ok, out, _ = run([
+        "gh", "issue", "list", "--repo", repo, "--state", "open",
+        "--label", "gap-scout-escalation", "--search", feature,
+        "--json", "number,title,url",
+    ])
+    if not ok or not out:
+        return []
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return []
+    feat = feature.lower()
+    return [i for i in items if feat in (i.get("title", "").lower())]
+
+
+def find_bead_dupe(feature):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    ok, out, _ = run(["bd", "list", "--json"], cwd=BEADS_DIR)
+    if not ok or not out:
+        return None
+    try:
+        items = json.loads(out)
+    except Exception:  # noqa: BLE001
+        return None
+    rows = items if isinstance(items, list) else items.get("issues", items.get("beads", []))
+    feat = feature.lower()
+    for b in rows or []:
+        if feat in (str(b.get("title", "")) + str(b.get("summary", ""))).lower():
+            return b.get("id") or b.get("bead_id")
+    return None
+
+
+def create_bead(title, body, skill, category):
+    if not (have("bd") and os.path.isdir(BEADS_DIR)):
+        return None
+    labels = f"sigma-converter,{skill},gap-scout-escalation,category:{category}"
+    ok, out, _ = run([
+        "bd", "create", title, "--priority", "2", "--labels", labels,
+        "--description", body, "--silent",
+    ], cwd=BEADS_DIR)
+    return out.strip() if ok else None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--skill", required=True)
+    ap.add_argument("--feature", required=True)
+    ap.add_argument("--category", default="converter", choices=list(ROUTES))
+    ap.add_argument("--description", default="")
+    ap.add_argument("--source-pattern", default="")
+    ap.add_argument("--template-attempted", default="")
+    ap.add_argument("--test-formula", default="")
+    ap.add_argument("--sigma-response", default="")
+    ap.add_argument("--example-from", default="")
+    ap.add_argument("--escalation-yaml", default="")
+    ap.add_argument("--extra-repo", action="append", default=[],
+                    help="additional target repo(s), repeatable")
+    ap.add_argument("--yes", action="store_true",
+                    help="actually file. Without it: dry-run, prints the draft only.")
+    ap.add_argument("--force", action="store_true",
+                    help="file even if a matching open issue already exists")
+    ap.add_argument("--no-beads", action="store_true")
+    a = ap.parse_args()
+
+    repos = list(dict.fromkeys(ROUTES[a.category] + a.extra_repo))
+    title, body = build_issue(a)
+    labels = labels_for(a)
+
+    # Dedupe scan (read-only) up front so the agent can show it to the user.
+    gh_ok = have("gh")
+    dupes = {r: (find_dupes(r, a.feature, a.skill) if gh_ok else []) for r in repos}
+    bead_dupe = None if a.no_beads else find_bead_dupe(a.feature)
+
+    if not a.yes:
+        # DRY RUN — this is what the agent presents to the user.
+        out = {
+            "mode": "draft",
+            "would_file_in": repos,
+            "labels": labels,
+            "title": title,
+            "body": body,
+            "existing_issues": {r: d for r, d in dupes.items() if d},
+            "existing_bead": bead_dupe,
+            "gh_available": gh_ok,
+            "next_step": "re-run with --yes to file (skips repos already covered)",
+        }
+        print(json.dumps(out, indent=2))
+        return 0
+
+    # --yes: actually file.
+    if not gh_ok:
+        print(json.dumps({"status": "error", "error": "gh not on PATH; cannot file"}))
+        return 3
+
+    # Bead first (authoritative tracker), so its id can be embedded in issues.
+    bead_id = bead_dupe
+    if bead_id is None and not a.no_beads:
+        bead_id = create_bead(title, body, a.skill, a.category)
+    issue_body = body + (f"\n\n**Bead:** `{bead_id}`" if bead_id else "")
+
+    filed, skipped = [], []
+    for repo in repos:
+        if dupes.get(repo) and not a.force:
+            skipped.append({"repo": repo, "existing": dupes[repo]})
+            continue
+        ensure_labels(repo, labels)
+        ok, out, err = run([
+            "gh", "issue", "create", "--repo", repo,
+            "--title", title, "--body", issue_body,
+            "--label", ",".join(labels),
+        ])
+        if ok:
+            filed.append({"repo": repo, "url": out.strip()})
+        else:
+            # retry once without labels (in case label creation was denied)
+            ok2, out2, err2 = run([
+                "gh", "issue", "create", "--repo", repo,
+                "--title", title, "--body", issue_body,
+            ])
+            if ok2:
+                filed.append({"repo": repo, "url": out2.strip(), "note": "filed without labels"})
+            else:
+                filed.append({"repo": repo, "error": err or err2})
+
+    # Cross-link mirrored issues to each other.
+    urls = [f["url"] for f in filed if f.get("url")]
+    if len(urls) > 1:
+        for f in filed:
+            if not f.get("url"):
+                continue
+            others = [u for u in urls if u != f["url"]]
+            num = f["url"].rstrip("/").split("/")[-1]
+            link_body = issue_body + "\n\n**Mirrored to:** " + ", ".join(others)
+            run(["gh", "issue", "edit", num, "--repo", f["repo"], "--body", link_body])
+
+    # Cross-link the bead back to the filed issue urls.
+    if bead_id and urls and have("bd"):
+        run(["bd", "update", bead_id, "--description",
+             issue_body + "\n\nFiled issues: " + ", ".join(urls)], cwd=BEADS_DIR)
+
+    print(json.dumps({
+        "status": "filed",
+        "filed": filed,
+        "skipped_existing": skipped,
+        "bead_id": bead_id,
+    }, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/metabase-migration-skills/metabase-to-sigma/scripts/find-or-pick-dm.rb
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/find-or-pick-dm.rb
@@ -1,0 +1,348 @@
+#!/usr/bin/env ruby
+# Phase 1.5 — Reuse existing Sigma data models when one already covers the
+# Tableau workbook's needs. Goals:
+#   1. Avoid DM sprawl: don't add a 4th "Orders" DM when the customer already
+#      has three that all point at the same warehouse table.
+#   2. Performance: skip Phase 2 (warehouse column discovery) and Phase 3
+#      (DM build + POST + validate) when reusing — often 2-3 min savings.
+#
+# This script DOES NOT mutate any DM. It only scores existing DMs against the
+# Tableau workbook signature and recommends a candidate (with a warning about
+# inherited columns / RLS / metrics). The downstream phase decides whether to
+# reuse or create new.
+#
+# Usage:
+#   ruby scripts/find-or-pick-dm.rb \
+#     --workbook-signature /tmp/<name>/workbook-signature.json \
+#     --out /tmp/<name>/dm-match.json \
+#     [--limit 200]                    # max DMs to scan
+#     [--min-score 0.6]                # below: no recommendation, build new
+#     [--force-new]                    # always recommend new (skip scan)
+#
+# Input signature shape (produced by Phase 1 + 2.5 — adjust paths as needed):
+#   {
+#     "tableau_workbook":   "Monthly Revenue",
+#     "warehouse_tables":   ["CSA.ORDER_FACT"],          # FQN list
+#     "referenced_columns": ["ORDER_DATE","GROSS_REVENUE","REGION","STATE"],
+#     "measures":           [{"col":"GROSS_REVENUE","derivation":"Sum"}, ...]
+#   }
+#
+# Output: dm-match.json with shape documented in SKILL.md Phase 1.5.
+# Exit: 0 if any candidate ≥ --min-score, 1 if none (caller can choose to
+# build new). Never aborts on missing inputs — always emits a result file so
+# the agent can decide.
+
+require 'json'
+require 'yaml'
+require 'net/http'
+require 'uri'
+require 'optparse'
+
+# Default limit 25: perf testing (2026-05-22) showed the picker's top-score
+# saturates by ~25 DMs in this org; the wall-time curve elbows hard after 50
+# (0.065s/DM → 0.25s/DM — Sigma drops off a cached-spec hot path). limit=25
+# finishes in ~2s. Earlier default was 50; dropping to 25 saves ~12s per
+# picker run with no score regression. beads-sigma-3kw.
+opts = { limit: 25, min_score: 0.6 }
+OptionParser.new do |p|
+  p.on('--workbook-signature P') { |v| opts[:sig]      = v }
+  p.on('--out P')                { |v| opts[:out]      = v }
+  p.on('--limit N', Integer)     { |v| opts[:limit]    = v }
+  p.on('--min-score F', Float)   { |v| opts[:min_score]= v }
+  p.on('--force-new')            { |_| opts[:force_new]= true }
+  p.on('--auto-pick',
+       'Auto-recommend without UX prompt when top score >= --auto-pick-threshold AND no other candidate within --auto-pick-tie-window of it. Sets `auto_picked: true` on the result so the caller can WARN about inherited columns.') { |_| opts[:auto_pick] = true }
+  p.on('--auto-pick-threshold F', Float, 'Min score for auto-pick (default 0.55).')                  { |v| opts[:auto_pick_threshold] = v }
+  p.on('--auto-pick-tie-window F', Float, 'Gap from top score within which other candidates count as a tie that disables auto-pick (default 0.05).') { |v| opts[:auto_pick_tie_window] = v }
+end.parse!
+%i[sig out].each { |k| abort "missing --#{k}" unless opts[k] }
+
+BASE = ENV.fetch('SIGMA_BASE_URL')
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+
+# DM-shortlisting scans many candidates and is called per-follower in cluster
+# orchestration — auto-refresh on 401 to survive long batch runs.
+def http_get(path)
+  attempts = 0
+  loop do
+    attempts += 1
+    uri = URI("#{BASE}#{path}")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    req['Accept'] = 'application/json'
+    res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+    if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+      Sigma.refresh_token!
+      next
+    end
+    return res
+  end
+end
+
+sig = JSON.parse(File.read(opts[:sig]))
+warn "workbook: #{sig['tableau_workbook'] || '(unnamed)'}"
+warn "  warehouse_tables:   #{sig['warehouse_tables']&.size || 0}"
+warn "  referenced_columns: #{sig['referenced_columns']&.size || 0}"
+
+# Force-new short-circuit: emit a no-match result and exit 1.
+if opts[:force_new]
+  File.write(opts[:out], JSON.pretty_generate({
+    'recommended_dm_id' => nil,
+    'score' => 0.0,
+    'rationale' => '--force-new: bypassed DM-reuse scan',
+    'candidates' => []
+  }))
+  warn "force-new mode — wrote empty match"
+  exit 1
+end
+
+# 1. List ALL data models, then sort deterministically before applying --limit.
+# Sigma's /v2/dataModels list endpoint returns server page-order, not
+# relevance order. Without a stable client-side sort, the same workbook
+# picks different candidates on different runs (observed: 3 conversions of
+# the same Tableau workbook reached 3 different recommendations). Fix:
+# fetch all DMs (cheap — one list call per 100), sort by updatedAt desc
+# (recent DMs are usually more relevant), then take the first --limit for
+# parallel spec-fetch + scoring. Stable tiebreaker by name. beads-sigma-3kw.
+all_dms = []
+page = nil
+hard_cap = 500
+loop do
+  qs = "limit=100"
+  qs += "&page=#{page}" if page
+  r = http_get("/v2/dataModels?#{qs}")
+  break unless r.code.to_i == 200
+  data = JSON.parse(r.body)
+  rows = data['entries'] || data['dataModels'] || []
+  break if rows.empty?
+  all_dms.concat(rows)
+  break if all_dms.size >= hard_cap
+  page = data['nextPage']
+  break if page.nil? || page.empty?
+end
+
+# Deterministic ranking: updatedAt desc, then name asc.
+# NOTE: require 'time' MUST come before the sort — without it Time.parse raises,
+# every timestamp rescues to 0, and the sort silently degrades to name-ascending
+# (recently-updated DMs past the --limit window are never scanned).
+require 'time'
+all_dms = all_dms.sort_by do |dm|
+  [-(Time.parse(dm['updatedAt'].to_s).to_i rescue 0), dm['name'].to_s]
+end
+
+warn "found #{all_dms.size} total DMs; scoring top #{[all_dms.size, opts[:limit]].min} by updatedAt"
+
+# 2. Fetch each DM's spec and extract its signature (tables + columns + metrics).
+def normalize_fqn(s)
+  return nil if s.nil? || s.empty?
+  parts = s.to_s.split('.').reject(&:empty?).map(&:upcase)
+  parts.join('.')
+end
+
+def normalize_col(s)
+  s.to_s.upcase.gsub(/[^A-Z0-9]/, '')
+end
+
+# Fetch all DM specs in parallel (10 threads). Some DMs return non-200
+# (archived, permission-restricted, broken refs) — log and continue. Single
+# transient 5xx errors are retried once.
+dm_specs = {}
+dm_failures = []
+require 'thread'
+mu = Mutex.new
+queue = Queue.new
+all_dms.take(opts[:limit]).each { |dm| queue << dm }
+threads = 5.times.map do
+  Thread.new do
+    until queue.empty?
+      dm = queue.pop(true) rescue nil
+      break unless dm
+      dm_id = dm['dataModelId'] || dm['id']
+      next unless dm_id
+      r = nil
+      # Retry on 429 (Cloudflare burst limit) with exponential backoff. The
+      # /v2/dataModels endpoint commonly 429s at >5 concurrent across
+      # tj-wells-1989 — see beads-sigma-cn5.
+      4.times do |attempt|
+        r = http_get("/v2/dataModels/#{dm_id}/spec")
+        code = r.code.to_i
+        break if code == 200 || (code != 429 && code < 500)
+        sleep (0.5 * (2 ** attempt))  # 0.5s, 1s, 2s, 4s
+      end
+      if r.code.to_i != 200
+        mu.synchronize { dm_failures << { name: dm['name'], id: dm_id, code: r.code, body_head: r.body[0..80] } }
+        next
+      end
+      spec = begin
+        JSON.parse(r.body)
+      rescue JSON::ParserError
+        YAML.safe_load(r.body, permitted_classes: [Date, Time])
+      end
+      mu.synchronize { dm_specs[dm_id] = spec }
+    end
+  end
+end
+threads.each(&:join)
+warn "fetched #{dm_specs.size} DM specs (#{dm_failures.size} failed)"
+dm_failures.first(5).each { |f| warn "  failure: #{f[:code]} #{f[:name]} — #{f[:body_head]}" }
+
+dm_signatures = []
+all_dms.take(opts[:limit]).each do |dm|
+  dm_id = dm['dataModelId'] || dm['id']
+  spec = dm_specs[dm_id]
+  next unless spec
+
+  tables = []
+  columns = []
+  metrics = []
+  column_captions = {}  # normalized → original, so output can be human-readable
+
+  # Walk every element. Sigma DM specs nest elements under pages[*].elements
+  # (NOT top-level `elements` — that's a workbook-only convention). Fall back
+  # to top-level for robustness in case schema changes.
+  all_elements = spec['elements'] || (spec['pages'] || []).flat_map { |p| p['elements'] || [] }
+  all_elements.each do |el|
+    src = el['source'] || {}
+    case src['kind']
+    when 'warehouse-table', 'table'
+      # source like { kind: warehouse-table, connectionId, path: "DB.SCHEMA.TABLE" }.
+      # Live API specs return path as an ARRAY (["DB","SCHEMA","TABLE"]) — join it,
+      # else normalize_fqn sees the array's to_s and table-match never fires.
+      raw = src['path']
+      fqn = raw.is_a?(Array) ? raw.join('.') : (raw || [src['database'], src['schema'], src['name']].compact.join('.'))
+      tables << normalize_fqn(fqn) if fqn && !fqn.empty?
+    when 'sql'
+      # Custom SQL — surface a sentinel so the agent knows; not directly comparable
+      tables << 'CUSTOM_SQL'
+    end
+    (el['columns'] || []).each do |c|
+      colname = c['name'] || (c['formula'].to_s.match(/\[.*?([^\/\]]+)\]/) || [])[1]
+      if colname && !colname.empty?
+        norm = normalize_col(colname)
+        columns << norm
+        column_captions[norm] ||= colname
+      end
+    end
+    (el['metrics'] || []).each do |m|
+      metrics << "#{m['name']}/#{m['aggregation'] || m['derivation']}"
+    end
+  end
+
+  dm_signatures << {
+    dm_id: dm_id,
+    dm_name: dm['name'],
+    tables: tables.uniq.compact,
+    columns: columns.uniq.compact,
+    column_captions: column_captions,
+    metrics: metrics.uniq.compact,
+    raw_element_count: all_elements.size
+  }
+end
+
+# 3. Score each DM.
+tableau_tables  = (sig['warehouse_tables']   || []).map { |t| normalize_fqn(t) }.compact
+# Keep both forms: normalized for matching, original for human-readable output.
+tableau_columns_orig = (sig['referenced_columns'] || [])
+tableau_columns      = tableau_columns_orig.map { |c| normalize_col(c) }
+tableau_col_caption  = tableau_columns.zip(tableau_columns_orig).to_h
+tableau_measure_keys = (sig['measures'] || []).map { |m| "#{normalize_col(m['col'])}/#{m['derivation']}" }
+
+candidates = dm_signatures.map do |dm|
+  # Table match: 1.0 if Tableau tables ⊆ DM tables. 0.5 if partial. 0 if disjoint.
+  shared_tables = (tableau_tables & dm[:tables])
+  table_match =
+    if tableau_tables.empty?
+      0.0
+    elsif shared_tables.size == tableau_tables.size
+      1.0
+    elsif shared_tables.any?
+      0.5 + 0.5 * (shared_tables.size.to_f / tableau_tables.size)
+    else
+      0.0
+    end
+
+  # Column match: % of Tableau-referenced columns present in DM.
+  shared_cols = (tableau_columns & dm[:columns])
+  col_match =
+    tableau_columns.empty? ? 0.0 : shared_cols.size.to_f / tableau_columns.size
+
+  # Metric overlap (small weight).
+  shared_metrics = (tableau_measure_keys & dm[:metrics])
+  metric_match =
+    tableau_measure_keys.empty? ? 0.0 : shared_metrics.size.to_f / tableau_measure_keys.size
+
+  # Weighting rationale: column overlap is the most reliable signal —
+  # a DM's source table FQN can vary (raw warehouse table vs view vs joined
+  # element) but the column set must be a superset of what the workbook
+  # references for reuse to be safe. Table-match is a soft tiebreaker.
+  score = 0.2 * table_match + 0.7 * col_match + 0.1 * metric_match
+
+  # Extras the workbook would inherit. Surface original captions (not the
+  # normalized form) so the user-facing report is readable.
+  extra_cols_norm = dm[:columns] - tableau_columns
+  caption_of = ->(norm) { dm[:column_captions][norm] || norm }
+  {
+    'dm_id'             => dm[:dm_id],
+    'dm_name'           => dm[:dm_name],
+    'score'             => score.round(3),
+    'table_match'       => table_match.round(2),
+    'column_match'      => col_match.round(2),
+    'metric_match'      => metric_match.round(2),
+    'shared_tables'     => shared_tables,
+    'missing_tables'    => tableau_tables - dm[:tables],
+    'shared_columns'    => shared_cols.map(&caption_of),
+    'missing_columns'   => (tableau_columns - dm[:columns]).map { |c| tableau_col_caption[c] || c },
+    'extra_columns'     => extra_cols_norm.size,
+    'extra_columns_sample' => extra_cols_norm.first(5).map(&caption_of),
+    'raw_element_count' => dm[:raw_element_count]
+  }
+end.sort_by { |c| -c['score'] }
+
+best = candidates.first
+second = candidates[1]
+
+# Auto-pick gate: only fires when (a) --auto-pick flag is set, (b) top score
+# clears the auto-pick threshold, and (c) the next candidate is at least
+# auto_pick_tie_window below the top. The tie check protects against silently
+# picking the wrong one of two very-close candidates (e.g., a duplicate DM).
+auto_pick_threshold  = opts[:auto_pick_threshold]  || 0.55
+auto_pick_tie_window = opts[:auto_pick_tie_window] || 0.05
+tie_with_second      = best && second && (best['score'] - second['score']) < auto_pick_tie_window
+auto_picked          = opts[:auto_pick] && best && best['score'] >= auto_pick_threshold && !tie_with_second
+
+# Standard recommend path keeps the old semantics.
+recommended_via_std  = best && best['score'] >= opts[:min_score]
+recommended_dm_id    = (auto_picked || recommended_via_std) ? best['dm_id'] : nil
+
+rationale =
+  if best.nil?
+    'no DMs in org'
+  elsif auto_picked
+    "AUTO-PICKED at score #{best['score']} (>= #{auto_pick_threshold}, no tie within #{auto_pick_tie_window}). #{best['shared_columns'].size}/#{tableau_columns.size} cols matched. Caller must WARN about #{best['extra_columns']} inherited columns."
+  elsif best['score'] >= 0.85
+    "auto-reuse candidate (#{best['shared_columns'].size}/#{tableau_columns.size} cols, #{best['shared_tables'].size}/#{tableau_tables.size} tables)"
+  elsif opts[:auto_pick] && best['score'] >= auto_pick_threshold && tie_with_second
+    "would auto-pick but second candidate at #{second['score']} is within #{auto_pick_tie_window} — TIE — falling back to ASK USER"
+  elsif best['score'] >= opts[:min_score]
+    'ambiguous match — ASK USER before reusing'
+  else
+    'no candidate above min-score; build a new DM'
+  end
+
+result = {
+  'workbook_signature_path' => opts[:sig],
+  'scanned_dm_count'        => candidates.size,
+  'recommended_dm_id'       => recommended_dm_id,
+  'auto_picked'             => auto_picked,
+  'score'                   => best ? best['score'] : 0.0,
+  'rationale'               => rationale,
+  'warning'                 => (best && best['extra_columns'] > 0) ? "Reusing inherits #{best['extra_columns']} extra columns (sample: #{best['extra_columns_sample'].join(', ')})" : nil,
+  'candidates'              => candidates.first(5)
+}.compact
+
+File.write(opts[:out], JSON.pretty_generate(result))
+warn ""
+warn "wrote #{opts[:out]}"
+warn "best score: #{result['score']}  →  #{result['rationale']}"
+exit result['recommended_dm_id'].nil? ? 1 : 0

--- a/metabase-migration-skills/metabase-to-sigma/scripts/gap-scout.md
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/gap-scout.md
@@ -1,0 +1,71 @@
+# gap-scout subagent — guide for the main agent
+
+When the Metabase converter can't translate an expression into a Sigma formula, it
+**flags** it (never fakes it). For a flagged expression that you want to actually
+resolve, spawn a separate subagent — the **gap scout** — to find a Sigma
+translation that validates against the customer's real Sigma site, and persist it.
+
+The scout writes successful rules to `~/.metabase-to-sigma/learned-rules.json` (the
+customer's home dir, NOT the skill repo, so a `git pull` never clobbers them). The
+converter CLI loads them via `loadLearnedRules()` and applies them *before* the
+built-in translator (`applyLearnedRules` in `converter/metabase.ts`), so a customer's
+discovered rule wins.
+
+## When to spawn
+
+After conversion emits a warning for an untranslated construct — typically:
+- **cum-sum / cum-count / offset** aggregations (window/running calcs)
+- **`["segment", id]` / legacy `["metric", id]`** refs (saved-filter/metric inlining)
+- **binned breakouts** (`{"binning": …}` — numeric histogram buckets)
+- **dimension-type field-filter** `{{tags}}` in native SQL cards
+- any `unmapped: <op>` warning from `translateMbqlExpr`
+
+Spawn ONE scout per distinct feature; run them in parallel where possible — they're
+independent.
+
+## How to spawn (from the main agent)
+
+Use the Agent tool with `subagent_type: 'general-purpose'`. Self-contained prompt:
+
+```
+You are a translation scout. Your job: propose a Sigma formula that replaces a
+Metabase expression, validate it against Sigma's API, and persist the rule if it works.
+
+INPUTS
+- Metabase feature: <e.g. "running-total">
+- Sample expressions: <2-5 examples from the module/report>
+- A real warehouse table on the customer's Sigma connection to test against:
+  --connection <connectionId>  --table-path <DB.SCHEMA.TABLE>
+- Sigma folder id: <folder-id>
+
+PROCEDURE
+1. Read refs/expression-dsl.md (the Metabase→Sigma mapping table) and
+   refs/format-shapes.md. Note Sigma window funcs (SumOver/CountOver/…) silently
+   error in data-model calc columns — prefer a non-window form or flag it.
+2. Propose ONE candidate Sigma formula using a column that exists on --table-path.
+3. Validate + persist:
+   eval "$(scripts/get-token.sh)"
+   node scripts/scout-validate-and-persist.mjs \
+     --feature '<feature>' \
+     --pattern '<Metabase regex, capture groups for column refs>' \
+     --template '<Sigma template using $1,$2 for captures>' \
+     --test-formula '<the candidate with a REAL column from --table-path>' \
+     --connection <connectionId> --table-path <DB.SCHEMA.TABLE> \
+     --folder <folder-id> --description '<one line>' --hint '<caveat>'
+4. Parse the JSON result:
+   - status=validated → success; rule is now in ~/.metabase-to-sigma/learned-rules.json
+   - status=escalated → try a different candidate (≤3 attempts). The last result
+     carries `escalation.dry_run_cmd`. Do NOT file anything yourself.
+
+OUTPUT
+One paragraph: feature, candidate, status (validated / escalated / abandoned-after-N),
+and — if escalated — the `escalation.dry_run_cmd` so the main agent can offer the
+user a tracking issue.
+```
+
+## Opt-in issue filing
+
+If the scout escalates (no formula validated), it returns a ready-to-run
+`scripts/escalate-gap.py … ` command (DRY-RUN by default). **Show it to the user and
+ask** before filing — only run it with `--yes` on their go-ahead. It routes
+converter gaps to the data-model repos (MCP + browser) with dedupe.

--- a/metabase-migration-skills/metabase-to-sigma/scripts/get-metabase-session.sh
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/get-metabase-session.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# get-metabase-session.sh — set up Metabase REST auth for discovery/extraction.
+#
+#   AUTH (two options — far friendlier than most BI tools):
+#   • API key (PREFERRED, Metabase v49+): Admin → Settings → Authentication →
+#     API keys → create a key in a group with read access to the content you're
+#     migrating (Administrators = read-everything). Durable; use for engagements.
+#   • Session token: POST /api/session with username/password. Sessions expire
+#     (max ~14 days, sooner under SSO); on HTTP 401 just re-run this script.
+#     SSO-only logins (no password) must use an API key.
+#
+# USAGE:
+#   export MB_BASE="https://metabase.example.com"     # no trailing slash, no /api
+#   # EITHER:
+#   export MB_KEY="mb_…"                               # the API key
+#   # OR:
+#   export MB_USER="you@example.com" MB_PASS="…"       # exchanged for a session
+#   eval "$(scripts/get-metabase-session.sh)"
+#   mb_get "/api/session/properties" | head            # smoke test (prints version)
+#
+# Emits a shell function `mb_get` on stdout (eval it). Read-only helper — only GETs.
+set -euo pipefail
+: "${MB_BASE:?set MB_BASE=https://<your-metabase-host>}"
+MB_BASE="${MB_BASE%/}"
+
+if [ -n "${MB_KEY:-}" ]; then
+  AUTH_HDR="x-api-key: $MB_KEY"
+elif [ -n "${MB_USER:-}" ] && [ -n "${MB_PASS:-}" ]; then
+  tok=$(curl -s "$MB_BASE/api/session" -H 'Content-Type: application/json' \
+    -d "{\"username\": \"$MB_USER\", \"password\": \"$MB_PASS\"}" |
+    python3 -c 'import sys,json;print(json.load(sys.stdin).get("id") or "")')
+  if [ -z "$tok" ]; then
+    echo "echo 'Metabase login failed — check MB_USER/MB_PASS (SSO-only users need an API key, MB_KEY).' >&2; false"
+    exit 0
+  fi
+  AUTH_HDR="X-Metabase-Session: $tok"
+else
+  echo "echo 'Set MB_KEY (preferred, v49+) or MB_USER+MB_PASS.' >&2; false"
+  exit 0
+fi
+
+cat <<EOF
+export MB_BASE='$MB_BASE'
+export MB_AUTH_HDR='$AUTH_HDR'
+mb_get() {
+  # mb_get "/api/…" → prints body; nonzero on HTTP>=400 (401 = key revoked / session expired)
+  local p="\$1" code
+  code=\$(curl -s -o /tmp/mb_last.json -w '%{http_code}' "\$MB_BASE\$p" \\
+    -H 'Accept: application/json' -H "\$MB_AUTH_HDR")
+  if [ "\$code" -ge 400 ]; then
+    echo "Metabase GET \$p -> HTTP \$code (401 = re-auth; 403 = key's group lacks access)" >&2
+    cat /tmp/mb_last.json >&2; echo >&2; return 1
+  fi
+  cat /tmp/mb_last.json
+}
+EOF

--- a/metabase-migration-skills/metabase-to-sigma/scripts/get-token.sh
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/get-token.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Exchange Sigma client credentials for a bearer token.
+# Usage:  eval "$(scripts/get-token.sh)"
+# Sets SIGMA_API_TOKEN in the calling shell.
+
+set -euo pipefail
+
+# Agent-neutral credential bootstrap. Claude Code auto-loads creds from
+# ~/.claude/settings.json into the env; other agents (Cursor, Cortex Code, plain
+# shell) don't. If the creds aren't already present, source the neutral cred
+# file written by setup.rb so this works under any agent.
+if [ -z "${SIGMA_CLIENT_ID:-}" ] && [ -f "$HOME/.sigma-migration/env" ]; then
+  . "$HOME/.sigma-migration/env"
+fi
+
+: "${SIGMA_BASE_URL:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_ID:?Run scripts/setup.rb to configure credentials}"
+: "${SIGMA_CLIENT_SECRET:?Run scripts/setup.rb to configure credentials}"
+
+CREDENTIALS=$(printf '%s:%s' "$SIGMA_CLIENT_ID" "$SIGMA_CLIENT_SECRET" | base64)
+
+RESPONSE=$(curl -sf -X POST \
+  -H "Authorization: Basic ${CREDENTIALS}" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  "$SIGMA_BASE_URL/v2/auth/token") || {
+    echo "Token exchange failed — check SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET" >&2
+    exit 1
+  }
+
+TOKEN=$(echo "$RESPONSE" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])" 2>/dev/null \
+  || echo "$RESPONSE" | ruby -r json -e "print JSON.parse(STDIN.read)['access_token']")
+
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
+  echo "Token exchange failed — response did not contain access_token" >&2
+  exit 1
+fi
+
+echo "export SIGMA_API_TOKEN=${TOKEN}"

--- a/metabase-migration-skills/metabase-to-sigma/scripts/lib/control_lint.rb
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/lib/control_lint.rb
@@ -1,0 +1,304 @@
+# frozen_string_literal: true
+#
+# control_lint.rb — mechanized control-wiring lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as layout_lint.rb / sigma_rest.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the layout lint
+#   - assert-phase6-ran.rb gate 7 (with a --skip-control-lint escape)
+#   - scripts/probe-controls.rb (reuses the reach computation to pick its
+#     in-closure / out-of-closure probe elements)
+#
+# It exists because a workbook can pass parity + layout gates and still ship
+# controls that DO NOTHING (the "Orders Overview (from Looker)" estate escape:
+# three list controls bound to no element at all) or controls that silently
+# skip same-page charts (the PHASEE "Action(Region) → Monthly Revenue Trend"
+# escape, and the Qlik class: source full of listboxes, spec with zero
+# controls). Three checks:
+#
+#   (a) dead control — every kind:control element must have >=1 `filters`
+#       target resolving to a REAL element id in the spec, OR be referenced
+#       as [controlId] in at least one non-control element (formula / spec
+#       reference). A control with neither is furniture: a user changes it
+#       and nothing on the page reacts.
+#   (b) reach — source-closure walk from the control's targets (filter
+#       targets + formula-referencing elements, expanded downstream through
+#       source.elementId chains). Any same-page QUERYABLE element outside
+#       the closure flags PARTIAL with the element names. Intentional
+#       single-chart switchers (grain / geo-level segmented controls) are
+#       allow-listed via the controlScope annotation (CONTRACT below).
+#   (c) source-scope coverage — when a control-scope sidecar is provided
+#       (emitted by the builder from the SOURCE BI artifact's filter
+#       signals), FAIL if the source had filter signals but the spec has
+#       zero controls, if an annotated control is missing from the spec,
+#       or if an annotated mustReach element is not in that control's
+#       closure.
+#
+# CONTRACT — <out>/control-scope.json (emitted by the converter/builder next
+# to the workbook spec; post-and-readback.rb and assert-phase6-ran.rb pick it
+# up from the workdir automatically, or take --control-scope PATH):
+#
+#   {
+#     "version": 1,
+#     "source": "qlik",               // provenance tag, free-form
+#     "sourceFilterSignals": 3,       // count of filter-like signals detected
+#                                     //   in the source artifact (listboxes,
+#                                     //   quick filters, actions, slicers,
+#                                     //   prompts, dashboard filters...).
+#                                     //   >0 with zero spec controls = FAIL.
+#     "controls": [
+#       {
+#         "controlId": "ctl-region",           // spec controlId (required)
+#         "sourceName": "Region quick filter", // optional, for messages
+#         "scope": "page",                     // "page" (default): the reach
+#                                              //   check applies to every
+#                                              //   same-page queryable element
+#                                              // OR an array of element ids /
+#                                              //   display names the control
+#                                              //   is INTENDED to affect — the
+#                                              //   single-chart-switcher
+#                                              //   allowlist (grain controls)
+#         "mustReach": ["Monthly Revenue Trend"] // optional hard assertions:
+#                                              //   each must be in the closure
+#       }
+#     ]
+#   }
+#
+# In-spec alternative (pre-POST local specs only): a control element may carry
+#   "controlScope": ["Element Name", ...]   // or "page"
+# with the same meaning as scope. NOTE: Sigma strips unknown keys on readback,
+# so the SIDECAR is the durable form — builders should emit both when the
+# allowlist must survive a live re-lint of the posted workbook.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query) evaluates a workbook
+# element WITH the workbook's saved control DEFAULTS applied and exposes NO
+# parameter mechanism to override them. The REST export API
+# (POST /v2/workbooks/{id}/export with `"parameters": {"<controlId>": "<value>"}`)
+# IS the only programmatic way to exercise a non-default control value — which
+# is why probe-controls.rb (the flip test) is built on export, not MCP.
+#
+# API:
+#   report     = ControlLint.controls_report(spec)   # per-control reach rows
+#   violations = ControlLint.lint(spec, scope: nil)  # scope = parsed sidecar
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/control_lint.rb <spec.json|spec.yaml> [control-scope.json]
+require 'json'
+require 'set'
+
+module ControlLint
+  QUERYABLE = %w[
+    table pivot-table input-table bar-chart line-chart pie-chart donut-chart
+    area-chart scatter-chart combo-chart kpi-chart box-chart funnel-chart
+    gauge-chart waterfall-chart sankey-chart region-map point-map viz chart
+    treemap-chart heatmap-chart word-cloud
+  ].to_set.freeze
+
+  module_function
+
+  # { element_id => {el:, page:, kind:, name:, srcel:} } for every element.
+  def elements(spec)
+    out = {}
+    (spec['pages'] || []).each do |pg|
+      (pg['elements'] || []).each do |el|
+        eid = el['id'] || el['elementId']
+        next unless eid
+        out[eid] = { el: el, page: pg['name'] || pg['id'],
+                     kind: (el['kind'] || el['type']).to_s,
+                     name: el['name'], srcel: source_element_id(el) }
+      end
+    end
+    out
+  end
+
+  # Unwraps {kind:"source", source:{elementId}} and direct {elementId} forms.
+  def source_element_id(el)
+    src = el['source']
+    return nil unless src.is_a?(Hash)
+    src = src['source'] if src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src.is_a?(Hash) ? src['elementId'] : nil
+  end
+
+  def control?(info)
+    info[:kind].include?('control')
+  end
+
+  # Transitive closure of elements sourcing (directly or via chains) from any
+  # element in `roots`. Returns roots + downstream ids.
+  def closure(elems, roots)
+    reach = roots.to_set
+    loop do
+      grew = false
+      elems.each do |eid, info|
+        next if reach.include?(eid)
+        next unless info[:srcel] && reach.include?(info[:srcel])
+        reach << eid
+        grew = true
+      end
+      break unless grew
+    end
+    reach
+  end
+
+  # Non-control elements whose serialized spec references [controlId] —
+  # catches formula refs (If([GeoLevel]="State",...)) and any other spec-level
+  # binding that names the control.
+  def formula_refs(elems, cid)
+    return [] if cid.nil? || cid.to_s.empty?
+    pat = /\[#{Regexp.escape(cid)}\]/
+    elems.select { |_eid, info| !control?(info) && JSON.generate(info[:el]).match?(pat) }
+         .keys
+  end
+
+  # Per-control reach report. Each row:
+  #   { control_element_id:, control_id:, name:, page:, control_type:,
+  #     filter_targets: [ids], ghost_targets: [ids], formula_refs: [ids],
+  #     reach: Set[ids], page_queryable: [ids], uncovered: [ids] }
+  def controls_report(spec)
+    elems = elements(spec)
+    rows = []
+    elems.each do |eid, info|
+      next unless control?(info)
+      el = info[:el]
+      cid = el['controlId']
+      tgt_ids = (el['filters'] || []).map { |t| t.is_a?(Hash) ? t.dig('source', 'elementId') : nil }.compact
+      live    = tgt_ids.select { |t| elems.key?(t) }
+      frefs   = formula_refs(elems, cid)
+      roots   = (live + frefs).uniq
+      reach   = roots.empty? ? Set.new : closure(elems, roots)
+      page_q  = elems.select do |qid, i|
+        qid != eid && i[:page] == info[:page] && QUERYABLE.include?(i[:kind])
+      end.keys
+      rows << { control_element_id: eid, control_id: cid, name: info[:name],
+                page: info[:page], control_type: el['controlType'],
+                filter_targets: live, ghost_targets: tgt_ids - live,
+                formula_refs: frefs, reach: reach, page_queryable: page_q,
+                uncovered: page_q.reject { |q| reach.include?(q) } }
+    end
+    rows
+  end
+
+  # Resolve a sidecar element reference (id or display name) to element ids.
+  def resolve_ref(elems, ref)
+    return [ref] if elems.key?(ref)
+    elems.select { |_eid, i| i[:name] == ref }.keys
+  end
+
+  def label(elems, eid)
+    n = elems[eid] && elems[eid][:name]
+    n && !n.to_s.empty? ? "#{n.inspect} (#{eid})" : eid
+  end
+
+  def lint(spec, scope: nil)
+    violations = []
+    elems = elements(spec)
+    rows  = controls_report(spec)
+
+    scope_by_cid = {}
+    if scope.is_a?(Hash)
+      Array(scope['controls']).each do |c|
+        scope_by_cid[c['controlId']] = c if c.is_a?(Hash) && c['controlId']
+      end
+      # (c) the Qlik class: source had filter signals, spec built zero controls.
+      signals = scope['sourceFilterSignals'].to_i
+      if signals.positive? && rows.empty?
+        violations << "no controls built: the source artifact reported #{signals} filter signal(s) " \
+                      '(control-scope.json sourceFilterSignals) but the spec contains ZERO control ' \
+                      'elements — the source dashboard is interactive and the migration shipped a ' \
+                      'static one; build the controls (or set sourceFilterSignals to 0 with a ' \
+                      'reason if the signals are genuinely non-portable)'
+      end
+    end
+
+    rows.each do |r|
+      ann = scope_by_cid.delete(r[:control_id]) || {}
+      ann_scope = ann['scope'] || elems[r[:control_element_id]][:el]['controlScope']
+      ctl_label = "control #{label(elems, r[:control_element_id])}#{r[:control_id] ? " [#{r[:control_id]}]" : ''} on page #{r[:page].inspect}"
+
+      r[:ghost_targets].each do |g|
+        violations << "ghost target: #{ctl_label} lists filter target #{g.inspect} which does not " \
+                      'resolve to any element in the spec — fix or drop the target'
+      end
+
+      # (a) dead control --------------------------------------------------------
+      if r[:reach].empty?
+        violations << "dead control: #{ctl_label} has no resolving `filters` target and no " \
+                      '[controlId] reference in any non-control element — a user changes it and ' \
+                      'nothing reacts; wire it (filters: [{source:{elementId}, columnId}]) or, if ' \
+                      'the bound column genuinely does not exist on any element, REMOVE the ' \
+                      'control (honest) instead of shipping furniture'
+        next
+      end
+
+      # (c) mustReach assertions -------------------------------------------------
+      Array(ann['mustReach']).each do |ref|
+        ids = resolve_ref(elems, ref)
+        if ids.empty?
+          violations << "scope mustReach: #{ctl_label} — annotated element #{ref.inspect} does not " \
+                        'exist in the spec'
+        elsif ids.none? { |i| r[:reach].include?(i) }
+          violations << "scope mustReach: #{ctl_label} does NOT reach annotated element " \
+                        "#{ref.inspect} — wire a filter target (or formula ref) so it does"
+        end
+      end
+
+      # (b) reach / PARTIAL --------------------------------------------------------
+      if ann_scope.is_a?(Array)
+        # Explicit allowlist (single-chart switcher): every listed element must
+        # be reached; same-page elements OUTSIDE the list are intentionally
+        # unaffected and not flagged.
+        ann_scope.each do |ref|
+          ids = resolve_ref(elems, ref)
+          if ids.empty?
+            violations << "controlScope: #{ctl_label} — scoped element #{ref.inspect} does not exist " \
+                          'in the spec'
+          elsif ids.none? { |i| r[:reach].include?(i) }
+            violations << "controlScope: #{ctl_label} does NOT reach its scoped element #{ref.inspect}"
+          end
+        end
+      elsif r[:uncovered].any?
+        names = r[:uncovered].map { |u| label(elems, u) }
+        violations << "partial control: #{ctl_label} affects #{r[:page_queryable].length - r[:uncovered].length} " \
+                      "of #{r[:page_queryable].length} same-page queryable element(s); NOT affected: " \
+                      "#{names.join(', ')} — wire those elements (add filter targets on their " \
+                      'sources, matching the source dashboard\'s filter scope) or declare the ' \
+                      'narrow scope intentional via controlScope (sidecar control-scope.json ' \
+                      'scope:[...] — see header CONTRACT)'
+      end
+    end
+
+    # (c) annotated controls that never made it into the spec ------------------
+    scope_by_cid.each do |cid, c|
+      violations << "missing control: control-scope.json expects control #{cid.inspect}" \
+                    "#{c['sourceName'] ? " (source: #{c['sourceName'].inspect})" : ''} but the spec " \
+                    'has no control with that controlId — the source filter was not migrated'
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  abort 'usage: ruby control_lint.rb <workbook-spec.json|yaml> [control-scope.json]' unless ARGV[0] && File.exist?(ARGV[0])
+  body = File.read(ARGV[0])
+  spec =
+    begin
+      JSON.parse(body)
+    rescue JSON::ParserError
+      require 'yaml'
+      require 'date'
+      YAML.safe_load(body, permitted_classes: [Date, Time], aliases: true) || {}
+    end
+  scope = ARGV[1] && File.exist?(ARGV[1]) ? JSON.parse(File.read(ARGV[1])) : nil
+  v = ControlLint.lint(spec, scope: scope)
+  if v.empty?
+    n = ControlLint.controls_report(spec).length
+    puts "control lint: clean (#{n} control(s) checked)"
+  else
+    warn "control lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/metabase-migration-skills/metabase-to-sigma/scripts/lib/layout_lint.rb
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/lib/layout_lint.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+#
+# layout_lint.rb — mechanized layout-quality lint for built Sigma workbooks.
+#
+# SHARED lib, vendored byte-identical into every covered plugin's scripts/lib/
+# (md5 discipline — same as escalate-gap.py / enhance-apply.rb). Run by:
+#   - post-and-readback.rb (--type workbook) right after the column-type guard
+#   - enhance-apply.rb's finalize (the Phase E clone must lint clean)
+#   - assert-phase6-ran.rb gate 6 (with a --skip-layout-lint escape)
+#
+# It exists because a workbook can pass every data gate and still ship as a
+# visual mess (raw-id chart titles, controls dumped at the page foot, dead
+# zones) — the "PHASEE PBI Employee Dashboard" regression. Five checks:
+#
+#   (a) raw-id display names — any element display name matching a raw-id
+#       pattern (^[0-9a-f]{12,}$ or ^el-[0-9a-f]+$). A human must never see a
+#       visual id as a chart title.
+#   (b) orphan controls — input controls placed OUTSIDE any <GridContainer>
+#       on a page that HAS containers (banded layout). Controls belong in a
+#       band (control band, or their chart's container), never loose at the
+#       page foot.
+#   (c) dead zones — more than 25% of a page's grid rows empty between the
+#       page's first and last positioned element (top-level layout entries).
+#       Catches the "elements scattered with a hole next to the title" look.
+#   (d) generic header-band title — the header band's text rendering as a
+#       generic auto-name ("Page 1" / "Sheet 3" / "Dashboard 2"). The header
+#       must carry the promoted source title, the source dashboard/report
+#       display name, or the workbook name — never the Sigma page name (the
+#       PHASEE2 PBI regression: header read "Page 1" while the real title sat
+#       inside band 1).
+#   (e) band column fill — a band (top-level GridContainer) whose children
+#       cover <60% of the 24 grid columns, i.e. shipped dead space (the
+#       PHASEE2 PBI regression: band 1 = one small bar chart at columns 1-6
+#       next to a 19-column hole). Deliberate KPI bands (<=4 tiles, all
+#       kpi-chart) are exempt.
+#
+# API:
+#   violations = LayoutLint.lint(spec)   # spec = parsed workbook spec Hash
+#   -> array of human-readable violation strings; empty = clean.
+#
+# Standalone:
+#   ruby scripts/lib/layout_lint.rb <spec.json>   # exit 1 + list on violations
+module LayoutLint
+  RAW_ID_NAME = /\A(?:[0-9a-f]{12,}|el-[0-9a-f]+)\z/i
+  DEAD_ZONE_MAX = 0.25
+  GENERIC_HEADER = /\A(?:page|sheet|dashboard)\s*\d+\z/i
+  GRID_COLS = 24
+  MIN_BAND_FILL = 0.60
+  KPI_BAND_MAX_TILES = 4
+
+  module_function
+
+  # All [element, page] pairs in the spec (skips layout-only container shells).
+  def named_elements(spec)
+    (spec['pages'] || []).flat_map do |pg|
+      (pg['elements'] || []).map { |el| [el, pg] }
+    end
+  end
+
+  # Per-page layout blocks: { page_id => page_inner_xml }.
+  def page_blocks(layout_xml)
+    layout_xml.to_s.scan(%r{<Page\b[^>]*\bid="([^"]*)"[^>]*>(.*?)</Page>}m).to_h
+  end
+
+  # Top-level entries of a page block (direct children only, containers kept
+  # opaque): [[:container|:element, element_id, row_start, row_end], ...]
+  def top_level_entries(page_xml)
+    entries = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<(GridContainer|LayoutElement)\b([^>]*?)(/>|>)}m, pos))
+      tag, attrs, close = m[1], m[2], m[3]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      rows = attrs[/gridRow="\s*(\d+)\s*/, 1].to_i
+      rowe = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)\s*"/, 1].to_i
+      if tag == 'GridContainer' && close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        entries << [:container, eid, rows, rowe]
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        entries << [tag == 'GridContainer' ? :container : :element, eid, rows, rowe]
+        pos = m.end(0)
+      end
+    end
+    entries
+  end
+
+  # Top-level GridContainers of a page block with their direct children:
+  # [{eid:, r0:, r1:, children: [[child_eid, c0, c1, r0, r1], ...]}, ...]
+  def containers(page_xml)
+    out = []
+    s = page_xml.to_s
+    pos = 0
+    while (m = s.match(%r{<GridContainer\b([^>]*?)(/>|>)}m, pos))
+      attrs, close = m[1], m[2]
+      eid = attrs[/elementId="([^"]*)"/, 1]
+      r0 = attrs[/gridRow="\s*(\d+)/, 1].to_i
+      r1 = attrs[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i
+      inner = ''
+      if close == '>'
+        endm = s.match(%r{</GridContainer>}m, m.end(0))
+        inner = endm ? s[m.end(0)...endm.begin(0)] : ''
+        pos = endm ? endm.end(0) : m.end(0)
+      else
+        pos = m.end(0)
+      end
+      children = inner.scan(%r{<LayoutElement\b[^>]*?/?>}m).map do |le|
+        [le[/elementId="([^"]*)"/, 1],
+         le[/gridColumn="\s*(\d+)/, 1].to_i, le[/gridColumn="\s*\d+\s*\/\s*(\d+)/, 1].to_i,
+         le[/gridRow="\s*(\d+)/, 1].to_i, le[/gridRow="\s*\d+\s*\/\s*(\d+)/, 1].to_i]
+      end
+      out << { eid: eid, r0: r0, r1: r1, children: children }
+    end
+    out
+  end
+
+  # A text element's body reduced to its visible text (markdown/HTML stripped).
+  def plain_text(body)
+    body.to_s.gsub(%r{<[^>]+>}, '').gsub(/^#+\s*/, '').gsub(/[*_`]/, '').strip
+  end
+
+  def lint(spec)
+    violations = []
+    el_kind = {}
+    el_body = {}
+    named_elements(spec).each do |el, _pg|
+      el_kind[el['id']] = el['kind']
+      el_body[el['id']] = el['body']
+    end
+
+    # (a) raw-id display names ------------------------------------------------
+    named_elements(spec).each do |el, pg|
+      name = el['name'].to_s
+      next if name.empty?
+      next unless name.match?(RAW_ID_NAME)
+      violations << "raw-id display name: element #{el['id']} (#{el['kind']}) on page " \
+                    "'#{pg['name'] || pg['id']}' is named #{name.inspect} — derive a human title " \
+                    '(the source visual had no explicit title; see derived_title in the builder)'
+    end
+
+    page_blocks(spec['layout']).each do |page_id, body|
+      next if page_id.to_s.downcase.include?('data')
+      entries = top_level_entries(body)
+      next if entries.empty?
+
+      # (b) controls outside any container on a containered page --------------
+      if body.include?('<GridContainer')
+        entries.each do |kind, eid, _r0, _r1|
+          next unless kind == :element && el_kind[eid] == 'control'
+          violations << "orphan control: #{eid} sits OUTSIDE every GridContainer on page #{page_id} " \
+                        '(banded page) — place it in the control band or its chart\'s container'
+        end
+      end
+
+      # (d) generic header-band title ------------------------------------------
+      bands = containers(body)
+      hdr = bands.select { |b| b[:r0] <= 1 }.min_by { |b| b[:r0] }
+      if hdr
+        hdr[:children].each do |ceid, _c0, _c1, _r0, _r1|
+          next unless el_kind[ceid] == 'text'
+          txt = plain_text(el_body[ceid])
+          next unless txt.match?(GENERIC_HEADER)
+          violations << "generic header title: the header band (#{hdr[:eid]}) on page #{page_id} " \
+                        "renders #{txt.inspect} (element #{ceid}) — a Sigma auto page name must never " \
+                        'title the dashboard; use the promoted source title, the source display name, ' \
+                        'or the workbook name (SigmaLayout.resolve_header_title)'
+        end
+      end
+
+      # (e) band column fill ---------------------------------------------------
+      bands.each do |b|
+        kids = b[:children]
+        kpi_band = kids.any? && kids.length <= KPI_BAND_MAX_TILES &&
+                   kids.all? { |k| el_kind[k[0]] == 'kpi-chart' }
+        next if kpi_band
+        covered = Array.new(GRID_COLS, false)
+        kids.each do |_eid, c0, c1, _r0, _r1|
+          (c0...c1).each { |c| covered[c - 1] = true if c >= 1 && c <= GRID_COLS }
+        end
+        fill = covered.count(true).to_f / GRID_COLS
+        next if fill >= MIN_BAND_FILL
+        empty_cols = covered.each_index.reject { |i| covered[i] }.map { |i| i + 1 }
+        violations << format('band under-filled: container %s on page %s — %s cover %d of %d grid ' \
+                             'columns (%.0f%% < %.0f%% required); dead space at columns %s — ' \
+                             're-flow the band (SigmaLayout.reflow_bands) or widen the elements',
+                             b[:eid], page_id,
+                             kids.empty? ? 'no children' : "#{kids.length} element(s) (#{kids.map(&:first).join(', ')})",
+                             covered.count(true), GRID_COLS, fill * 100, MIN_BAND_FILL * 100,
+                             empty_cols.empty? ? '-' : empty_cols.slice_when { |a, x| x != a + 1 }.map { |g| g.length > 1 ? "#{g.first}-#{g.last}" : g.first.to_s }.join(', '))
+      end
+
+      # (c) dead-zone heuristic ------------------------------------------------
+      spans = entries.map { |_k, _e, r0, r1| [r0, [r1, r0 + 1].max] }
+                     .select { |r0, _r1| r0.positive? }
+      next if spans.length < 2
+      first = spans.map(&:first).min
+      last  = spans.map(&:last).max
+      total = last - first
+      next if total <= 0
+      covered = Array.new(total, false)
+      spans.each { |r0, r1| (r0...r1).each { |r| covered[r - first] = true if r - first < total } }
+      empty = covered.count(false)
+      ratio = empty.to_f / total
+      if ratio > DEAD_ZONE_MAX
+        violations << format('dead zone: page %s has %d of %d grid rows empty between its first and ' \
+                             'last element (%.0f%% > %.0f%% allowed) — close the gaps (banded layout)',
+                             page_id, empty, total, ratio * 100, DEAD_ZONE_MAX * 100)
+      end
+    end
+
+    violations
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  require 'json'
+  abort 'usage: ruby layout_lint.rb <workbook-spec.json>' unless ARGV[0] && File.exist?(ARGV[0])
+  v = LayoutLint.lint(JSON.parse(File.read(ARGV[0])))
+  if v.empty?
+    puts 'layout lint: clean'
+  else
+    warn "layout lint: #{v.size} violation(s):"
+    v.each { |x| warn "  - #{x}" }
+    exit 1
+  end
+end

--- a/metabase-migration-skills/metabase-to-sigma/scripts/lib/preflight_lint.rb
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/lib/preflight_lint.rb
@@ -1,0 +1,94 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# Preflight lint for a workbook spec — catches the two EDNA-class failure modes
+# BEFORE POST, with a precise message instead of the opaque "Invalid kind: control"
+# or a silently-detail-rendered table.
+#
+#   ruby preflight_lint.rb <workbook-spec.json>
+#     exit 0  = clean
+#     exit 1  = violations (printed, one per line)
+#
+# Checks:
+#   T1  a `table` with aggregate column(s) + dimension(s) but NO `groupings`
+#       → renders raw detail rows (the 9.6M-row / $0 / duplicate-dim EDNA bug).
+#   T2  a `groupings.calculations` column that is a PASSTHROUGH of an aggregate
+#       (re-aggregates to "multiple values"); calc cols must be Sum(...)/etc.
+#   C1  a `control` missing id / controlId / controlType.
+#   C2  a list/segmented/hierarchy control missing the flat value fields
+#       (source / mode / selectionMode / values) or nesting them under a
+#       bogus `value` object → the opaque `Invalid kind: control`.
+require 'json'
+
+AGG = /\A\s*(Sum|Avg|Count|CountDistinct|CountIf|SumIf|Min|Max|Median|Percentile|StdDev|Variance|VariancePop|GrandTotal)\s*\(/i
+PLAIN_REF = /\A\s*\[[^\]]+\]\s*\z/   # a bare column reference, e.g. [Table/Region]
+LISTY = %w[list segmented hierarchy].freeze
+
+def lint(spec)
+  errs = []
+  cols_by_id = {}
+  pages = spec['pages'] || []
+  pages.each do |pg|
+    (pg['elements'] || []).each do |el|
+      (el['columns'] || []).each { |c| cols_by_id[c['id']] = c }
+    end
+  end
+  pages.each do |pg|
+    (pg['elements'] || []).each do |el|
+      kind = el['kind']
+      name = el['name'] || el['id'] || '(unnamed)'
+      cols = el['columns'] || []
+
+      if kind == 'table'
+        agg = cols.select { |c| c['formula'].to_s =~ AGG }
+        dim = cols.select { |c| c['formula'].to_s =~ PLAIN_REF }
+        grouped = el['groupings'].is_a?(Array) && !el['groupings'].empty?
+        if agg.any? && dim.any? && !grouped
+          errs << "T1 table '#{name}': has aggregate column(s) #{agg.map { |c| c['name'] }.inspect} + dimension(s) but NO `groupings` → will render raw detail rows, not an aggregated summary. Add groupings:[{groupBy:[<dim id>], calculations:[<agg id>...]}]."
+        end
+        # T2: a grouping calculation that points at a passthrough-of-aggregate column
+        (el['groupings'] || []).each do |g|
+          (g['calculations'] || []).each do |cid|
+            f = (cols_by_id[cid] || {})['formula'].to_s
+            # a calc that is a plain ref to another column whose own formula is an aggregate
+            if f =~ PLAIN_REF
+              # can't always resolve cross-element; flag bare passthroughs that look like measures
+              errs << "T2 table '#{name}': grouping calculation '#{cid}' is a passthrough (`#{f}`) — a grouped calculation must be an aggregate expression (Sum([...]) etc.), not a passthrough of an already-aggregated column (renders 'multiple values')." if cols_by_id[cid] && (cols_by_id[cid]['name'].to_s =~ /total|sum|count|avg|revenue|profit|tcv|amount/i)
+            end
+          end
+        end
+      end
+
+      if kind == 'control'
+        %w[id controlId controlType].each do |f|
+          errs << "C1 control '#{name}': missing required field `#{f}`." if el[f].to_s.empty?
+        end
+        errs << "C1 control '#{name}': `id` and `controlId` must be DISTINCT." if !el['id'].to_s.empty? && el['id'] == el['controlId']
+        if LISTY.include?(el['controlType'])
+          errs << "C2 control '#{name}': list-type control missing `source` (value-list; needs nested {kind:source, source:{kind:table,elementId}, columnId})." unless el['source'].is_a?(Hash)
+          if el['source'].is_a?(Hash) && !(el['source']['source'].is_a?(Hash))
+            errs << "C2 control '#{name}': `source` must be double-nested ({kind:source, source:{kind:table,elementId}, columnId}) — got a flat source."
+          end
+          %w[mode selectionMode values].each do |f|
+            errs << "C2 control '#{name}': missing flat top-level `#{f}` (list controls carry mode/selectionMode/values as flat siblings, NOT in a value object)." unless el.key?(f)
+          end
+          errs << "C2 control '#{name}': value fields nested under a `value` object — they must be FLAT top-level (source/mode/selectionMode/values)." if el['value'].is_a?(Hash)
+        end
+      end
+    end
+  end
+  errs
+end
+
+if __FILE__ == $PROGRAM_NAME
+  path = ARGV[0] or abort('usage: preflight_lint.rb <workbook-spec.json>')
+  spec = JSON.parse(File.read(path))
+  errs = lint(spec)
+  if errs.empty?
+    puts 'preflight lint: clean'
+    exit 0
+  end
+  warn "preflight lint: #{errs.size} violation(s)"
+  errs.each { |e| warn "  ✗ #{e}" }
+  exit 1
+end

--- a/metabase-migration-skills/metabase-to-sigma/scripts/lib/sigma-rest.mjs
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/lib/sigma-rest.mjs
@@ -1,0 +1,51 @@
+// Minimal Sigma REST helper for the metabase-to-sigma verify scripts.
+// Reads SIGMA_BASE_URL + SIGMA_API_TOKEN from env — run `eval "$(scripts/get-token.sh)"` first.
+// Tolerates YAML responses (Sigma's /spec POST returns YAML) when pulling an id.
+
+export function sigmaEnv() {
+  const base = process.env.SIGMA_BASE_URL, token = process.env.SIGMA_API_TOKEN;
+  if (!base || !token) {
+    console.error('Missing SIGMA_BASE_URL / SIGMA_API_TOKEN. Run: eval "$(scripts/get-token.sh)"');
+    process.exit(2);
+  }
+  return { base: base.replace(/\/$/, ''), token };
+}
+
+export async function api(method, path, body) {
+  const { base, token } = sigmaEnv();
+  const res = await fetch(base + path, {
+    method,
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: body == null ? undefined : (typeof body === 'string' ? body : JSON.stringify(body)),
+  });
+  const text = await res.text();
+  let json = null; try { json = JSON.parse(text); } catch { /* YAML or empty */ }
+  return { status: res.status, ok: res.ok, text, json };
+}
+
+// Sigma POST /spec returns JSON ({"workbookId":...}) OR YAML (workbookId: ...). Pull either.
+export function extractId(r, field) {
+  if (r.json && r.json[field]) return r.json[field];
+  const m = r.text.match(new RegExp(`${field}:\\s*"?([0-9a-f-]{36})`, 'i'));
+  return m ? m[1] : null;
+}
+
+// Tiny --flag parser: returns { flag: value | true }.
+export function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i++) {
+    if (!argv[i].startsWith('--')) continue;
+    const k = argv[i].slice(2);
+    const next = argv[i + 1];
+    out[k] = (next == null || next.startsWith('--')) ? true : (i++, next);
+  }
+  return out;
+}
+
+// DM/workbook element listings come back under a few shapes — normalize to [{id,name,kind}].
+export function elementsOf(json) {
+  const list = json?.entries || json?.elements || (Array.isArray(json) ? json : []);
+  return (Array.isArray(list) ? list : []).map((e) => ({
+    id: e.elementId || e.id, name: e.name || e.elementName || '', kind: e.kind || e.type,
+  })).filter((e) => e.id);
+}

--- a/metabase-migration-skills/metabase-to-sigma/scripts/lib/sigma_rest.rb
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/lib/sigma_rest.rb
@@ -1,0 +1,130 @@
+# Sigma REST API wrapper with automatic 401 retry + token refresh.
+#
+# Sigma OAuth bearer tokens expire after ~1 hour. Long-running scripts (a
+# 30-min conversion, an hour+ batch orchestration, an assessment readout)
+# routinely outlive a single token and would otherwise fail mid-run.
+#
+# This module mirrors the shape of `tableau_rest.rb`. It provides:
+#   - `Sigma.refresh_token!`         — re-do client_credentials exchange,
+#                                       update in-memory token under a mutex
+#   - `Sigma.request(method, path)`  — catches 401, refreshes once, retries
+#
+# Required env: SIGMA_BASE_URL, SIGMA_CLIENT_ID, SIGMA_CLIENT_SECRET.
+# Optional env: SIGMA_API_TOKEN (initial token; refreshed on demand).
+#
+# Usage:
+#   require_relative 'lib/sigma_rest'
+#   wb = Sigma.request(:get, "/v2/workbooks/#{id}")
+#   Sigma.request(:post, '/v2/workbooks/spec', body: spec.to_json)
+#
+# All methods return parsed Hash/Array (or raw bytes for binary endpoints).
+
+require 'net/http'
+require 'uri'
+require 'json'
+require 'base64'
+
+# Agent-neutral credential bootstrap. Claude Code injects creds from
+# ~/.claude/settings.json into the env automatically; other agents (Cursor,
+# Cortex Code, plain shell) don't. If the Sigma creds aren't in ENV yet, load
+# them from the neutral cred file written by setup.rb. Existing env always wins.
+_neutral_env = File.expand_path('~/.sigma-migration/env')
+if ENV['SIGMA_CLIENT_ID'].nil? && File.exist?(_neutral_env)
+  File.foreach(_neutral_env) do |line|
+    next unless (m = line.chomp.match(/\A\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)=(.*)\z/))
+    key, raw = m[1], m[2].strip
+    raw = raw[1..-2] if raw.length >= 2 &&
+      ((raw.start_with?("'") && raw.end_with?("'")) || (raw.start_with?('"') && raw.end_with?('"')))
+    ENV[key] ||= raw
+  end
+end
+
+module Sigma
+  class Error < StandardError; end
+  class AuthError < Error; end
+
+  @token_mutex = Mutex.new
+  @token_override = nil
+  @refresh_inflight = false
+
+  module_function
+
+  def base_url
+    ENV.fetch('SIGMA_BASE_URL') { raise Error, 'SIGMA_BASE_URL not set' }
+  end
+
+  def auth_token
+    @token_mutex.synchronize { @token_override } || ENV['SIGMA_API_TOKEN'] || refresh_token!
+  end
+
+  # Re-do the OAuth client_credentials exchange and store the new token.
+  # Thread-safe and single-flight: concurrent callers all wait for one
+  # exchange and share the result. Returns the new token.
+  def refresh_token!
+    @token_mutex.synchronize do
+      return @token_override if @refresh_inflight
+      @refresh_inflight = true
+    end
+    begin
+      cid    = ENV.fetch('SIGMA_CLIENT_ID')     { raise AuthError, 'SIGMA_CLIENT_ID not set' }
+      secret = ENV.fetch('SIGMA_CLIENT_SECRET') { raise AuthError, 'SIGMA_CLIENT_SECRET not set' }
+      creds = Base64.strict_encode64("#{cid}:#{secret}")
+      uri = URI("#{base_url}/v2/auth/token")
+      req = Net::HTTP::Post.new(uri)
+      req['Authorization'] = "Basic #{creds}"
+      req['Content-Type']  = 'application/x-www-form-urlencoded'
+      req.body = 'grant_type=client_credentials'
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 30) { |h| h.request(req) }
+      raise AuthError, "token exchange -> #{res.code} #{res.body}" unless res.is_a?(Net::HTTPSuccess)
+      tok = JSON.parse(res.body)['access_token']
+      raise AuthError, "token exchange returned no access_token: #{res.body}" if tok.nil? || tok.empty?
+      @token_mutex.synchronize { @token_override = tok }
+      # Surface the refreshed token to child processes / shell evals.
+      ENV['SIGMA_API_TOKEN'] = tok
+      tok
+    ensure
+      @token_mutex.synchronize { @refresh_inflight = false }
+    end
+  end
+
+  def request(method, path, body: nil, content_type: 'application/json', accept: 'application/json', binary: false, http: nil)
+    uri = URI("#{base_url}#{path}")
+    attempts = 0
+    loop do
+      attempts += 1
+      req = case method
+            when :get    then Net::HTTP::Get.new(uri)
+            when :post   then Net::HTTP::Post.new(uri)
+            when :put    then Net::HTTP::Put.new(uri)
+            when :patch  then Net::HTTP::Patch.new(uri)
+            when :delete then Net::HTTP::Delete.new(uri)
+            else raise ArgumentError, "unsupported method #{method}"
+            end
+      req['Authorization'] = "Bearer #{auth_token}"
+      req['Accept']        = accept
+      if body
+        req['Content-Type'] = content_type
+        req.body = body
+      end
+
+      res = if http
+              http.request(req)
+            else
+              Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 120) { |h| h.request(req) }
+            end
+
+      # Sigma returns 401 with code:"unauthorized" when the bearer expires.
+      # Refresh once and retry; on a second 401, surface the error.
+      if res.code.to_i == 401 && attempts == 1 && ENV['SIGMA_CLIENT_ID']
+        refresh_token!
+        next
+      end
+      unless res.is_a?(Net::HTTPSuccess)
+        raise Error, "#{method.upcase} #{path} -> #{res.code} #{res.message}\n#{res.body}"
+      end
+      return res.body if binary
+      return res.body unless accept == 'application/json'
+      return res.body.empty? ? nil : JSON.parse(res.body)
+    end
+  end
+end

--- a/metabase-migration-skills/metabase-to-sigma/scripts/lib/sigma_telemetry.py
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/lib/sigma_telemetry.py
@@ -1,0 +1,97 @@
+"""
+Drop-in telemetry client for Sigma migration skills.
+
+Usage:
+    from sigma_telemetry import report_migration
+    import time
+
+    start = time.time()
+    # ... do migration ...
+    report_migration(
+        tool="metabase-to-sigma",
+        sigma_base="https://api.au.aws.sigmacomputing.com",
+        client_id=os.environ["SIGMA_CLIENT_ID"],
+        duration_seconds=int(time.time() - start),
+        success=True,
+    )
+"""
+
+import hashlib
+import time
+import os
+import urllib.request
+import urllib.error
+import json
+
+TELEMETRY_ENDPOINT = "https://sigma-migration-telemetry.onrender.com/track"
+SKILL_VERSION = "1.0"
+
+
+def _region_from_base(sigma_base: str) -> str:
+    if ".au." in sigma_base: return "au"
+    if ".eu." in sigma_base: return "eu"
+    if ".uk." in sigma_base: return "uk"
+    if ".ca." in sigma_base: return "ca"
+    return "us"
+
+
+def _org_hash(client_id: str) -> str:
+    """First 8 hex chars of SHA256(client_id). Unique per org, not reversible."""
+    return hashlib.sha256(client_id.encode()).hexdigest()[:8]
+
+
+def report_migration(
+    tool: str,
+    sigma_base: str,
+    client_id: str,
+    duration_seconds: int,
+    success: bool,
+    skill_version: str = SKILL_VERSION,
+    endpoint: str = TELEMETRY_ENDPOINT,
+    timeout: int = 5,
+) -> None:
+    """
+    Fire-and-forget anonymous usage ping. Never raises.
+
+    What IS sent:
+      tool            — e.g. "metabase-to-sigma"
+      sigma_region    — derived from API base URL (e.g. "au")
+      org_id_hash     — SHA256(SIGMA_CLIENT_ID)[0:8], unique per org, not reversible
+      duration_seconds
+      success         — True/False
+      skill_version
+
+    What is NOT sent:
+      workbook names, IDs, or URLs
+      SQL queries or column names
+      dashboard or card titles
+      user email or name
+      any customer data or warehouse content
+    """
+    payload = {
+        "event":            "migration_complete",
+        "tool":             tool,
+        "sigma_region":     _region_from_base(sigma_base),
+        "org_id_hash":      _org_hash(client_id),
+        "duration_seconds": duration_seconds,
+        "success":          success,
+        "skill_version":    skill_version,
+    }
+
+    print("\nReporting anonymous migration telemetry (no customer data sent):")
+    for k, v in payload.items():
+        if k != "event":
+            print(f"  {k}: {v}")
+
+    try:
+        body = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            endpoint,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            print(f"  → telemetry sent ({resp.status})\n")
+    except Exception:
+        print("  → telemetry unavailable (skipped)\n")

--- a/metabase-migration-skills/metabase-to-sigma/scripts/metabase-discover.sh
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/metabase-discover.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Metabase REST discovery helper (converter-side; the assessment skill has the
+# full estate walker). Read-only GETs.
+#
+#   export MB_BASE="https://<host>"           # plus MB_KEY or MB_USER/MB_PASS
+#   eval "$(scripts/get-metabase-session.sh)"
+#
+#   metabase-discover.sh collections                 # collection tree (id, name, location)
+#   metabase-discover.sh items     <collectionId>    # cards/dashboards/models in a collection
+#   metabase-discover.sh card      <cardId>          # full card JSON (question/model)  → stdout
+#   metabase-discover.sh dashboard <dashboardId>     # full dashboard JSON              → stdout
+#   metabase-discover.sh databases                   # list databases (find the warehouse conn)
+#   metabase-discover.sh metadata  <databaseId>      # schema metadata (FIELD IDS — converter needs this)
+set -euo pipefail
+if ! command -v mb_get >/dev/null 2>&1 && [ -z "${MB_AUTH_HDR:-}" ]; then
+  echo "Run: eval \"\$(scripts/get-metabase-session.sh)\" first" >&2; exit 1
+fi
+req() { curl -s "$MB_BASE$1" -H 'Accept: application/json' -H "$MB_AUTH_HDR"; }
+cmd="${1:-}"; id="${2:-}"
+case "$cmd" in
+  collections)
+    req "/api/collection" | python3 -c '
+import sys,json
+for c in json.load(sys.stdin):
+    if isinstance(c, dict):
+        kind = "personal" if c.get("personal_owner_id") else "shared"
+        cid, loc, name = str(c.get("id")), c.get("location") or "/", c.get("name")
+        print(f"{cid:>6}  {kind:8}  {loc:12}  {name}")' ;;
+  items)
+    req "/api/collection/$id/items?models=card&models=dashboard&models=dataset&limit=200" | python3 -c '
+import sys,json
+d=json.load(sys.stdin)
+for i in d.get("data", []):
+    model, iid, name = i.get("model", "?"), str(i.get("id")), i.get("name")
+    print(f"{model:10} {iid:>6}  {name}")
+t=d.get("total"); n=len(d.get("data", []))
+if t and t > n: print(f"… {t-n} more — paginate with &offset={n}", file=sys.stderr)' ;;
+  card)      req "/api/card/$id" ;;
+  dashboard) req "/api/dashboard/$id" ;;
+  databases)
+    req "/api/database" | python3 -c '
+import sys,json
+d=json.load(sys.stdin); rows=d.get("data") if isinstance(d, dict) else d
+for db in rows or []:
+    did, eng, name = str(db.get("id")), db.get("engine", "?"), db.get("name")
+    print(f"{did:>4}  {eng:12}  {name}")' ;;
+  metadata)  req "/api/database/$id/metadata" ;;
+  *) echo "usage: metabase-discover.sh {collections | items <id> | card <id> | dashboard <id> | databases | metadata <dbId>}" >&2; exit 1 ;;
+esac

--- a/metabase-migration-skills/metabase-to-sigma/scripts/metabase-dm-signature.py
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/metabase-dm-signature.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""metabase-dm-signature.py — build a DM-reuse signature from the Metabase converter output.
+
+Feeds scripts/find-or-pick-dm.rb (Phase 1.5) so the migration REUSES an existing
+Sigma data model that already covers the same warehouse tables instead of
+creating a 4th near-identical one. Mirrors powerbi-to-sigma's
+pbi-dm-signature.py. Emits the signature shape find-or-pick-dm expects:
+
+  { "tableau_workbook": "<bundle name>",          # label only
+    "warehouse_tables":   ["DB.SCHEMA.TABLE", ...],
+    "referenced_columns": ["Col", ...],
+    "measures":           [{"col": "Col", "derivation": "Sum|CountDistinct|..."}] }
+
+Input = the Phase-1 converter output (the Sigma data-model JSON `cli.ts` printed
+for the Data Module — dm.json, BEFORE it is POSTed). Walks every element:
+`source.path` (warehouse-table) → tables, column `name`/formula tail → columns,
+element `metrics` → measures. Custom-SQL elements surface as a CUSTOM_SQL
+sentinel, same as the picker uses for candidate DMs. Pure (no network).
+
+Usage: python3 scripts/metabase-dm-signature.py --dm-spec dm.json --out dm-signature.json
+"""
+import argparse, json, re, sys
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dm-spec", required=True, help="Phase-1 converter output (Sigma DM JSON)")
+    ap.add_argument("--out", required=True)
+    a = ap.parse_args()
+    spec = json.load(open(a.dm_spec))
+
+    elements = spec.get("elements") or [e for p in spec.get("pages", []) for e in p.get("elements", [])]
+    tables, cols, measures = [], [], []
+    for el in elements:
+        src = el.get("source") or {}
+        kind = src.get("kind")
+        if kind in ("warehouse-table", "table"):
+            path = src.get("path")
+            fqn = ".".join(path) if isinstance(path, list) else \
+                  (path or ".".join(p for p in [src.get("database"), src.get("schema"), src.get("name")] if p))
+            if fqn:
+                tables.append(str(fqn).upper())
+        elif kind == "sql":
+            tables.append("CUSTOM_SQL")
+        for c in el.get("columns", []):
+            name = c.get("name")
+            if not name:
+                m = re.search(r"\[.*?([^/\]]+)\]", str(c.get("formula", "")))
+                name = m.group(1) if m else None
+            if name:
+                cols.append(name)
+        for m in el.get("metrics", []):
+            measures.append({"col": m.get("name", ""),
+                             "derivation": m.get("aggregation") or m.get("derivation")})
+
+    sig = {"tableau_workbook": spec.get("name") or "Metabase card bundle",
+           "warehouse_tables": sorted(set(tables)),
+           "referenced_columns": sorted(set(cols)),
+           "measures": measures}
+    json.dump(sig, open(a.out, "w"), indent=2)
+    print(f"[metabase-dm-signature] {len(elements)} element(s): {len(sig['warehouse_tables'])} table(s), "
+          f"{len(sig['referenced_columns'])} col(s), {len(measures)} measure(s) -> {a.out}",
+          file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/metabase-migration-skills/metabase-to-sigma/scripts/pick-destination.mjs
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/pick-destination.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Shared destination picker for the *-to-sigma migration skills (Node port).
+// Produces the folderId where a migrated data model + workbook should land.
+// The SKILL drives the *asking*; this script lists candidates and creates folders.
+//
+//   node pick-destination.mjs list
+//       -> { workspaces:[{id,name}], folders:[{id,name,parentId,parentName}], myDocuments }
+//   node pick-destination.mjs create --name "<NAME>" [--parent "<workspace-or-folder-id>"]
+//       -> { id, name, parentId }
+//
+// Auth: SIGMA_API_TOKEN + SIGMA_BASE_URL if set; else minted from
+// SIGMA_CLIENT_ID/SIGMA_CLIENT_SECRET (sourced from ~/.sigma-migration/env).
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+function loadNeutralEnv() {
+  if (process.env.SIGMA_CLIENT_ID || process.env.SIGMA_API_TOKEN) return;
+  const p = path.join(os.homedir(), '.sigma-migration', 'env');
+  if (!fs.existsSync(p)) return;
+  for (const line of fs.readFileSync(p, 'utf8').split('\n')) {
+    const t = line.trim();
+    if (!t || t.startsWith('#') || !t.includes('=')) continue;
+    const idx = t.indexOf('=');
+    const k = t.slice(0, idx).trim();
+    const v = t.slice(idx + 1).trim().replace(/^["']|["']$/g, '');
+    if (process.env[k] === undefined) process.env[k] = v;
+  }
+}
+
+const BASE = () => (process.env.SIGMA_BASE_URL || 'https://aws-api.sigmacomputing.com').replace(/\/$/, '');
+let TOK = null;
+async function token() {
+  if (process.env.SIGMA_API_TOKEN) return process.env.SIGMA_API_TOKEN;
+  loadNeutralEnv();
+  const body = new URLSearchParams({ grant_type: 'client_credentials',
+    client_id: process.env.SIGMA_CLIENT_ID, client_secret: process.env.SIGMA_CLIENT_SECRET });
+  const r = await fetch(BASE() + '/v2/auth/token', { method: 'POST', body });
+  return (await r.json()).access_token;
+}
+async function call(method, p, body) {
+  if (!TOK) TOK = await token();
+  const r = await fetch(BASE() + p, { method,
+    headers: { Authorization: 'Bearer ' + TOK, 'Content-Type': 'application/json' },
+    body: body !== undefined ? JSON.stringify(body) : undefined });
+  const raw = await r.text();
+  if (!r.ok) { console.error(`${method} ${p} -> ${r.status} ${raw.slice(0, 300)}`); process.exit(1); }
+  return raw ? JSON.parse(raw) : {};
+}
+async function myDocumentsId() {
+  try {
+    const uid = (await call('GET', '/v2/whoami'))?.userId;
+    if (!uid) return null;
+    const entries = (await call('GET', `/v2/members/${uid}/files?typeFilters=folder&limit=500`))?.entries || [];
+    const hit = entries.find(e => e.name === 'My Documents' || e.path === 'My Documents');
+    return hit ? hit.id : null;
+  } catch { return null; }
+}
+async function cmdList() {
+  const ws = ((await call('GET', '/v2/workspaces?limit=500')).entries || [])
+    .map(w => ({ id: w.workspaceId || w.id, name: w.name }));
+  const wsName = Object.fromEntries(ws.map(w => [w.id, w.name]));
+  const folders = ((await call('GET', '/v2/files?typeFilters=folder&limit=500')).entries || [])
+    .filter(f => f.permission === 'edit')
+    .map(f => ({ id: f.id, name: f.name, parentId: f.parentId, parentName: wsName[f.parentId] || null }));
+  console.log(JSON.stringify({ workspaces: ws, folders, myDocuments: await myDocumentsId() }, null, 2));
+}
+async function cmdCreate(argv) {
+  let name = null, parent = null;
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--name') { name = argv[++i]; }
+    else if (argv[i] === '--parent') { parent = argv[++i]; }
+  }
+  if (!name) { console.error('pick-destination create: --name is required'); process.exit(1); }
+  if (!parent) parent = await myDocumentsId();
+  const body = { type: 'folder', name };
+  if (parent) body.parentId = parent;
+  const res = await call('POST', '/v2/files', body);
+  console.log(JSON.stringify({ id: res.id, name: res.name, parentId: res.parentId }, null, 2));
+}
+const cmd = process.argv[2] || 'list';
+if (cmd === 'list') await cmdList();
+else if (cmd === 'create') await cmdCreate(process.argv.slice(3));
+else { console.error('usage: pick-destination.mjs [list | create --name NAME [--parent ID]]'); process.exit(1); }

--- a/metabase-migration-skills/metabase-to-sigma/scripts/post-and-readback.mjs
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/post-and-readback.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+// post-and-readback.mjs — POST a Metabase-converted DM or workbook spec, then read it
+// back and FAIL LOUDLY on any error-typed column (a spec can POST 200 yet have
+// formulas that don't resolve at query time — those surface as type "error").
+//
+// Workbook POSTs additionally run the SHARED layout + control lints on the
+// readback spec (scripts/lib/layout_lint.rb / control_lint.rb — vendored
+// byte-identical across the sigma-migration-skills plugins; gate 6/7 of
+// assert-phase6-ran.rb re-checks the same thing later). The control lint picks
+// up the control-scope.json sidecar next to --spec (or --control-scope PATH).
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/post-and-readback.mjs --type datamodel|workbook --spec spec.json --folder <folderId> \
+//     [--name N] [--out map.json] [--control-scope scope.json]
+//     [--keep-rejected-bindings]   # legacy behavior: if the org rejects
+//                                  # control→DM-parameter bindings, keep the
+//                                  # (now-decorative) controls and only strip
+//                                  # the binding. Default is to DROP them: a
+//                                  # control that provably drives nothing is
+//                                  # the exact furniture gate 7 exists to block
+//                                  # (the customer-feedback issue was "controls
+//                                  # not driving anything"). The DM {{tag}}
+//                                  # controls still carry the filter — re-add a
+//                                  # workbook control synced to the DM
+//                                  # parameter in the UI when the org enables it.
+//
+// Prints { dataModelId|workbookId, errors:[...] } and exits non-zero if any error
+// columns (exit 1) or lint violations (exit 4 = control, exit 5 = layout).
+import { readFileSync, writeFileSync, appendFileSync, existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+import { api, extractId, parseArgs, elementsOf } from './lib/sigma-rest.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+if (!a.type || !a.spec || !a.folder) { console.error('need --type datamodel|workbook --spec <spec.json> --folder <folderId>'); process.exit(2); }
+const idField = a.type === 'datamodel' ? 'dataModelId' : 'workbookId';
+const postPath = a.type === 'datamodel' ? '/v2/dataModels/spec' : '/v2/workbooks/spec';
+const colsPath = (id) => a.type === 'datamodel' ? `/v2/dataModels/${id}/columns` : `/v2/workbooks/${id}/columns`;
+const SCRIPTS = dirname(fileURLToPath(import.meta.url));
+const WORKDIR = dirname(a.spec);
+const scopePath = a['control-scope'] || join(WORKDIR, 'control-scope.json');
+
+const spec = JSON.parse(readFileSync(a.spec, 'utf8'));
+// name AFTER the spread — `{name, ...spec}` let spec.name silently override --name (beads-sigma-unff).
+const body = { folderId: a.folder, ...spec, name: a.name || spec.name || `metabase ${a.type} ${Date.now()}` };
+let post = await api('POST', postPath, body);
+// Control→DM-parameter bindings (remap --dm-spec) can be rejected by orgs where
+// data-model parameter targeting isn't enabled. Default: DROP the affected
+// controls entirely (a control that provably drives nothing is furniture — the
+// control lint would rightly fail it) and patch the control-scope sidecar.
+// --keep-rejected-bindings keeps them with only the binding stripped (legacy;
+// gate 7 WILL flag them dead until you sync each control in the UI:
+// control → Settings → "Sync with data source parameter").
+if (!post.ok && /Invalid parameter on control/.test(post.text)) {
+  const bound = (c) => c?.kind === 'control' && c.parameters;
+  const dropped = [];
+  if (a['keep-rejected-bindings']) {
+    let stripped = 0;
+    const strip = (c) => { if (bound(c)) { delete c.parameters; stripped++; } };
+    for (const c of body.controls || []) strip(c);
+    for (const p of body.pages || []) for (const e of p.elements || []) strip(e);
+    if (stripped) {
+      console.error(`WARN: org rejected control→data-model parameter bindings — stripped ${stripped} and retrying (--keep-rejected-bindings). These controls POST but DRIVE NOTHING until you sync each to its DM control in the UI; the control lint (gate 7) will flag them dead until then.`);
+      post = await api('POST', postPath, body);
+    }
+  } else {
+    for (const c of body.controls || []) if (bound(c)) dropped.push(c.controlId);
+    body.controls = (body.controls || []).filter((c) => !bound(c));
+    for (const p of body.pages || []) p.elements = (p.elements || []).filter((e) => !bound(e));
+    if (dropped.length) {
+      console.error(`WARN: org rejected control→data-model parameter bindings — DROPPED ${dropped.length} control(s) [${dropped.join(', ')}] and retrying. The filters still live on the DM's {{tag}} controls; re-add a workbook control synced to the DM parameter in the UI when the org enables data-model parameter targeting (or re-run with --keep-rejected-bindings to keep decorative controls and sync them by hand).`);
+      // patch the control-scope sidecar so gate 7 doesn't expect the dropped controls
+      if (existsSync(scopePath)) {
+        try {
+          const scope = JSON.parse(readFileSync(scopePath, 'utf8'));
+          scope.controls = (scope.controls || []).filter((c) => !dropped.includes(c.controlId));
+          const specControls = (body.pages || []).flatMap((p) => p.elements || []).filter((e) => e.kind === 'control').length;
+          if (!specControls) {
+            scope.note = `sourceFilterSignals zeroed by post-and-readback: the org rejected control→DM-parameter bindings for [${dropped.join(', ')}] — the signals are non-portable here; the DM {{tag}} controls carry the filters.`;
+            scope.sourceFilterSignals = 0;
+          }
+          writeFileSync(scopePath, JSON.stringify(scope, null, 2));
+          console.error(`patched ${scopePath} (removed ${dropped.length} sidecar entr${dropped.length === 1 ? 'y' : 'ies'})`);
+        } catch { console.error(`WARN: could not patch ${scopePath} — fix it by hand before gate 7.`); }
+      }
+      post = await api('POST', postPath, body);
+    }
+  }
+}
+const id = extractId(post, idField);
+if (!id) { console.error(`POST failed (HTTP ${post.status}): ${post.text.slice(0, 500)}`); process.exit(1); }
+console.error(`POST ok → ${idField}=${id}`);
+
+// Gate-2 sentinel (assert-phase6-ran.rb orphan check): every POSTed workbook is
+// recorded; >1 unique id without a cleanup marker blocks GREEN.
+if (a.type === 'workbook') {
+  appendFileSync(join(WORKDIR, 'posted-workbooks.jsonl'), JSON.stringify({ id, name: body.name, at: new Date().toISOString() }) + '\n');
+  writeFileSync(join(WORKDIR, 'wb-ids.json'), JSON.stringify({ workbookId: id }, null, 2));
+}
+
+// Silent-error guard: scan resolved column types; type "error" = formula didn't resolve.
+const cols = await api('GET', colsPath(id));
+const errors = [];
+const list = cols.json?.entries || cols.json?.columns || (Array.isArray(cols.json) ? cols.json : []);
+for (const c of (Array.isArray(list) ? list : [])) {
+  const t = c.type?.type || c.columnType || c.type;
+  if (String(t).toLowerCase() === 'error') errors.push(c.name || c.columnName || c.columnId);
+}
+const elements = elementsOf((await api('GET', a.type === 'datamodel' ? `/v2/dataModels/${id}/elements` : `/v2/workbooks/${id}/elements`)).json);
+const result = { [idField]: id, elements, errors };
+if (a.out) writeFileSync(a.out, JSON.stringify(result, null, 2));
+console.log(JSON.stringify(result, null, 2));
+if (errors.length) { console.error(`FAIL: ${errors.length} error-typed column(s): ${errors.join(', ')}`); process.exit(1); }
+console.error(`readback clean: ${elements.length} element(s), 0 error columns`);
+
+// ── shared lint pass (workbooks): layout_lint + control_lint on the READBACK spec
+if (a.type === 'workbook') {
+  const rb = await api('GET', `/v2/workbooks/${id}/spec`);
+  const rbPath = join(WORKDIR, 'workbook-readback.spec.json');
+  writeFileSync(rbPath, rb.json ? JSON.stringify(rb.json, null, 2) : rb.text);
+  const run = (script, args) => spawnSync('ruby', [join(SCRIPTS, 'lib', script), ...args], { stdio: 'inherit' });
+  // layout lint: pre-apply-layout this only catches raw-id display names; the
+  // full check re-runs in apply-layout.mjs and as gate 6.
+  const lay = run('layout_lint.rb', [rbPath]);
+  if (lay.status !== 0) { console.error('FAIL: layout lint violations on the readback spec (see above).'); process.exit(5); }
+  const ctl = run('control_lint.rb', existsSync(scopePath) ? [rbPath, scopePath] : [rbPath]);
+  if (ctl.status !== 0) {
+    console.error('FAIL: control lint violations on the readback spec (see above). Fix the wiring');
+    console.error('      (refs/control-parity.md repair recipes) or annotate intent in control-scope.json, then re-run.');
+    process.exit(4);
+  }
+}

--- a/metabase-migration-skills/metabase-to-sigma/scripts/probe-controls.rb
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/probe-controls.rb
@@ -1,0 +1,236 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+#
+# probe-controls.rb — live flip test proving a workbook's controls actually
+# filter what they claim to. OPTIONAL Phase 6 step (not the mandatory inner
+# loop): run it after the control lint (gate 7) passes when you want runtime
+# evidence, after repairing control wiring on a live workbook, or whenever a
+# control's reach was wired by hand.
+#
+# SHARED script, vendored byte-identical into every covered plugin's scripts/
+# (md5 discipline — same as scripts/lib/control_lint.rb, which it reuses).
+#
+# What it does, per control:
+#   1. computes the control's reach (filter targets + [controlId] formula
+#      references, expanded through source.elementId chains —
+#      ControlLint.controls_report)
+#   2. exports one IN-closure queryable element as CSV twice via
+#      POST /v2/workbooks/{id}/export — once with no `parameters` (the saved
+#      control defaults) and once with parameters:{<controlId>: <flip value>}.
+#      The two CSVs MUST differ, or the control is wired but inert -> FAIL.
+#   3. with --check-out-of-closure: also exports one same-page queryable
+#      element OUTSIDE the closure with and without the parameter — those
+#      MUST be identical (the flip must not leak) -> FAIL if they differ
+#      (the closure walk missed an edge; fix control_lint, not the workbook).
+#
+# Flip-value selection ("first non-default value"):
+#   --value <controlId>=<value> beats everything (repeatable).
+#   Otherwise: the control's value-source column (source.columnId, falling
+#   back to the first filter target's columnId) is resolved to its display
+#   label via GET /v2/workbooks/{id}/columns, that element is exported once,
+#   and the first distinct value of that column NOT in the control's saved
+#   defaults (`values`) is used. switch controls flip true<->false. Controls
+#   whose value cannot be auto-picked (date ranges, numeric sliders, missing
+#   labels) are SKIPped with a NOTE — pass --value for those.
+#
+# MCP / export-API note (verified empirically 2026-06-12 on tj-wells-1989):
+# the Sigma MCP query path (mcp__sigma-mcp-v2__query / claude.ai Sigma MCP)
+# evaluates workbook elements WITH the saved control defaults applied and
+# exposes NO parameter mechanism to set a control value. The REST export API
+# (POST /v2/workbooks/{id}/export with "parameters": {"<controlId>": "<val>"})
+# is the ONLY programmatic way to exercise a non-default control value —
+# which is why this probe is built on export, not MCP. (MCP is still fine for
+# default-state parity checks — Phase 6 uses it for exactly that.)
+#
+# Usage:
+#   ruby scripts/probe-controls.rb --workbook-id <id> \
+#     [--control <controlId>]        # probe just one control (repeatable)
+#     [--value <controlId>=<value>]  # explicit flip value (repeatable)
+#     [--check-out-of-closure]       # also assert the flip does NOT leak
+#     [--out DIR]                    # CSV evidence dir (default /tmp/probe-controls-<id>)
+#     [--timeout SECS]               # export poll timeout per CSV (default 90)
+#
+# Exit codes: 0 = every probed control flips correctly (skips allowed);
+#             1 = at least one FAIL; 2 = no control could be probed at all.
+require 'json'
+require 'csv'
+require 'optparse'
+require 'net/http'
+require 'uri'
+require 'fileutils'
+
+$LOAD_PATH.unshift File.expand_path('lib', __dir__)
+require 'sigma_rest'
+require 'control_lint'
+
+opts = { values: {}, controls: [], timeout: 90 }
+OptionParser.new do |p|
+  p.on('--workbook-id ID')        { |v| opts[:wb] = v }
+  p.on('--control CID')           { |v| opts[:controls] << v }
+  p.on('--value SPEC', '<controlId>=<value>') do |v|
+    cid, val = v.split('=', 2)
+    abort "bad --value #{v.inspect} (want <controlId>=<value>)" unless cid && val
+    opts[:values][cid] = val
+  end
+  p.on('--check-out-of-closure')  { opts[:check_out] = true }
+  p.on('--out DIR')               { |v| opts[:out] = v }
+  p.on('--timeout SECS', Integer) { |v| opts[:timeout] = v }
+end.parse!
+abort('--workbook-id required') unless opts[:wb]
+WB = opts[:wb]
+OUT = opts[:out] || "/tmp/probe-controls-#{WB}"
+FileUtils.mkdir_p(OUT)
+
+# --- Sigma plumbing ---------------------------------------------------------
+
+def fetch_spec(wb)
+  body = Sigma.request(:get, "/v2/workbooks/#{wb}/spec", accept: 'application/json')
+  return body if body.is_a?(Hash)
+  require 'yaml'
+  require 'date'
+  YAML.safe_load(body.to_s, permitted_classes: [Date, Time]) || {}
+end
+
+# Export an element as CSV (optionally with control parameters), poll the
+# query download until ready, return the CSV text. Raises on timeout/error.
+def export_csv(wb, element_id, params, timeout)
+  body = { 'elementId' => element_id, 'format' => { 'type' => 'csv' } }
+  body['parameters'] = params if params && !params.empty?
+  res = Sigma.request(:post, "/v2/workbooks/#{wb}/export", body: JSON.generate(body))
+  qid = res.is_a?(Hash) && res['queryId']
+  raise "export request failed: #{res.inspect}" unless qid
+  deadline = Time.now + timeout
+  loop do
+    uri = URI("#{Sigma.base_url}/v2/query/#{qid}/download")
+    req = Net::HTTP::Get.new(uri)
+    req['Authorization'] = "Bearer #{Sigma.auth_token}"
+    r = Net::HTTP.start(uri.host, uri.port, use_ssl: true, read_timeout: 60) { |h| h.request(req) }
+    return r.body if r.code.to_i == 200
+    raise "export download failed: HTTP #{r.code} #{r.body.to_s[0, 300]}" if r.code.to_i >= 400 && r.code.to_i != 404
+    raise "export timed out after #{timeout}s (queryId=#{qid})" if Time.now > deadline
+    sleep 2
+  end
+end
+
+# Row-order-insensitive CSV signature (filters change row SETS; ordering noise
+# must not mask or fake a flip).
+def csv_sig(text)
+  text.to_s.lines.map(&:chomp).sort
+end
+
+# --- reach + element metadata ------------------------------------------------
+
+spec  = fetch_spec(WB)
+elems = ControlLint.elements(spec)
+rows  = ControlLint.controls_report(spec)
+rows.select! { |r| opts[:controls].include?(r[:control_id]) } if opts[:controls].any?
+abort "no controls found in workbook #{WB}#{opts[:controls].any? ? " matching #{opts[:controls].inspect}" : ''}" if rows.empty?
+
+cols = Sigma.request(:get, "/v2/workbooks/#{WB}/columns")
+col_label = {} # [elementId, columnId] -> display label
+(cols && cols['entries'] || []).each do |c|
+  col_label[[c['elementId'], c['columnId']]] = c['label'] if c['elementId'] && c['columnId']
+end
+
+baseline_cache = {}
+get_baseline = lambda do |eid|
+  baseline_cache[eid] ||= export_csv(WB, eid, nil, opts[:timeout])
+end
+
+# Pick the flip value for a control (returns [value, note] — value nil = skip).
+pick_value = lambda do |r|
+  el = elems[r[:control_element_id]][:el]
+  cid = r[:control_id]
+  return [opts[:values][cid], 'explicit --value'] if opts[:values].key?(cid)
+  defaults = Array(el['values']).map(&:to_s)
+  case el['controlType'].to_s
+  when 'switch'
+    return [(defaults.first.to_s.downcase == 'true' ? 'false' : 'true'), 'switch flip']
+  when 'list', 'segmented', 'text'
+    src = el['source']
+    src = src['source'].merge('columnId' => src['columnId']) if src.is_a?(Hash) && src['kind'] == 'source' && src['source'].is_a?(Hash)
+    src = (el['filters'] || []).map { |f| f.is_a?(Hash) ? (f['source'] || {}).merge('columnId' => f['columnId']) : nil }.compact.first if !src.is_a?(Hash) || !src['columnId']
+    return [nil, 'no value-source column resolvable — pass --value'] unless src.is_a?(Hash) && src['elementId'] && src['columnId']
+    label = col_label[[src['elementId'], src['columnId']]]
+    return [nil, "no /columns label for #{src['elementId']}/#{src['columnId']} — pass --value"] unless label
+    csv = CSV.parse(get_baseline.call(src['elementId']), headers: true)
+    return [nil, "column #{label.inspect} not in export of #{src['elementId']} — pass --value"] unless csv.headers.include?(label)
+    distinct = csv.map { |row| row[label] }.compact.map(&:to_s).reject(&:empty?).uniq
+    val = distinct.find { |v| !defaults.include?(v) }
+    val ? [val, "auto-picked from #{label.inspect}"] : [nil, 'no non-default value found — pass --value']
+  else
+    [nil, "controlType=#{el['controlType'].inspect} has no auto flip value — pass --value"]
+  end
+end
+
+# --- probe loop ----------------------------------------------------------------
+
+failures = 0
+probed = 0
+results = []
+rows.each do |r|
+  cid = r[:control_id]
+  ctl = "#{r[:name].inspect} [#{cid}]"
+  if r[:reach].empty?
+    results << { control: cid, result: 'FAIL', note: 'dead control — empty reach (run the control lint)' }
+    failures += 1
+    next
+  end
+
+  in_el = (r[:reach] & r[:page_queryable]).first ||
+          r[:reach].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if in_el.nil?
+    results << { control: cid, result: 'SKIP', note: 'no queryable element in closure' }
+    next
+  end
+
+  val, note = pick_value.call(r)
+  if val.nil?
+    results << { control: cid, result: 'SKIP', note: note }
+    next
+  end
+
+  probed += 1
+  base = get_baseline.call(in_el)
+  flip = export_csv(WB, in_el, { cid => val }, opts[:timeout])
+  File.write(File.join(OUT, "#{cid}--#{in_el}--base.csv"), base)
+  File.write(File.join(OUT, "#{cid}--#{in_el}--flip.csv"), flip)
+  changed = csv_sig(base) != csv_sig(flip)
+  if changed
+    results << { control: cid, result: 'PASS', element: in_el, value: val,
+                 note: "#{note}; in-closure export differs (#{base.lines.count - 1} -> #{flip.lines.count - 1} rows)" }
+  else
+    failures += 1
+    results << { control: cid, result: 'FAIL', element: in_el, value: val,
+                 note: "#{note}; in-closure export IDENTICAL with #{cid}=#{val.inspect} — control is wired but inert" }
+  end
+
+  next unless opts[:check_out]
+  out_el = r[:uncovered].find { |e| elems[e] && ControlLint::QUERYABLE.include?(elems[e][:kind]) }
+  if out_el.nil?
+    results << { control: cid, result: 'OK', note: 'out-of-closure: none on page (full reach) — nothing to check' }
+  else
+    obase = get_baseline.call(out_el)
+    oflip = export_csv(WB, out_el, { cid => val }, opts[:timeout])
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-base.csv"), obase)
+    File.write(File.join(OUT, "#{cid}--#{out_el}--out-flip.csv"), oflip)
+    if csv_sig(obase) == csv_sig(oflip)
+      results << { control: cid, result: 'OK', element: out_el, note: 'out-of-closure export unchanged (no leak)' }
+    else
+      failures += 1
+      results << { control: cid, result: 'FAIL', element: out_el,
+                   note: 'out-of-closure export CHANGED — the closure walk missed an edge (fix control_lint, not the workbook)' }
+    end
+  end
+end
+
+puts format('%-22s %-6s %-34s %s', 'CONTROL', 'RESULT', 'ELEMENT', 'NOTE')
+results.each do |x|
+  puts format('%-22s %-6s %-34s %s', x[:control], x[:result], x[:element] || '-', [x[:value] && "flip=#{x[:value].inspect}", x[:note]].compact.join('; '))
+end
+File.write(File.join(OUT, 'probe-results.json'), JSON.pretty_generate(results))
+puts "evidence: #{OUT}/ (CSVs + probe-results.json)"
+
+exit 1 if failures.positive?
+exit 2 if probed.zero?
+exit 0

--- a/metabase-migration-skills/metabase-to-sigma/scripts/remap-wb-to-dm-ids.mjs
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/remap-wb-to-dm-ids.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// remap-wb-to-dm-ids.mjs — wire a Metabase-converted workbook spec to a freshly-posted DM.
+//
+// The report converter emits each element's `source.elementId` as the query's
+// SUBJECT DISPLAY NAME (a placeholder), because the real Sigma element IDs don't
+// exist until the DM is POSTed. After you POST the DM, run this to rewrite every
+// element's `source.elementId` (and `dataModelId`) to the real IDs, matched by
+// element NAME from the DM readback. (This was a manual step in every live test.)
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/remap-wb-to-dm-ids.mjs --wb wb-spec.json --dm-id <dataModelId> [--out wb.remapped.json]
+import { readFileSync, writeFileSync } from 'node:fs';
+import { api, parseArgs, elementsOf } from './lib/sigma-rest.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+if (!a.wb || !a['dm-id']) { console.error('need --wb <spec.json> --dm-id <dataModelId>'); process.exit(2); }
+const dmId = a['dm-id'];
+const wb = JSON.parse(readFileSync(a.wb, 'utf8'));
+
+const els = elementsOf((await api('GET', `/v2/dataModels/${dmId}/elements`)).json);
+if (!els.length) { console.error(`No elements found on data model ${dmId} (token? wrong id?)`); process.exit(1); }
+const byName = new Map(els.map((e) => [e.name.toLowerCase(), e.id]));
+
+let remapped = 0; const unresolved = [];
+// Column-set fallback: Sigma does NOT honor sql-element names (all read back as
+// "Custom SQL"), so native-card placeholders never match by name. Fingerprint each
+// DM element by its column display names and match the workbook element's bare
+// [Col] refs against them (best unique superset wins).
+// Normalize: DM sql columns keep RAW aliases (NET_REVENUE), workbook refs are
+// prettified (Net Revenue) — compare alphanumerics only.
+const norm = (s) => String(s || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+const colEntries = (await api('GET', `/v2/dataModels/${dmId}/columns?limit=500`)).json?.entries || [];
+const colsByElement = new Map();
+for (const c of colEntries) {
+  if (!colsByElement.has(c.elementId)) colsByElement.set(c.elementId, new Set());
+  colsByElement.get(c.elementId).add(norm(c.name));
+}
+const wantedCols = (e) => {
+  const names = new Set();
+  for (const c of e.columns || []) {
+    const m = /^\[([^\]/]+)\]$/.exec(String(c.formula || ''));
+    if (m) names.add(norm(m[1]));
+  }
+  return names;
+};
+const byColumns = (e) => {
+  const want = wantedCols(e);
+  if (!want.size) return undefined;
+  const hits = [];
+  for (const [elId, have] of colsByElement) {
+    if ([...want].every((n) => have.has(n))) hits.push({ elId, extra: have.size - want.size });
+  }
+  if (!hits.length) return undefined;
+  // Smallest superset wins (a native card's sql element carries EXACTLY its result
+  // columns; wide base tables also match but with many extras). Tie → ambiguous.
+  hits.sort((x, y) => x.extra - y.extra);
+  if (hits.length > 1 && hits[0].extra === hits[1].extra) return undefined;
+  return hits[0].elId;
+};
+
+// Ref repair: workbook formulas must be [<DM element name>/<ACTUAL column name>]
+// (DM sql elements keep RAW aliases like NET_REVENUE; derived views suffix duplicate
+// names like "Category (PRODUCT_DIM)"). Bare or prettified refs POST 200 but resolve
+// to type "error" — rewrite every bracket token against the live DM columns.
+const nameByElement = new Map(els.map((e) => [e.id, e.name]));
+const colNamesByElement = new Map(); // elId -> Map(norm -> [actual names])
+for (const c of colEntries) {
+  if (!colNamesByElement.has(c.elementId)) colNamesByElement.set(c.elementId, new Map());
+  const m = colNamesByElement.get(c.elementId);
+  const n = norm(c.name);
+  if (!m.has(n)) m.set(n, []);
+  if (!m.get(n).includes(c.name)) m.get(n).push(c.name);
+}
+let repaired = 0; const unrepairable = [];
+// Control references ([<controlId>] in boolean match columns like
+// `[Region] = [region]`) must survive repair UNTOUCHED — rewriting `[region]`
+// to `[Customer Dim/Region]` turns the filter into always-true (live-caught by
+// the control lint: the control reads back dead).
+const controlIds = new Set();
+for (const c of wb.controls || []) if (c.controlId) controlIds.add(c.controlId);
+for (const p of wb.pages || []) for (const e of p.elements || []) {
+  if (e.kind === 'control' && e.controlId) controlIds.add(e.controlId);
+}
+const repairRefs = (e, elId) => {
+  const elName = nameByElement.get(elId);
+  const colMap = colNamesByElement.get(elId);
+  if (!elName || !colMap) return;
+  const resolveCol = (token) => {
+    const n = norm(token);
+    const exact = colMap.get(n);
+    if (exact?.length === 1) return exact[0];
+    // tolerate the derived-view disambiguation suffix: Category -> "Category (PRODUCT_DIM)"
+    const cands = [];
+    for (const [k, names] of colMap) {
+      if (k !== n && k.startsWith(n)) cands.push(...names.filter((nm) => /\(.+\)\s*$/.test(nm)));
+    }
+    return cands.length === 1 ? cands[0] : undefined;
+  };
+  for (const c of e.columns || []) {
+    if (typeof c.formula !== 'string') continue;
+    c.formula = c.formula.replace(/\[([^\]]+)\]/g, (whole, inner) => {
+      if (controlIds.has(inner)) return whole;       // control ref — never a column
+      const slash = inner.indexOf('/');
+      const colTok = slash >= 0 ? inner.slice(slash + 1) : inner;
+      const real = resolveCol(colTok);
+      if (!real) { unrepairable.push(`${e.name || e.id}: ${whole}`); return whole; }
+      repaired++;
+      return `[${elName}/${real}]`;
+    });
+  }
+};
+
+// Intra-workbook sources (charts re-rooted through a hidden base TABLE so a
+// range control's `filters` target has a table to point at — see the converter's
+// pendingRanges) reference another element's id, not a DM placeholder: skip them.
+const inWorkbookIds = new Set();
+for (const p of wb.pages || []) for (const e of p.elements || []) if (e.id) inWorkbookIds.add(e.id);
+
+for (const p of wb.pages || []) for (const e of p.elements || []) {
+  const s = e.source; if (!s || !('elementId' in s)) continue;
+  if (inWorkbookIds.has(s.elementId)) continue;          // base-table source — already real
+  s.dataModelId = dmId;
+  const want = String(s.elementId || '').toLowerCase();
+  const real = byName.get(want) || byColumns(e) || (els.length === 1 ? els[0].id : undefined);
+  if (real) { s.elementId = real; remapped++; repairRefs(e, real); } else unresolved.push(s.elementId);
+}
+
+// ── wire workbook controls to the DM controls they duplicate ─────────────────
+// The DM converter emits a control per {{tag}} (the tag lives in DM SQL); the
+// dashboard converter emits a control per dashboard parameter with the SAME
+// controlId (slug). Without wiring, the workbook control is decorative — pass
+// --dm-spec <the dm spec JSON you POSTed> to set control.parameters so the
+// workbook control DRIVES the DM control.
+let wired = 0;
+if (a['dm-spec']) {
+  const dmSpec = JSON.parse(readFileSync(a['dm-spec'], 'utf8'));
+  const dmControlIds = new Set();
+  for (const p of dmSpec.pages || []) for (const e of p.elements || []) {
+    if (e.kind === 'control' && e.controlId) dmControlIds.add(e.controlId);
+  }
+  const wireControl = (c) => {
+    if (c?.kind !== 'control' || !dmControlIds.has(c.controlId)) return;
+    c.parameters = [{ kind: 'data-model', dataModelId: dmId, controlId: c.controlId }];
+    wired++;
+  };
+  for (const c of wb.controls || []) wireControl(c);
+  for (const p of wb.pages || []) for (const e of p.elements || []) wireControl(e);
+}
+
+const out = a.out || a.wb.replace(/\.json$/, '.remapped.json');
+writeFileSync(out, JSON.stringify(wb, null, 2));
+console.log(JSON.stringify({ dataModelId: dmId, dmElements: els.length, remapped, repaired, unrepairable, controlsWired: wired, unresolved, out }, null, 2));
+if (unresolved.length) { console.error(`WARN: ${unresolved.length} elementId(s) unresolved — DM has no element named: ${unresolved.join(', ')}`); process.exit(1); }

--- a/metabase-migration-skills/metabase-to-sigma/scripts/report-telemetry.mjs
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/report-telemetry.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// report-telemetry.mjs — fire an anonymous usage ping after a successful migration.
+//
+// Usage (after get-token.sh has been eval'd):
+//   node scripts/report-telemetry.mjs --duration <seconds> [--failed]
+//
+// What IS sent:  tool, sigma_region, org_id_hash (SHA256 of SIGMA_CLIENT_ID first 8 chars),
+//               duration_seconds, success flag, skill_version
+// What is NOT sent: workbook names/IDs, SQL, column names, dashboard titles, user email
+// See https://github.com/twells89/sigma-migration-telemetry/blob/main/TELEMETRY.md
+
+import { createHash } from 'node:crypto';
+import { parseArgs } from './lib/sigma-rest.mjs';
+
+const ENDPOINT = 'https://sigma-migration-telemetry.onrender.com/track';
+const SKILL_VERSION = '1.0';
+
+function regionFromBase(base = '') {
+  if (base.includes('.au.')) return 'au';
+  if (base.includes('.eu.')) return 'eu';
+  if (base.includes('.uk.')) return 'uk';
+  if (base.includes('.ca.')) return 'ca';
+  return 'us';
+}
+
+function orgHash(clientId = '') {
+  return createHash('sha256').update(clientId).digest('hex').slice(0, 8);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const success = !args.failed;
+const duration = parseInt(args.duration ?? '0', 10);
+
+const payload = {
+  event:            'migration_complete',
+  tool:             'metabase-to-sigma',
+  sigma_region:     regionFromBase(process.env.SIGMA_BASE_URL),
+  org_id_hash:      orgHash(process.env.SIGMA_CLIENT_ID),
+  duration_seconds: duration,
+  success,
+  skill_version:    SKILL_VERSION,
+};
+
+console.log('\nReporting anonymous migration telemetry (no customer data sent):');
+for (const [k, v] of Object.entries(payload)) {
+  if (k !== 'event') console.log(`  ${k}: ${v}`);
+}
+
+try {
+  const res = await fetch(ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(5000),
+  });
+  console.log(`  → telemetry sent (${res.status})\n`);
+} catch {
+  console.log('  → telemetry unavailable (skipped)\n');
+}

--- a/metabase-migration-skills/metabase-to-sigma/scripts/scout-validate-and-persist.mjs
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/scout-validate-and-persist.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// scout-validate-and-persist.mjs — the gap-scout's terminal step.
+// Given a candidate Sigma formula + the gap context, validate it against the customer's
+// Sigma site (POST a throwaway probe data model whose one calc column IS the candidate,
+// check it resolves to a concrete type), then PERSIST the rule on success or report an
+// escalation command on failure. The subagent does the reasoning (proposing the
+// candidate); this script does the deterministic POST/validate/write.
+//
+// Usage:
+//   eval "$(scripts/get-token.sh)"
+//   node scripts/scout-validate-and-persist.mjs \
+//     --feature 'running-total' \
+//     --pattern '\brunning-total\s*\(\s*\[([^\]]+)\]\s*\)' \
+//     --template 'CumulativeSum([$1])' \
+//     --test-formula 'CumulativeSum([Net Revenue])' \
+//     --connection <connId> --table-path CSA.TJ.ORDER_FACT \
+//     --folder <folderId> [--description '...'] [--hint '...']
+//
+// Output (JSON): { status: "validated"|"escalated", rule_path?, escalation? , ... }
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { api, extractId, parseArgs } from './lib/sigma-rest.mjs';
+
+const a = parseArgs(process.argv.slice(2));
+for (const k of ['feature', 'template', 'test-formula', 'connection', 'table-path', 'folder']) {
+  if (!a[k]) { console.error(`need --${k}`); process.exit(2); }
+}
+const [db, schema, ...t] = a['table-path'].split('.');
+const table = t.join('.');
+const RULES = join(homedir(), '.metabase-to-sigma', 'learned-rules.json');
+
+// minimal probe DM: a warehouse-table element exposing the raw columns the candidate
+// references (bare `[Name]` refs → raw cols `[TABLE/Name]`), plus the candidate calc col.
+const tail = table.toUpperCase();
+const refNames = [...new Set([...a['test-formula'].matchAll(/\[([^\]\/]+)\]/g)].map((m) => m[1]))];
+const rawCols = refNames.map((nm, i) => ({ id: `r${i}`, name: nm, formula: `[${tail}/${nm}]` }));
+const cols = [...rawCols, { id: 'c1', name: 'scout_candidate', formula: a['test-formula'] }];
+const probe = {
+  folderId: a.folder, name: `GAPSCOUT PROBE ${a.feature} ${Date.now()}`, schemaVersion: 1,
+  pages: [{ id: 'p1', name: 'P', elements: [{
+    id: 'e1', kind: 'table', name: 'Probe',
+    source: { connectionId: a.connection, kind: 'warehouse-table', path: [db, schema, table] },
+    columns: cols, order: cols.map((c) => c.id),
+  }] }],
+};
+const post = await api('POST', '/v2/dataModels/spec', probe);
+const id = extractId(post, 'dataModelId');
+let resolved = false, detail = '';
+if (id) {
+  const cols = await api('GET', `/v2/dataModels/${id}/columns`);
+  const list = cols.json?.entries || cols.json?.columns || (Array.isArray(cols.json) ? cols.json : []);
+  const cand = (Array.isArray(list) ? list : []).find((c) => (c.name || c.columnName) === 'scout_candidate');
+  const type = cand && (cand.type?.type || cand.columnType || cand.type);
+  resolved = !!type && String(type).toLowerCase() !== 'error';
+  detail = `column type=${type || 'missing'}`;
+  await api('DELETE', `/v2/files/${id}`); // always clean up the probe
+} else {
+  detail = `POST rejected: ${post.text.slice(0, 200)}`;
+}
+
+if (resolved) {
+  let rules = [];
+  try { rules = JSON.parse(readFileSync(RULES, 'utf8')); rules = Array.isArray(rules) ? rules : (rules.rules || []); } catch {}
+  rules = rules.filter((r) => r.feature !== a.feature);
+  rules.push({ feature: a.feature, pattern: a.pattern || a['test-formula'], template: a.template, flags: 'gi', description: a.description || '', hint: a.hint || '', validatedAt: new Date().toISOString() });
+  mkdirSync(join(homedir(), '.metabase-to-sigma'), { recursive: true });
+  writeFileSync(RULES, JSON.stringify(rules, null, 2));
+  console.log(JSON.stringify({ status: 'validated', feature: a.feature, rule_path: RULES, detail }, null, 2));
+  process.exit(0);
+}
+
+// escalation (opt-in; this script does NOT file — it hands back the command)
+const dry = `python3 scripts/escalate-gap.py --skill metabase-to-sigma --category converter --feature ${JSON.stringify(a.feature)} --description ${JSON.stringify(a.description || '')} --source-pattern ${JSON.stringify(a.pattern || '')} --template-attempted ${JSON.stringify(a.template)} --test-formula ${JSON.stringify(a['test-formula'])} --sigma-response ${JSON.stringify(detail)}`;
+console.log(JSON.stringify({ status: 'escalated', feature: a.feature, detail, escalation: { dry_run_cmd: dry, file_cmd: dry + ' --yes' } }, null, 2));
+process.exit(0);

--- a/metabase-migration-skills/metabase-to-sigma/scripts/setup.rb
+++ b/metabase-migration-skills/metabase-to-sigma/scripts/setup.rb
@@ -1,0 +1,95 @@
+#!/usr/bin/env ruby
+# Store Sigma credentials so any coding agent can load them:
+#   - ~/.claude/settings.json   — Claude Code auto-loads this into the env
+#   - ~/.sigma-migration/env    — neutral, sourceable file every other agent
+#                                 (Cursor, Cortex Code, plain shell) can use
+# get-token.sh and lib/sigma_rest.rb fall back to the neutral file when the
+# env vars aren't already set, so the skill works under any agent.
+
+require 'io/console'
+require 'json'
+require 'fileutils'
+
+SETTINGS_PATH = File.expand_path("~/.claude/settings.json")
+NEUTRAL_PATH  = File.expand_path("~/.sigma-migration/env")
+
+# Upsert `export KEY='value'` lines into the neutral cred file (0600), preserving
+# any other vars already there (e.g. Tableau creds from setup-tableau.rb).
+def upsert_neutral_env(pairs)
+  FileUtils.mkdir_p(File.dirname(NEUTRAL_PATH), mode: 0o700)
+  body = File.exist?(NEUTRAL_PATH) ? File.read(NEUTRAL_PATH) : ""
+  pairs.each do |k, v|
+    line = "export #{k}='#{v}'"
+    if body =~ /^export #{Regexp.escape(k)}=.*$/
+      body = body.sub(/^export #{Regexp.escape(k)}=.*$/, line)
+    else
+      body += "\n" unless body.empty? || body.end_with?("\n")
+      body += line + "\n"
+    end
+  end
+  File.write(NEUTRAL_PATH, body)
+  File.chmod(0o600, NEUTRAL_PATH)
+end
+
+puts "Sigma credential setup"
+puts "Values are stored in #{SETTINGS_PATH} and loaded automatically into every Claude Code session."
+puts
+
+print "Base URL [https://aws-api.sigmacomputing.com]: "
+base = $stdin.gets.chomp
+base = "https://aws-api.sigmacomputing.com" if base.empty?
+
+# Client ID is NOT a secret — echo it so the reader can eyeball it. A hidden
+# (noecho) prompt here was a recurring quickstart confusion: people paste the
+# wrong value blind and only discover it when auth fails.
+print "Client ID (not a secret — will echo): "
+cid = $stdin.gets.chomp
+
+print "Client Secret (hidden): "
+sec = $stdin.noecho(&:gets).chomp
+puts
+
+if [base, cid, sec].any?(&:empty?)
+  abort "Base URL, Client ID, and Client Secret are all required. Aborting without writing settings."
+end
+
+# The one-command orchestrators (migrate-looker.py, migrate-qlik.rb, ...) need
+# the FULL warehouse-connection UUID for DM conversion. Capturing it here (when
+# known) saves an export step on every run. Optional — Enter to skip.
+print "Connection ID (full warehouse-connection UUID, optional — Enter to skip): "
+conn = $stdin.gets.chomp
+
+settings = File.exist?(SETTINGS_PATH) ? JSON.parse(File.read(SETTINGS_PATH)) : {}
+settings["env"] ||= {}
+settings["env"]["SIGMA_BASE_URL"]      = base
+settings["env"]["SIGMA_CLIENT_ID"]     = cid
+settings["env"]["SIGMA_CLIENT_SECRET"] = sec
+settings["env"]["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+
+FileUtils.mkdir_p(File.dirname(SETTINGS_PATH))
+File.write(SETTINGS_PATH, JSON.pretty_generate(settings))
+
+pairs = {
+  "SIGMA_BASE_URL"      => base,
+  "SIGMA_CLIENT_ID"     => cid,
+  "SIGMA_CLIENT_SECRET" => sec,
+}
+pairs["SIGMA_CONNECTION_ID"] = conn unless conn.empty?
+upsert_neutral_env(pairs)
+
+redacted_secret = sec.length > 8 ? "#{sec[0..3]}…#{sec[-4..]} (#{sec.length} chars)" : "(#{sec.length} chars)"
+
+puts
+puts "Credentials saved to:"
+puts "  #{SETTINGS_PATH}  (Claude Code auto-loads this)"
+puts "  #{NEUTRAL_PATH}  (any other agent / shell)"
+puts
+puts "  SIGMA_BASE_URL:      #{base}"
+puts "  SIGMA_CLIENT_ID:     #{cid}"
+puts "  SIGMA_CLIENT_SECRET: #{redacted_secret}"
+puts "  SIGMA_CONNECTION_ID: #{conn.empty? ? '(skipped)' : conn}"
+puts
+puts "If the Client ID above looks like a URL or doesn't match what Sigma showed you, re-run this script."
+puts "Claude Code: open a new session (or run `! source ~/.claude/settings.json`)."
+puts "Other agents / shell: run `source ~/.sigma-migration/env` once per shell —"
+puts "though get-token.sh and the Ruby scripts auto-source it for you."


### PR DESCRIPTION
## Summary
Adds the **8th member** of the BI migration skill family — \`metabase-migration-skills/metabase-to-sigma/\` and \`metabase-migration-skills/metabase-assessment/\`, vendored from [\`twells89/metabase-to-sigma\`](https://github.com/twells89/metabase-to-sigma).

These files back the upcoming "Migrating From Metabase Made Easy" QuickStart (in sigmaquickstarts).

## Vendor notes
- TJ's Metabase plugin ships as a **standalone repo** (not under \`sigma-migration-skills\`'s monorepo \`plugins/\` folder). Vendor flow is otherwise identical: flatten \`skills/<plugin>/\` into the mirror's top-level \`<plugin>/\` folder.
- **\`setup.rb\` added** (copied from \`looker-migration-skills/looker-to-sigma/scripts/setup.rb\` — the canonical Sigma-aligned variant TJ uses across the family after the 2026-06-24 upstream alignment). TJ's standalone Metabase repo doesn't ship one, but the QS Install pattern across the family expects it.

## Status from upstream README
- **Discovery / extraction / scoring:** production-validated against a live 7k-card / 1.5k-dashboard Metabase Cloud estate (v1.61.4).
- **Sigma BUILD path:** live-validated end to end (per the more-recent SKILL.md preamble), with exact MCP-query parity including models, nested questions, combo charts, controls, and exact-grid layout.

## Test plan
- [ ] \`git sparse-checkout set metabase-migration-skills\` resolves the folder cleanly.
- [ ] Symlinking \`~/.claude/skills/metabase-to-sigma\` to the vendored folder allows \`ruby ~/.claude/skills/metabase-to-sigma/scripts/setup.rb\` to run with the visible Client ID prompt.
- [ ] \`scripts/get-metabase-session.sh\` captures auth (API key or username/password) against a live Metabase instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)