### PR TITLE
Auto-create the drift label before applying it - fixes silent PR failure

### DIFF
--- a/sigma-workbooks-as-code-demo-main/.github/workflows/drift-check.yml
+++ b/sigma-workbooks-as-code-demo-main/.github/workflows/drift-check.yml
@@ -45,6 +45,10 @@ jobs:
           SIGMA_API_TOKEN: ${{ steps.auth.outputs.token }}
           GH_TOKEN: ${{ github.token }}
         run: |
+          # Ensure the "drift" label exists - a fresh repo won't have it, and gh pr create
+          # fails outright (no PR created at all) if asked to apply a label that doesn't exist
+          gh label create drift --color "D93F0B" --description "Opened automatically by drift-check" 2>/dev/null || true
+
           EXISTING=$(gh pr list --label drift --state open --json number --jq 'length')
           if [[ "$EXISTING" != "0" ]]; then
             echo "Drift PR already open — skipping"


### PR DESCRIPTION
Live test: gh pr create --label drift failed outright with "could not add label: 'drift' not found" on a freshly created reader repo - no GitHub default label set includes it, and nothing in this demo created it. The PR was never created at all, not just missing the label. Fixed by having the workflow create the label idempotently (gh label create ... || true) before applying it, so a fresh repo doesn't need any manual label setup.