### PR TITLE
Fix invalid rgb() color in title-text body - deploy requires hex

### DIFF
--- a/sigma-workbooks-as-code-demo-main/workbook.yaml
+++ b/sigma-workbooks-as-code-demo-main/workbook.yaml
@@ -13,7 +13,7 @@ document:
       body: |-
         ## **Plugs Electronics — Sales Overview**
 
-        <p class="p-small"><span style="color: rgb(100, 116, 139)">Managed via GitHub · Workbooks as Code</span></p>
+        <p class="p-small"><span style="color: #64748B">Managed via GitHub · Workbooks as Code</span></p>
     - kind: control
       controlId: DateFilter
       id: ctrl-date


### PR DESCRIPTION
Live deploy failed: "elements[1].body: color value must be hex (#rgb or #rrggbb) or a theme reference (var(--colors-xxx)), got 'rgb(100, 116, 139)'". Sigma's UI apparently allows rgb() when editing the text element directly, but the deploy API validates more strictly. Converted to the equivalent hex value, #64748B (same color the original hand-authored spec used before this section adopted Phil's exported version).