### PR TITLE
Fix validate.sh and drift-check.sh to surface API error bodies on fai…

### DIFF
--- a/sigma-workbooks-as-code-demo-main/scripts/drift-check.sh
+++ b/sigma-workbooks-as-code-demo-main/scripts/drift-check.sh
@@ -24,10 +24,19 @@ fi
 
 echo "Pulling live spec for workbook $WORKBOOK_ID..."
 
-LIVE_SPEC=$(curl -sf -X GET \
+HTTP_CODE=$(curl -s -o /tmp/drift-check-response.yaml -w "%{http_code}" \
+  -X GET \
   -H "Authorization: Bearer $SIGMA_API_TOKEN" \
   -H "Accept: application/yaml" \
   "$SIGMA_API_HOST/v2/workbooks/$WORKBOOK_ID/spec")
+
+if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+  echo "FAIL: fetching live spec returned HTTP $HTTP_CODE"
+  cat /tmp/drift-check-response.yaml
+  exit 1
+fi
+
+LIVE_SPEC=$(cat /tmp/drift-check-response.yaml)
 
 # Strip server-generated metadata for comparison
 LIVE_NORMALIZED=$(echo "$LIVE_SPEC" | yq -P 'del(.workbookId, .url, .documentVersion, .latestDocumentVersion, .ownerId, .createdBy, .updatedBy, .createdAt, .updatedAt)')

--- a/sigma-workbooks-as-code-demo-main/scripts/validate.sh
+++ b/sigma-workbooks-as-code-demo-main/scripts/validate.sh
@@ -17,12 +17,21 @@ fi
 
 echo "Validating $SPEC_FILE against Sigma API..."
 
-RESPONSE=$(curl -sf -X POST \
+HTTP_CODE=$(curl -s -o /tmp/validate-response.json -w "%{http_code}" \
+  -X POST \
   -H "Authorization: Bearer $SIGMA_API_TOKEN" \
   -H "Content-Type: application/yaml" \
   -H "Accept: application/json" \
   --data-binary @"$SPEC_FILE" \
   "$SIGMA_API_HOST/v2/workbooks/spec/verify")
+
+RESPONSE=$(cat /tmp/validate-response.json)
+
+if [[ "$HTTP_CODE" -lt 200 || "$HTTP_CODE" -ge 300 ]]; then
+  echo "FAIL: validate endpoint returned HTTP $HTTP_CODE"
+  echo "$RESPONSE" | jq '.' 2>/dev/null || echo "$RESPONSE"
+  exit 1
+fi
 
 VALID=$(echo "$RESPONSE" | jq -r '.valid')
 
@@ -31,6 +40,6 @@ if [[ "$VALID" == "true" ]]; then
   exit 0
 else
   echo "FAIL: spec validation errors:"
-  echo "$RESPONSE" | jq '.errors[]'
+  echo "$RESPONSE" | jq '.errors[]' 2>/dev/null || echo "$RESPONSE"
   exit 1
 fi


### PR DESCRIPTION
…lure

Both scripts used curl -f, which silently swallows the response body on any non-2xx status - so a real validation error (e.g. a bad KPI element) shows up in Actions only as "Process completed with exit code 22" with zero diagnostic detail. Switched to the same http-code-plus-body pattern deploy.sh already uses, so failures always print the API's actual error message.